### PR TITLE
feat(api): wire HTTP server with health probes and stubbed cluster ha…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,4 +36,9 @@ Argos is a CMDB (Configuration Management Database) for Kubernetes environments,
 
 ## Architecture notes
 
-Implementation is currently a skeleton (`cmd/argosd/main.go` only). When the codebase spans multiple subsystems — collector, store, API — expand this section with how they interact, how Kubernetes kinds map to ANSSI cartography layers, and how snapshots are versioned in PostgreSQL.
+The codebase currently covers the API layer only:
+
+- `cmd/argosd/main.go` — daemon entry point: env-based configuration (`ARGOS_ADDR`, `ARGOS_SHUTDOWN_TIMEOUT`), HTTP server startup, graceful shutdown on SIGINT / SIGTERM.
+- `internal/api/` — generated server (`api.gen.go`) + hand-written handlers (`server.go`) implementing `ServerInterface`. Health probes are real; cluster handlers stub to `501 Not Implemented` until the store lands. RFC 7807 `application/problem+json` for all errors.
+
+Remaining subsystems (PostgreSQL store, Kubernetes collector) will arrive with follow-up docs on how K8s kinds map to ANSSI cartography layers and how snapshots are versioned in PostgreSQL.

--- a/cmd/argosd/main.go
+++ b/cmd/argosd/main.go
@@ -2,8 +2,17 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/sthalbert/argos/internal/api"
 )
 
 // version is set at build time via -ldflags.
@@ -13,5 +22,71 @@ func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	slog.SetDefault(logger)
 
-	slog.Info("argosd starting", "version", version)
+	if err := run(); err != nil {
+		slog.Error("argosd exited with error", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	addr := envOr("ARGOS_ADDR", ":8080")
+	shutdownTimeout, err := parseDurationEnv("ARGOS_SHUTDOWN_TIMEOUT", 15*time.Second)
+	if err != nil {
+		return err
+	}
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           api.Handler(api.NewServer(version)),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	rootCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	errCh := make(chan error, 1)
+	go func() {
+		slog.Info("argosd listening", "addr", addr, "version", version)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
+		close(errCh)
+	}()
+
+	select {
+	case <-rootCtx.Done():
+		slog.Info("shutdown signal received, draining", "timeout", shutdownTimeout)
+	case err := <-errCh:
+		if err != nil {
+			return fmt.Errorf("http server: %w", err)
+		}
+		return nil
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("graceful shutdown: %w", err)
+	}
+	slog.Info("argosd stopped cleanly")
+	return nil
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func parseDurationEnv(key string, fallback time.Duration) (time.Duration, error) {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback, nil
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s=%q: %w", key, v, err)
+	}
+	return d, nil
 }

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+// writeJSON writes body as JSON with the given status code.
+// Errors encoding the body are logged; the response status is already written.
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		slog.Error("write json response", "error", err)
+	}
+}
+
+// writeProblem writes an RFC 7807 problem+json response.
+func writeProblem(w http.ResponseWriter, status int, title, detail string) {
+	p := Problem{
+		Type:   "about:blank",
+		Title:  title,
+		Status: status,
+	}
+	if detail != "" {
+		p.Detail = &detail
+	}
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(p); err != nil {
+		slog.Error("write problem response", "error", err)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"net/http"
+)
+
+// Server implements ServerInterface for the Argos REST API.
+// It will be progressively extended as subsystems (store, collector, auth) land.
+type Server struct {
+	version string
+}
+
+// NewServer returns a Server wired with the build version reported on health probes.
+func NewServer(version string) *Server {
+	return &Server{version: version}
+}
+
+var _ ServerInterface = (*Server)(nil)
+
+// GetHealthz reports that the process is alive.
+func (s *Server) GetHealthz(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, Health{Status: Ok, Version: &s.version})
+}
+
+// GetReadyz reports that the service can accept traffic.
+// v1 has no downstream dependencies; this will check PostgreSQL once the store lands.
+func (s *Server) GetReadyz(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, Health{Status: Ok, Version: &s.version})
+}
+
+// ListClusters is stubbed until the persistence layer lands.
+func (s *Server) ListClusters(w http.ResponseWriter, _ *http.Request, _ ListClustersParams) {
+	writeNotImplemented(w, "listClusters")
+}
+
+// CreateCluster is stubbed until the persistence layer lands.
+func (s *Server) CreateCluster(w http.ResponseWriter, _ *http.Request) {
+	writeNotImplemented(w, "createCluster")
+}
+
+// GetCluster is stubbed until the persistence layer lands.
+func (s *Server) GetCluster(w http.ResponseWriter, _ *http.Request, _ ClusterId) {
+	writeNotImplemented(w, "getCluster")
+}
+
+// UpdateCluster is stubbed until the persistence layer lands.
+func (s *Server) UpdateCluster(w http.ResponseWriter, _ *http.Request, _ ClusterId) {
+	writeNotImplemented(w, "updateCluster")
+}
+
+// DeleteCluster is stubbed until the persistence layer lands.
+func (s *Server) DeleteCluster(w http.ResponseWriter, _ *http.Request, _ ClusterId) {
+	writeNotImplemented(w, "deleteCluster")
+}
+
+func writeNotImplemented(w http.ResponseWriter, op string) {
+	writeProblem(w, http.StatusNotImplemented, "Not Implemented", op+": cluster persistence is not yet wired")
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestHandler(t *testing.T, version string) http.Handler {
+	t.Helper()
+	return Handler(NewServer(version))
+}
+
+func TestServerRoutes(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(t, "test")
+
+	tests := []struct {
+		name       string
+		method     string
+		target     string
+		body       string
+		wantStatus int
+		wantCT     string
+	}{
+		{
+			name:       "healthz ok",
+			method:     http.MethodGet,
+			target:     "/healthz",
+			wantStatus: http.StatusOK,
+			wantCT:     "application/json",
+		},
+		{
+			name:       "readyz ok",
+			method:     http.MethodGet,
+			target:     "/readyz",
+			wantStatus: http.StatusOK,
+			wantCT:     "application/json",
+		},
+		{
+			name:       "list clusters stubbed",
+			method:     http.MethodGet,
+			target:     "/v1/clusters",
+			wantStatus: http.StatusNotImplemented,
+			wantCT:     "application/problem+json",
+		},
+		{
+			name:       "create cluster stubbed",
+			method:     http.MethodPost,
+			target:     "/v1/clusters",
+			body:       `{"name":"prod"}`,
+			wantStatus: http.StatusNotImplemented,
+			wantCT:     "application/problem+json",
+		},
+		{
+			name:       "get cluster stubbed",
+			method:     http.MethodGet,
+			target:     "/v1/clusters/00000000-0000-0000-0000-000000000000",
+			wantStatus: http.StatusNotImplemented,
+			wantCT:     "application/problem+json",
+		},
+		{
+			name:       "patch cluster stubbed",
+			method:     http.MethodPatch,
+			target:     "/v1/clusters/00000000-0000-0000-0000-000000000000",
+			body:       `{"environment":"prod"}`,
+			wantStatus: http.StatusNotImplemented,
+			wantCT:     "application/problem+json",
+		},
+		{
+			name:       "delete cluster stubbed",
+			method:     http.MethodDelete,
+			target:     "/v1/clusters/00000000-0000-0000-0000-000000000000",
+			wantStatus: http.StatusNotImplemented,
+			wantCT:     "application/problem+json",
+		},
+		{
+			name:       "unknown route 404",
+			method:     http.MethodGet,
+			target:     "/does-not-exist",
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var body *strings.Reader
+			if tt.body != "" {
+				body = strings.NewReader(tt.body)
+			} else {
+				body = strings.NewReader("")
+			}
+			req := httptest.NewRequest(tt.method, tt.target, body)
+			if tt.body != "" {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d; body=%q", rr.Code, tt.wantStatus, rr.Body.String())
+			}
+			if tt.wantCT != "" {
+				if ct := rr.Header().Get("Content-Type"); ct != tt.wantCT {
+					t.Errorf("Content-Type = %q, want %q", ct, tt.wantCT)
+				}
+			}
+		})
+	}
+}
+
+func TestHealthzBody(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(t, "v1.2.3")
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	var got Health
+	if err := json.NewDecoder(rr.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Status != Ok {
+		t.Errorf("Status = %q, want %q", got.Status, Ok)
+	}
+	if got.Version == nil || *got.Version != "v1.2.3" {
+		t.Errorf("Version = %v, want pointer to \"v1.2.3\"", got.Version)
+	}
+}
+
+func TestProblemResponseShape(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(t, "test")
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/clusters", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	var got Problem
+	if err := json.NewDecoder(rr.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Status != http.StatusNotImplemented {
+		t.Errorf("Status = %d, want %d", got.Status, http.StatusNotImplemented)
+	}
+	if got.Title == "" {
+		t.Error("Title is empty")
+	}
+	if got.Type != "about:blank" {
+		t.Errorf("Type = %q, want %q", got.Type, "about:blank")
+	}
+}


### PR DESCRIPTION
…ndlers

Implements the walking-skeleton server behind the OpenAPI contract:

- cmd/argosd/main.go rebuilt around a real HTTP listener with graceful shutdown on SIGINT / SIGTERM. Configuration via ARGOS_ADDR (default :8080) and ARGOS_SHUTDOWN_TIMEOUT (default 15s).
- internal/api/server.go provides *Server implementing ServerInterface. GetHealthz and GetReadyz return a real Health payload including the build version. The five Cluster operations stub to 501 Not Implemented until the persistence layer lands.
- internal/api/responses.go centralises JSON and RFC 7807 problem+json writers shared by every handler.
- internal/api/server_test.go is table-driven with t.Parallel() subtests covering every route, the Health body shape, and the Problem shape. Internal api package coverage is 62.7%.

Auth middleware, PostgreSQL store, and the Kubernetes collector are deliberately out of scope here; each gets its own commit.