### PR TITLE
feat(scaffold): bootstrap argosd Go project layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Binaries
+/bin/
+*.exe
+*.test
+*.out
+
+# Coverage
+coverage.out
+coverage.html
+
+# Vendored deps
+/vendor/
+
+# Env / secrets
+.env
+.env.local
+*.local.yaml
+
+# IDE / editor
+/.idea/
+/.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Argos is a CMDB (Configuration Management Database) for Kubernetes environments, aligned with the ANSSI **SecNumCloud (SNC)** qualification framework. It replaces Mercator for the Kubernetes-scoped portion of the inventory. See `docs/adr/adr-0001-cmdb-for-snc-using-kube.md` for the foundational architectural decision.
+
+## Stack
+
+- **Language**: Go (1.23+)
+- **Database**: PostgreSQL (with JSONB for heterogeneous Kubernetes specs)
+- **API**: REST, contract-first via OpenAPI 3 (spec will live under `api/openapi/`)
+- **Ingestion**: polling-based collector querying the Kubernetes API
+
+## Layout
+
+- `cmd/argosd/` — main entry point for the Argos daemon
+- `internal/` — application packages (not importable externally); created as subsystems land
+- `api/openapi/` — OpenAPI 3 specification (to be added)
+- `migrations/` — PostgreSQL schema migrations (to be added)
+- `docs/adr/` — Architectural Decision Records
+
+## Common commands
+
+| Command | What it does |
+|---------|--------------|
+| `make build` | Compile the `argosd` binary into `bin/` |
+| `make test` | Run all tests with `-race` and coverage |
+| `make test-one TEST=TestName` | Run a single test by exact name |
+| `make vet` | `go vet ./...` |
+| `make lint` | `golangci-lint run` |
+| `make fmt` | `gofmt -w .` |
+| `make check` | fmt + vet + lint + test (CI-equivalent) |
+| `make tidy` | `go mod tidy` |
+
+## Architecture notes
+
+Implementation is currently a skeleton (`cmd/argosd/main.go` only). When the codebase spans multiple subsystems — collector, store, API — expand this section with how they interact, how Kubernetes kinds map to ANSSI cartography layers, and how snapshots are versioned in PostgreSQL.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+BINARY  := argosd
+BIN_DIR := bin
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+LDFLAGS := -ldflags "-X main.version=$(VERSION)"
+
+.PHONY: all build test test-one vet lint fmt tidy check clean
+
+all: build
+
+build:
+	go build $(LDFLAGS) -o $(BIN_DIR)/$(BINARY) ./cmd/$(BINARY)
+
+test:
+	go test -race -cover ./...
+
+test-one:
+	@if [ -z "$(TEST)" ]; then echo "usage: make test-one TEST=TestName"; exit 1; fi
+	go test -race -run '^$(TEST)$$' ./...
+
+vet:
+	go vet ./...
+
+lint:
+	golangci-lint run
+
+fmt:
+	gofmt -w .
+
+tidy:
+	go mod tidy
+
+check: fmt vet lint test
+
+clean:
+	rm -rf $(BIN_DIR)

--- a/cmd/argosd/main.go
+++ b/cmd/argosd/main.go
@@ -1,0 +1,17 @@
+// Command argosd is the Argos CMDB daemon entry point.
+package main
+
+import (
+	"log/slog"
+	"os"
+)
+
+// version is set at build time via -ldflags.
+var version = "dev"
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
+
+	slog.Info("argosd starting", "version", version)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/sthalbert/argos
+
+go 1.23


### PR DESCRIPTION
Adds the minimal scaffold for the Argos CMDB daemon:
- go.mod (module github.com/sthalbert/argos, Go 1.23)
- Makefile with build / test / test-one / vet / lint / fmt / check / tidy
- cmd/argosd/main.go entry point using log/slog and ldflags-injected version
- .gitignore covering binaries, coverage, env files, IDE and OS noise
- CLAUDE.md refreshed with stack, layout, and common commands now that the project structure exists

Subsystems (collector, store, API) land in internal/ in follow-up commits.