### PR TITLE
feat(api): per-operation scopes for bearer auth (read/write/delete/ad…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,26 @@ Argos is a CMDB (Configuration Management Database) for Kubernetes environments,
 
 The codebase currently covers the API layer only:
 
-- `cmd/argosd/main.go` — daemon entry point: env-based configuration (`ARGOS_ADDR`, `ARGOS_DATABASE_URL`, `ARGOS_API_TOKEN`, `ARGOS_AUTO_MIGRATE`, `ARGOS_SHUTDOWN_TIMEOUT`, collector vars), opens the PostgreSQL pool, runs migrations, starts the HTTP server (wrapped in `BearerAuth` middleware), spawns the collector goroutine when enabled, handles graceful shutdown on SIGINT / SIGTERM.
+- `cmd/argosd/main.go` — daemon entry point: env-based configuration (`ARGOS_ADDR`, `ARGOS_DATABASE_URL`, `ARGOS_API_TOKEN` and/or `ARGOS_API_TOKENS`, `ARGOS_AUTO_MIGRATE`, `ARGOS_SHUTDOWN_TIMEOUT`, collector vars). Opens the PostgreSQL pool, runs migrations, builds the bearer-token store, starts the HTTP server with the scope-aware `BearerAuth` middleware, spawns the collector goroutine when enabled, handles graceful shutdown on SIGINT / SIGTERM.
+
+### Auth scopes
+
+`BearerAuth` enforces per-operation scopes declared in the OpenAPI spec:
+
+| Scope    | Grants                                              |
+|----------|-----------------------------------------------------|
+| `read`   | list and get cluster endpoints                      |
+| `write`  | create and update                                   |
+| `delete` | removal                                             |
+| `admin`  | implicit grant of every other scope                 |
+
+Configure tokens via either or both env vars (merged at startup):
+
+- `ARGOS_API_TOKEN=<value>` — convenience: a single token granted `admin`.
+- `ARGOS_API_TOKENS=<json>` — JSON array, e.g.
+  `[{"name":"collector","token":"...","scopes":["read","write"]}]`.
+
+At least one token must be configured; `/healthz` and `/readyz` stay open.
 - `internal/api/` — generated server (`api.gen.go`), hand-written handlers (`server.go`), `Store` interface (`store.go`) with `ErrNotFound` / `ErrConflict` sentinels. RFC 7807 `application/problem+json` for all errors.
 - `internal/store/` — PostgreSQL implementation of `api.Store` using `pgx/v5`. Cursor-paginated list, merge-patch updates, embedded `goose` migrations.
 - `internal/collector/` — Kubernetes polling collector (v1 scope: fetches the API server version via `client-go` and refreshes the matching cluster record by name). Disabled by default; enable with `ARGOS_COLLECTOR_ENABLED=true` and `ARGOS_CLUSTER_NAME=...`.

--- a/api/openapi/openapi.yaml
+++ b/api/openapi/openapi.yaml
@@ -72,6 +72,8 @@ paths:
       tags: [clusters]
       summary: List clusters
       operationId: listClusters
+      security:
+        - BearerAuth: [read]
       parameters:
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Cursor'
@@ -86,11 +88,15 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
 
     post:
       tags: [clusters]
       summary: Register a cluster
       operationId: createCluster
+      security:
+        - BearerAuth: [write]
       requestBody:
         required: true
         content:
@@ -114,6 +120,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '409':
           $ref: '#/components/responses/Conflict'
 
@@ -124,6 +132,8 @@ paths:
       tags: [clusters]
       summary: Get a cluster
       operationId: getCluster
+      security:
+        - BearerAuth: [read]
       responses:
         '200':
           description: Cluster details.
@@ -133,6 +143,8 @@ paths:
                 $ref: '#/components/schemas/Cluster'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
 
@@ -143,6 +155,8 @@ paths:
         Merge-patch semantics: fields omitted from the body are unchanged.
         `name` is immutable after creation.
       operationId: updateCluster
+      security:
+        - BearerAuth: [write]
       requestBody:
         required: true
         content:
@@ -160,6 +174,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
 
@@ -167,11 +183,15 @@ paths:
       tags: [clusters]
       summary: Delete a cluster
       operationId: deleteCluster
+      security:
+        - BearerAuth: [delete]
       responses:
         '204':
           description: Cluster deleted.
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
 
@@ -184,6 +204,15 @@ components:
       bearerFormat: token
       description: |
         API token issued out-of-band. Send as `Authorization: Bearer <token>`.
+
+        Scopes granted to a token:
+          - `read`   — list and get operations
+          - `write`  — create and update (implies `read` at the caller's discretion)
+          - `delete` — remove resources
+          - `admin`  — all of the above; reserved for future admin-only endpoints
+
+        Tokens carrying the `admin` scope implicitly satisfy any scope required
+        by an operation.
 
   parameters:
 
@@ -227,6 +256,13 @@ components:
 
     Unauthorized:
       description: Missing or invalid bearer token.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+
+    Forbidden:
+      description: Token is valid but lacks the scope required by the operation.
       content:
         application/problem+json:
           schema:

--- a/cmd/argosd/main.go
+++ b/cmd/argosd/main.go
@@ -37,9 +37,9 @@ func run() error {
 	if dsn == "" {
 		return errors.New("ARGOS_DATABASE_URL is required")
 	}
-	token := os.Getenv("ARGOS_API_TOKEN")
-	if token == "" {
-		return errors.New("ARGOS_API_TOKEN is required")
+	tokenStore, err := loadTokenStore()
+	if err != nil {
+		return err
 	}
 	shutdownTimeout, err := parseDurationEnv("ARGOS_SHUTDOWN_TIMEOUT", 15*time.Second)
 	if err != nil {
@@ -71,8 +71,10 @@ func run() error {
 	}
 
 	srv := &http.Server{
-		Addr:              addr,
-		Handler:           api.BearerAuth(token)(api.Handler(api.NewServer(version, pg))),
+		Addr: addr,
+		Handler: api.HandlerWithOptions(api.NewServer(version, pg), api.StdHTTPServerOptions{
+			Middlewares: []api.MiddlewareFunc{api.BearerAuth(tokenStore)},
+		}),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
@@ -141,6 +143,43 @@ func maybeStartCollector(ctx context.Context, s api.Store) error {
 		}
 	}()
 	return nil
+}
+
+// loadTokenStore merges ARGOS_API_TOKEN (a convenience single admin token)
+// and ARGOS_API_TOKENS (a JSON array of full scoped tokens) into a validated
+// TokenStore. Returns an error if neither env var is set.
+func loadTokenStore() (*api.TokenStore, error) {
+	var tokens []api.ScopedToken
+
+	if adminToken := os.Getenv("ARGOS_API_TOKEN"); adminToken != "" {
+		tokens = append(tokens, api.ScopedToken{
+			Name:   "env:ARGOS_API_TOKEN",
+			Token:  adminToken,
+			Scopes: []string{api.ScopeAdmin},
+		})
+	}
+
+	parsed, err := api.ParseTokensJSON(os.Getenv("ARGOS_API_TOKENS"))
+	if err != nil {
+		return nil, fmt.Errorf("ARGOS_API_TOKENS: %w", err)
+	}
+	for i, p := range parsed {
+		if p.Name == "" {
+			p.Name = fmt.Sprintf("env:ARGOS_API_TOKENS[%d]", i)
+		}
+		tokens = append(tokens, p)
+	}
+
+	if len(tokens) == 0 {
+		return nil, api.ErrNoTokensConfigured
+	}
+
+	store, err := api.NewTokenStore(tokens)
+	if err != nil {
+		return nil, fmt.Errorf("build token store: %w", err)
+	}
+	slog.Info("auth tokens loaded", "count", store.Len())
+	return store, nil
 }
 
 func envOr(key, fallback string) string {

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -171,6 +171,9 @@ type BadRequest = Problem
 // Conflict RFC 7807 problem details.
 type Conflict = Problem
 
+// Forbidden RFC 7807 problem details.
+type Forbidden = Problem
+
 // NotFound RFC 7807 problem details.
 type NotFound = Problem
 
@@ -261,7 +264,7 @@ func (siw *ServerInterfaceWrapper) ListClusters(w http.ResponseWriter, r *http.R
 
 	ctx := r.Context()
 
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"read"})
 
 	r = r.WithContext(ctx)
 
@@ -300,7 +303,7 @@ func (siw *ServerInterfaceWrapper) CreateCluster(w http.ResponseWriter, r *http.
 
 	ctx := r.Context()
 
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"write"})
 
 	r = r.WithContext(ctx)
 
@@ -331,7 +334,7 @@ func (siw *ServerInterfaceWrapper) DeleteCluster(w http.ResponseWriter, r *http.
 
 	ctx := r.Context()
 
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"delete"})
 
 	r = r.WithContext(ctx)
 
@@ -362,7 +365,7 @@ func (siw *ServerInterfaceWrapper) GetCluster(w http.ResponseWriter, r *http.Req
 
 	ctx := r.Context()
 
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"read"})
 
 	r = r.WithContext(ctx)
 
@@ -393,7 +396,7 @@ func (siw *ServerInterfaceWrapper) UpdateCluster(w http.ResponseWriter, r *http.
 
 	ctx := r.Context()
 
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"write"})
 
 	r = r.WithContext(ctx)
 
@@ -542,47 +545,51 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/8RZbXPbNhL+Kzu4frBT6sVO0jbq3Nw4TtN6Li8eu7n7YPliiFhKqECAAUC5qkf//WYB",
-	"UiIlKnbb1P1iUySIXeyz++wL71hq8sJo1N6x0R0ruOU5erTh16kqnUd7JuiHQJdaWXhpNBuxS7QLtD3u",
-	"nJxqFJDGpSAFai8zibbPEiZpacH9jCVM8xzZiEnBEmbxUyktCjbytsSEuXSGOScpmbE592zEyjKs9MuC",
-	"3nLeSj1lq1XCTkvrjN3V6H3BP5UIaXgMFn1pSbHMmhw4FBYX0pQOlHQeLLrCaIdrHT+VaJcbJeMmrKlY",
-	"zn99g3rqZ2z0/Oi4S7E3Mpd+V6+3/FeZlznoMp+gBZOB9Jg78KZSsg/RmJAqnhfhwdVRAsfD4fU+/VQQ",
-	"1VRPYMZL5dno+TAhXUkkGx0P6ZfU8dfRWmupPU7RshXpXRsjQP6Siwv8VKILJ0mN9qjDJS8KJVNOhxoU",
-	"1kwU5l//4uiEdw01vrKYsRH7x2DjVoP41A3O41tR6LaNFAGPAmwU3meEtNGZkumjalLLhFvpZ+RMFrUH",
-	"57lHOMD+tJ+AKKN8BELjMKj6zvjXptTiMVW9QGdKmyJo4yEj6UGVD5qXfmas/A0fVZ230jmpp2AsSL3g",
-	"SgqYILdowZs56n6IkWqfBrkEvZR6n7HR1edlVy+8LT2fKGSr5I4V1hRovYy+m1rkHsVH7ltMIrjHnpc5",
-	"BuLh4r1Wy5p4tqI4IXrqYKF7X4tx2WKJb56F0Kt/HidEhB4t2ep/V7z327D34rr637u+GybfHK/q21+x",
-	"DhllIf7k8VZN5r2KVBw0T5q2a0m6Xm9iJr9g6tnqehv4E/h3OUGr0aNb5wGLU0kXKEBq8DOE07evXsaw",
-	"jktOg8QvCH+NwVaiCsvBqXLaU3KOjQyVQKkl5QyeWuPcRsuxPsvzKAd4RscJ5pFG98eaJX8hylsIhSM9",
-	"AIJzvlSGi5hTouGBg8bbGo+m4d9I15GmzvkURcyOJqtfc5SA2lYOyat18QDQSHp1Bm4tX4aQwV/9x/RB",
-	"ydwbKLhzwB3c/Cve++cN3c3Qp7OAG+0GBZ9if6xPJo5I21jQpVJwO0MN2kBuLIYlDizmXFZg0prgUQ+L",
-	"mXDqXUjW1q39c+dIryUq4cBo4FCtBT/jHlIlyWaQ8yU49MC1AMXpcYzDXQx4IT+iFoWRugPJRjSenJ+B",
-	"i8XFh4s3cCB1pA1pNFeHtPGG6azsIh0hXaH48mN3cP1U5lz3MitRC7UExSeoEsgsYo827rdj5fj5Nx0S",
-	"UC+kNTrHrrO8rreCxjLwfLpOxrhIKD1PpZ4mUFgjDvu7EbojdL620ccFWidjDtwqBSqQGkas1oLFwliP",
-	"AibLJvkFnWDMjvrHL/rPx2xblafHHaoEo0VYhZARmvMW3PeacIuP7UR6y+0SSoe250rK+iggroc5LgcL",
-	"rkqMcLlKx6bIhsk2/l1Ys5ACO4L1gxZo1ZI2bxhDSBI4KWkRxeLMOE9L6n36Y/2+QN1DLVB8D6nJc6Mh",
-	"aOZGMJ1jAjh3CXD6YwrUbiYzn4ClJ4QfF3kCRhcW6b+fhS0fgD0xZMT78ytX+4P8QwjMP567dgj8Ldop",
-	"9gpOdDYxYtkHSuNQJ6EscMf3cENheAPSgawTFJkxl56cMa4CbhEUZh5Knc64nqIgu6wS9hNyRWfdTpxU",
-	"3ZbhCjX1CVfMzBsUt7Hc3lB5WUol1tFhskDJttSaAOd2apzo35vsKjW6uLUuO3cEX7w+hW+/G34LVTkL",
-	"Aj2XqiNvxQd0tctA1hrr9jB2T+ECFYSCNhAnxOVJzCtVSU1AUK9W58S27ABMp+gcneNT7Hi2ZZy4xeaF",
-	"LittZ1ipnec6xXZF283zGx9YN4/PX7xoNo/USm63jwnz0ivsPFq80ehMGZ+Y0o8miuv5vZln6/jhaS0t",
-	"2e8qdBJMSyv98pJir2pqQx9yUkbnj13J61p86E7YDomen8W+BaRzJQowpe+ZrDfhWlDDrkWoRk6qVit4",
-	"xgiiIBiXw+HTNLweLvEmMlOgA1I3qrA59cz7IvZUlKE73PyHy59DHsqMhSdPTiiinjxJqJJ4++pluNtg",
-	"3kaqdMBVHNCEftbPcKxP3l1ensElpu/K/FSZUsDB5bvTQ/hUciWzqj+EzPIcb42d98d6rH+eSbeO74Nh",
-	"/6g/PCQa4nDL1Zyi3M1RoTcaUrNAwnA01gA9eCMXqJGKN03dPRcy/KJ4RReX3FT0eAO2bmlPLz68IrmX",
-	"5cThp5KSfiXdwa1UCrgQ8M4ITOAdz9EVPMUE/mvsnOrgBM6NSILEkBfGumUdL/0S5lILqrmKgsDV3gTO",
-	"irZJufVmankxo5pmSXUwKfNDCHzIjFLmFtbUc3Czr6++OaxwL/Oc22WrNuulqL2VaURwGyXYBWkDyDoQ",
-	"KNdPjYtbnJyfsQZFswASBSLlTl5INmJPw63QosxCYAxmISX8RtdTDPUX8VY4yZlgI/Yj+p+qJVuDouPh",
-	"8DPThd83VagSU8dQ4RLtQqYYXE3JBfZbIc5GV9dN6659LXgXmYlPHdFHPCa7ppcH5ITL5pHbIv+DlrpD",
-	"B8LcauctcsoqBZUpOqX7B4J7PuEOD0OqtcjTWZ0Adqx3EYX93cYLZ6aOKRSy4C3PMpmGrvD58Oljjoka",
-	"Smnjo2KfR/WiTRr7YF0cDequda87U+t7Wi9KWtPuPRXcZskgzndXyb0Lqwk1VXl/GerNXr7Dyvu6+VXC",
-	"nkUtujZfaztojIHDK0f3v9KaOwY8G3Hp/FqJBn7rW9fUXxjXgVicEtVjhFgUoPMvjVh+aVtWA6lVu/bw",
-	"tsTVDpBHX1p45yy6akCr2Rzxywy5qBz8jYnyOvqxi7O6Btd4q5b1BpthUPcXl846bPVoLkMvvbj/pfVX",
-	"gbaPXWzmXunaWzocbYsqBndSrKIJFcaWru2Ar8L9pgO2HOHZ/rlB3FH0/4Q5nt3/0vrLQ9scUe37jJHs",
-	"zfp7Dzx8TM9fd3N/hwl/RH+//X5fCtl8UKXkENr9jg+GjVmAw5xrL1M3qrt7Uzf71uQhxCdGLEMh0mz3",
-	"OwYFnZPsNu5xrPF7yTbf6Pv1H/KAapryIOJ9FPeLConW8PzxOPCPe2zUe2tqRKngPk5sV1/thvnqmnw1",
-	"DkCjk7eNRXlIgcAFKlOEKW7CSquqrnY0GChaMDPOj74bfjcMnl/psLPV53pFOCiDqah/SwmeMF2tPohX",
-	"lSAVZ3uH4fWB936b2nz+r02zul79PwAA//+4GdMsIiEAAA==",
+	"H4sIAAAAAAAC/9RabXPbxvH/Kjv4Z+YvOeCDZDuJmel0ZDlONJVtjRS3L0TVOuIW5IWHO/geqDAezvRD",
+	"9BP2k3T2DiBBEhSV1FHTNzYI7N3u7cNvH06fkkwXpVaonE0Gn5KSGVagQxN+nUpvHZozTj842syI0gmt",
+	"kkFyhWaGpsOsFWOFHLJICoKjciIXaLpJmggiLZmbJGmiWIHJIBE8SRODH70wyJOBMx7TxGYTLBhxybUp",
+	"mEsGifeB0s1LWmWdEWqcLBZpcuqN1WZboncl++gRsvAZDDpvSLDc6AIYlAZnQnsLUlgHBm2plcWljB89",
+	"mvlKyLhJ0hSsYD+foxq7STJ4fnTcJti5KITblusN+1kUvgDlixEa0DkIh4UFpyshuxCVCZlkRRk+XB+l",
+	"cNzv3+ySTwZWTfE45sxLlwye91OSlVgmg+M+/RIq/jpaSi2UwzGaZEFy18oIJn/J+CV+9GjDSTKtHKrw",
+	"yMpSiozRoXql0SOJxZc/WTrhp4YYXxjMk0Hyf72VW/XiV9u7iKsi000dSTI8cjCReTchS2uVS5E9qiQ1",
+	"T7gTbkLOZFA5sI45hAPsjrspcB/5I5A1DoOor7UZCc5RPaasP+opKhAWZkwKDiPvQLJsasFNEGymS4Q6",
+	"0GA0D291iSZIE6R+q91r7RV/TKEv0WpvMgSlHeTEPYjyXjHvJtqIX/BRxXkjrBVqDNqAUJUekRk04Ei7",
+	"3RDZ1T4NSAxySfkuTwbX9/OuFrzxjo0kJov0U1IaMoMTMeIyg8wh/8DcGv5x5rDjRIEBLhl/p+S8hssN",
+	"7EkJVFuwc++yiCZr2PbVswAY9c/jlODboSFd/f2adX7pd17cVP93bj7106+OF/XrL5IWHr7k/+HxFs18",
+	"cR0TSJA8bepujdPNchM9+gkzlyxuNg1/An/xIzQKHdpl9jI4FvSAHIQKAXP65tXLCEaR5DRw/Izmr22w",
+	"kV4DOVjpxx0pptjIqyl4JSjTscxoa1dSDtVZUUQ+wHI6TlAPBftQJenvaOUNC4UjPcAEF2wuNeMxE0bF",
+	"AwOFd7U9moo/F7YluV6wMfKY03VeL7OUNte1HFLu2sMDjEbcqzMwY9g8hAz+7D5kDypBnIaSWQvMwu2f",
+	"47s/3dLbHF02CXaj3aBkY+wO1cnIUqrRBpSXEu4mqEBpKLTBQGLBYMFEZUyiCR71sJgJp942yVK7tX9u",
+	"Hem1QMktaAUMKlpwE+Ygk4J0BgWbg0UHTHGQjD7HONy2ASvFB1S81EK1WLIRjScXZ2BjSfT+8hwOhIqw",
+	"IbRi8pA2XiGdEW2gw4UtJZt/aA+uH3zBVCc3AhWXc5BshDKF3CB2aOPueqwcP/+qhQOqmTBaFdh2ltf1",
+	"VtAgA8fGyxICZykVFWOhximURvPD7naEbjGdLnX0YYbGipgDNwqYykgNJVa0YLDUxsVioKHuIBMMk6Pu",
+	"8Yvu82GyKcrT4xZRgtKiWTkX0TQXa+beq8INPDYj4Qwzc/AWTcd6yvrIIdLDFOe9GZMeo7lsJWOTZUNl",
+	"K/8ujZ4Jji3B+l5xNHJOmzeUwQUxHHkiolicaOuIpN6nO1TvSlQdVBz5t5DpotAKgmR2AOMppoBTmwKj",
+	"f3SJyk5E7lIw9IXsx3iRglalQfrfTcKWD7A9IWS09/2Ui91B/j4E5m/PXVsA/gbNGDslIzgbaT7vAqVx",
+	"qJNQHrDjW7ilMLylQlXUCYrUWAhHzhipgBkEibkDr7IJU2PkpJdFmvyATNJZNxMn1eQ+PKGi7uY60dMG",
+	"xK00tzNUXnoh+TI6dB4g2XilyODMjLXl3b3JrhKjDVvrsnOL8eXrU/j6m/7XUJWzwNExIVvyVvxAT9sI",
+	"ZIw2dgdidyTOUMbGIAAnRPI05pWqpCZDUIdZ58R13sEwrawLtJaNseXbhnLiFqsFbVrazLBCWcdUhusV",
+	"bTvOr3xg2fI+f/Gi2fJSA7zZ9KaJE05i69Hii0Y/nbCR9m4wkkxN92aejeOHrzW3dLer0Ekw80a4+RXF",
+	"XtWKhz7kxEfnj13J65p96E6SLRC9OIt9CwhrPXLQ3nV03hkxxbtwhYqHauSkarWCZwwgMoKh7/efZmF5",
+	"eMTb7lAN1RU1khbGhikKV6eBRR6DoQLowC2V77cA8K9//DNWYlQKjNGtmk1bUd4Z4fA2UsbSPdDGggEO",
+	"REGQb+sdmQsBmTEp0fx/gObMIO13WO3HUSJtSPsZLPSMGt7YXtYsGS+EqlgyKesoZyM9w2+JmlIkh1wb",
+	"yL3zBiGs6GgCsrpasaSH0G1byJgxIWnQNvX2sdkO8mfCyTlY5oTN58DUfKMTH6oRvW504gH+A+aST0Q7",
+	"r1xr4lwZG1cqg1qw5LurH0OypyM8eXJCsPXkSUrl2ptXL8PbRnpr1CMWmIyzuzDqcBMcqpO3V1dncIXZ",
+	"W1+cSu05HFy9PT2Ej55JkVdNOOSGFXinzTT4x48TYZcgetDvHnX7h4T1DO6YnJKm7JTspBVkeoYUKJXn",
+	"nIsZKqQKWXEgm4vwi0Bxab8qB90uDQunl+9fBb/0I4sfPVVWFXcLd0JKYJzDW80xhbesQFuyDFP4mzZT",
+	"ajZSuNA8DRxD8h2qNe044eYwFYpTYVuWFEHK6WDrqJuMGafHhpUTKhzn1GyQMN8FdIVcS6nvYInvB7e7",
+	"hhe3h5XdfVEwM18rgDsZKmdEFi24aSXYNtLKIEu0oYJqrG3c4uTiLGnkwSQYidCOChRWimSQPA2vQh84",
+	"CejTm4S8+ws9jzEUuUuXPePJIPke3Q8VycYM8bjfv2eE8+tGN1X2b5ncXKGZiQyDq0kxw+4ajiaD65um",
+	"dpe+FryL1MTGljA6HjO5ocU9csJ588jrLP+KhlpwC1zfKesMMkrdJdWCKqP3B5w5NmIWD0M9Y5BlkzrL",
+	"bmnvMjL7bysvnJlgPUAhOMPyXGSh9X7ef/qYs7iGUEq7KNj9Vr1cB41dZp0d9erRwE53PhfWndZE6dpF",
+	"yI4yeUXSi6P/RbqXsLq8oFL6d7N6c2DSouVdI5NFmjyLUrRtvpS217ghCEuO9i9ZG+6GRU/3L1qN1Dc8",
+	"YL0yug7jw+RmsRHu1i3P1nCL5asb6g21bXGEOOGrR0CxoEPrXmo+/9wmqoaJi/W60RmPiy3/OPrczFtv",
+	"P6rhQTVXJdiaIONV3JzryK+ll748qysrhXdyXm+wGuS13/G11tCLP7An0ooX+1csb672uG4oiDd993I1",
+	"C82WXtjiwBvI1vsk+CKahqribcd+Fd43HXvNwZ7tniXFHXn3UdX8bP+K5f3VHjVXGtnQc9THPi2nO6uf",
+	"nZrsP2aoLkcH/6O2aUPv79HtN8uvy9CrP2UgVmFk1XJV35hnWSyYciKzg3pCpeuBldFFgLqR5vNQ5zVH",
+	"Vi3DrtbbmHV3iqO5X5t0ipW8X/4mx6omgg9KQI/i1VEgvnYB9EfOBZ8xEFpzQdTHxkSVUu2+3HAvr8gk",
+	"XA7E4Fk3AuV5CRxnKHUZbjjSxBtZDSMGvZ4kgom2bvBN/5t+iKhKhq2t7mvx4cAHE1DbnZHZw81D9Scu",
+	"VQFPNfXOi6L6wDvvbVd/0FOrZnGz+HcAAAD//zBlqu30JAAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -2,43 +2,151 @@ package api
 
 import (
 	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 )
 
-// BearerAuth returns a middleware that enforces bearer-token auth on every
-// request except the liveness and readiness probes, matching the security
-// declared in api/openapi/openapi.yaml.
+// Scope names exactly match the strings declared per-operation in
+// api/openapi/openapi.yaml and surfaced by oapi-codegen under BearerAuthScopes.
+const (
+	ScopeRead   = "read"
+	ScopeWrite  = "write"
+	ScopeDelete = "delete"
+	ScopeAdmin  = "admin"
+)
+
+// ScopedToken is a bearer token with its granted scopes. Name is a
+// human-friendly label used only in logs and error messages — never the token
+// value itself.
+type ScopedToken struct {
+	Name   string   `json:"name"`
+	Token  string   `json:"token"`
+	Scopes []string `json:"scopes"`
+}
+
+// hasScope reports whether the token grants want. The admin scope implies
+// every other scope.
+func (t ScopedToken) hasScope(want string) bool {
+	for _, s := range t.Scopes {
+		if s == ScopeAdmin || s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TokenStore is an immutable lookup table from token value to scopes. Build
+// once at startup via NewTokenStore and share across goroutines — it's
+// read-only and therefore safe for concurrent use.
+type TokenStore struct {
+	tokens []ScopedToken
+}
+
+// NewTokenStore validates tokens and returns a ready-to-use store. It rejects
+// empty token values, duplicate token values across entries, and unknown
+// scope names.
+func NewTokenStore(tokens []ScopedToken) (*TokenStore, error) {
+	seen := make(map[string]struct{}, len(tokens))
+	for i, t := range tokens {
+		if t.Token == "" {
+			return nil, fmt.Errorf("token[%d] %q has empty value", i, t.Name)
+		}
+		if _, dup := seen[t.Token]; dup {
+			return nil, fmt.Errorf("token[%d] %q duplicates an earlier token value", i, t.Name)
+		}
+		seen[t.Token] = struct{}{}
+		for _, s := range t.Scopes {
+			switch s {
+			case ScopeRead, ScopeWrite, ScopeDelete, ScopeAdmin:
+			default:
+				return nil, fmt.Errorf("token[%d] %q has unknown scope %q", i, t.Name, s)
+			}
+		}
+	}
+	return &TokenStore{tokens: tokens}, nil
+}
+
+// Len returns the number of tokens in the store.
+func (s *TokenStore) Len() int { return len(s.tokens) }
+
+// lookup finds the ScopedToken matching the presented bearer using a
+// constant-time compare across every stored token, so elapsed time can't leak
+// which entry matched (or that any matched at all).
+func (s *TokenStore) lookup(presented string) (ScopedToken, bool) {
+	pb := []byte(presented)
+	var matched ScopedToken
+	found := 0
+	for _, t := range s.tokens {
+		if subtle.ConstantTimeCompare([]byte(t.Token), pb) == 1 {
+			matched = t
+			found = 1
+		}
+	}
+	return matched, found == 1
+}
+
+// ParseTokensJSON decodes a JSON array of ScopedToken. An empty or whitespace
+// input returns (nil, nil) so callers can feed it unset env vars directly.
+func ParseTokensJSON(raw string) ([]ScopedToken, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	var out []ScopedToken
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil, fmt.Errorf("parse tokens json: %w", err)
+	}
+	return out, nil
+}
+
+// BearerAuth returns a middleware suitable for the Middlewares slot of
+// StdHTTPServerOptions. Behaviour:
 //
-// A constant-time compare prevents token-probing timing attacks. Callers
-// must not pass an empty token; argosd refuses to start without one.
-func BearerAuth(token string) func(http.Handler) http.Handler {
-	expected := []byte(token)
+//   - Operations whose generated wrapper does not set BearerAuthScopes in
+//     context (i.e., those declared with `security: []` in the OpenAPI
+//     spec, such as /healthz and /readyz) pass through untouched.
+//   - Missing or malformed Authorization header: 401 with WWW-Authenticate.
+//   - Token not in the store: 401.
+//   - Valid token missing any of the operation's required scopes: 403.
+func BearerAuth(store *TokenStore) MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if isHealthProbe(r.URL.Path) {
+			scopesIface := r.Context().Value(BearerAuthScopes)
+			if scopesIface == nil {
 				next.ServeHTTP(w, r)
 				return
 			}
+			required, _ := scopesIface.([]string)
+
 			presented, ok := extractBearer(r.Header.Get("Authorization"))
 			if !ok {
 				w.Header().Set("WWW-Authenticate", `Bearer realm="argos"`)
 				writeProblem(w, http.StatusUnauthorized, "Unauthorized", "missing bearer token")
 				return
 			}
-			if subtle.ConstantTimeCompare([]byte(presented), expected) != 1 {
+			token, found := store.lookup(presented)
+			if !found {
 				w.Header().Set("WWW-Authenticate", `Bearer realm="argos"`)
 				writeProblem(w, http.StatusUnauthorized, "Unauthorized", "invalid bearer token")
 				return
+			}
+			for _, want := range required {
+				if !token.hasScope(want) {
+					writeProblem(w, http.StatusForbidden, "Forbidden", fmt.Sprintf("token %q lacks scope %q", token.Name, want))
+					return
+				}
 			}
 			next.ServeHTTP(w, r)
 		})
 	}
 }
 
-func isHealthProbe(path string) bool {
-	return path == "/healthz" || path == "/readyz"
-}
+// ErrNoTokensConfigured is returned when argosd starts without any configured
+// tokens. Callers typically return it from main() with a user-facing message.
+var ErrNoTokensConfigured = errors.New("no API tokens configured; set ARGOS_API_TOKEN or ARGOS_API_TOKENS")
 
 func extractBearer(header string) (string, bool) {
 	const prefix = "Bearer "

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -3,86 +3,155 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
-func TestBearerAuth(t *testing.T) {
+func mustTokenStore(t *testing.T, tokens []ScopedToken) *TokenStore {
+	t.Helper()
+	store, err := NewTokenStore(tokens)
+	if err != nil {
+		t.Fatalf("NewTokenStore: %v", err)
+	}
+	return store
+}
+
+func TestNewTokenStoreValidation(t *testing.T) {
 	t.Parallel()
-
-	const token = "s3cret-token"
-	passthrough := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-	wrapped := BearerAuth(token)(passthrough)
-
 	tests := []struct {
-		name        string
-		path        string
-		authHeader  string
-		wantStatus  int
-		wantWWWAuth bool
+		name    string
+		tokens  []ScopedToken
+		wantErr bool
 	}{
-		{"healthz open without auth", "/healthz", "", http.StatusOK, false},
-		{"readyz open without auth", "/readyz", "", http.StatusOK, false},
-		{"missing header rejected", "/v1/clusters", "", http.StatusUnauthorized, true},
-		{"wrong scheme rejected", "/v1/clusters", "Basic abc", http.StatusUnauthorized, true},
-		{"empty bearer rejected", "/v1/clusters", "Bearer ", http.StatusUnauthorized, true},
-		{"bad token rejected", "/v1/clusters", "Bearer wrong-token", http.StatusUnauthorized, true},
-		{"correct token allowed", "/v1/clusters", "Bearer " + token, http.StatusOK, false},
+		{"empty slice ok", nil, false},
+		{"valid single", []ScopedToken{{Name: "a", Token: "x", Scopes: []string{ScopeRead}}}, false},
+		{"empty token rejected", []ScopedToken{{Name: "a", Token: "", Scopes: []string{ScopeRead}}}, true},
+		{"duplicate token rejected", []ScopedToken{
+			{Name: "a", Token: "same", Scopes: []string{ScopeRead}},
+			{Name: "b", Token: "same", Scopes: []string{ScopeWrite}},
+		}, true},
+		{"unknown scope rejected", []ScopedToken{{Name: "a", Token: "x", Scopes: []string{"bogus"}}}, true},
+		{"admin scope accepted", []ScopedToken{{Name: "a", Token: "x", Scopes: []string{ScopeAdmin}}}, false},
+		{"all known scopes accepted", []ScopedToken{
+			{Name: "a", Token: "x", Scopes: []string{ScopeRead, ScopeWrite, ScopeDelete, ScopeAdmin}},
+		}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
-			if tt.authHeader != "" {
-				req.Header.Set("Authorization", tt.authHeader)
-			}
-			rr := httptest.NewRecorder()
-			wrapped.ServeHTTP(rr, req)
-
-			if rr.Code != tt.wantStatus {
-				t.Errorf("status=%d, want=%d body=%q", rr.Code, tt.wantStatus, rr.Body.String())
-			}
-			gotWWW := rr.Header().Get("WWW-Authenticate") != ""
-			if gotWWW != tt.wantWWWAuth {
-				t.Errorf("WWW-Authenticate presence=%v, want=%v", gotWWW, tt.wantWWWAuth)
+			_, err := NewTokenStore(tt.tokens)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("err=%v, wantErr=%v", err, tt.wantErr)
 			}
 		})
 	}
 }
 
-// TestBearerAuthWithServer verifies the middleware composes correctly with
-// the generated handler chain and keeps health probes unauthenticated.
-func TestBearerAuthWithServer(t *testing.T) {
+func TestParseTokensJSON(t *testing.T) {
 	t.Parallel()
-	const token = "srv-token"
-	base := Handler(NewServer("test", newMemStore()))
-	h := BearerAuth(token)(base)
-
-	cases := []struct {
-		name       string
-		method     string
-		path       string
-		header     string
-		wantStatus int
+	tests := []struct {
+		name    string
+		raw     string
+		wantLen int
+		wantErr bool
 	}{
-		{"authorized list", http.MethodGet, "/v1/clusters", "Bearer " + token, http.StatusOK},
-		{"unauthorized list", http.MethodGet, "/v1/clusters", "", http.StatusUnauthorized},
-		{"healthz open", http.MethodGet, "/healthz", "", http.StatusOK},
-		{"readyz open", http.MethodGet, "/readyz", "", http.StatusOK},
+		{"empty string yields nil", "", 0, false},
+		{"whitespace yields nil", "   \t\n ", 0, false},
+		{"empty array", "[]", 0, false},
+		{"single token", `[{"name":"a","token":"tok","scopes":["read"]}]`, 1, false},
+		{"multiple tokens", `[{"name":"a","token":"t1","scopes":["read"]},{"name":"b","token":"t2","scopes":["admin"]}]`, 2, false},
+		{"malformed json", `[{`, 0, true},
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			req := httptest.NewRequest(tc.method, tc.path, nil)
-			if tc.header != "" {
-				req.Header.Set("Authorization", tc.header)
+			got, err := ParseTokensJSON(tt.raw)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err=%v, wantErr=%v", err, tt.wantErr)
 			}
-			rr := httptest.NewRecorder()
-			h.ServeHTTP(rr, req)
-			if rr.Code != tc.wantStatus {
-				t.Errorf("status=%d, want=%d body=%q", rr.Code, tc.wantStatus, rr.Body.String())
+			if err == nil && len(got) != tt.wantLen {
+				t.Errorf("len=%d, want %d", len(got), tt.wantLen)
 			}
 		})
 	}
+}
+
+func TestBearerAuthEnforcesScopes(t *testing.T) {
+	t.Parallel()
+
+	store := mustTokenStore(t, []ScopedToken{
+		{Name: "ro", Token: "ro-tok", Scopes: []string{ScopeRead}},
+		{Name: "rw", Token: "rw-tok", Scopes: []string{ScopeRead, ScopeWrite}},
+		{Name: "del", Token: "del-tok", Scopes: []string{ScopeDelete}},
+		{Name: "god", Token: "god-tok", Scopes: []string{ScopeAdmin}},
+	})
+
+	h := HandlerWithOptions(NewServer("test", newMemStore()), StdHTTPServerOptions{
+		Middlewares: []MiddlewareFunc{BearerAuth(store)},
+	})
+
+	// Pre-create a cluster with the admin token so subsequent cases exercise
+	// auth, not missing-data paths.
+	precondition := doAuth(t, h, http.MethodPost, "/v1/clusters", "god-tok", `{"name":"prod"}`)
+	if precondition.Code != http.StatusCreated {
+		t.Fatalf("precondition failed to create cluster: status=%d body=%q", precondition.Code, precondition.Body.String())
+	}
+
+	anyUUID := "00000000-0000-0000-0000-000000000000"
+
+	tests := []struct {
+		name       string
+		method     string
+		target     string
+		token      string
+		body       string
+		wantStatus int
+	}{
+		{"healthz unauthenticated", http.MethodGet, "/healthz", "", "", http.StatusOK},
+		{"readyz unauthenticated", http.MethodGet, "/readyz", "", "", http.StatusOK},
+
+		{"list without token 401", http.MethodGet, "/v1/clusters", "", "", http.StatusUnauthorized},
+		{"list bad token 401", http.MethodGet, "/v1/clusters", "nope", "", http.StatusUnauthorized},
+		{"list with read ok", http.MethodGet, "/v1/clusters", "ro-tok", "", http.StatusOK},
+		{"list with delete-only 403", http.MethodGet, "/v1/clusters", "del-tok", "", http.StatusForbidden},
+		{"list with admin ok", http.MethodGet, "/v1/clusters", "god-tok", "", http.StatusOK},
+
+		{"create with read 403", http.MethodPost, "/v1/clusters", "ro-tok", `{"name":"a"}`, http.StatusForbidden},
+		{"create with write ok", http.MethodPost, "/v1/clusters", "rw-tok", `{"name":"b"}`, http.StatusCreated},
+		{"create with admin ok", http.MethodPost, "/v1/clusters", "god-tok", `{"name":"c"}`, http.StatusCreated},
+
+		{"patch with read 403", http.MethodPatch, "/v1/clusters/" + anyUUID, "ro-tok", `{"provider":"gke"}`, http.StatusForbidden},
+		{"patch with write returns 404 (no row)", http.MethodPatch, "/v1/clusters/" + anyUUID, "rw-tok", `{"provider":"gke"}`, http.StatusNotFound},
+
+		{"delete with write 403", http.MethodDelete, "/v1/clusters/" + anyUUID, "rw-tok", "", http.StatusForbidden},
+		{"delete with delete-scope returns 404", http.MethodDelete, "/v1/clusters/" + anyUUID, "del-tok", "", http.StatusNotFound},
+		{"delete with admin returns 404", http.MethodDelete, "/v1/clusters/" + anyUUID, "god-tok", "", http.StatusNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := doAuth(t, h, tt.method, tt.target, tt.token, tt.body)
+			if rr.Code != tt.wantStatus {
+				t.Errorf("status=%d, want=%d; body=%q", rr.Code, tt.wantStatus, rr.Body.String())
+			}
+			if tt.wantStatus == http.StatusUnauthorized {
+				if rr.Header().Get("WWW-Authenticate") == "" {
+					t.Error("WWW-Authenticate header missing on 401")
+				}
+			}
+		})
+	}
+}
+
+func doAuth(t *testing.T, h http.Handler, method, target, token, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	return rr
 }


### PR DESCRIPTION
…min)

Extends the bearer-token middleware from a single god token to a scope- aware token store driven by scopes declared per operation in the OpenAPI contract.

Contract:
- api/openapi/openapi.yaml: every cluster operation now carries an explicit 'security: [BearerAuth: [<scope>]]' block. GETs require read, POST/PATCH require write, DELETE requires delete. /healthz and /readyz stay security: [] (open). Added a Forbidden (403) response component and reference it from each scoped op. BearerAuth component description documents the four scopes.
- internal/api/api.gen.go regenerated; the wrapper now sets BearerAuthScopes=["read"|"write"|"delete"] in context before calling HandlerMiddlewares, which is exactly the hook the middleware uses.

Auth core:
- internal/api/auth.go:
  - ScopedToken{Name, Token, Scopes} with JSON tags so it also serves as the wire shape for ARGOS_API_TOKENS.
  - TokenStore validates inputs (no empty, no duplicate, only known scopes) and looks tokens up via constant-time compare iterated across the full set so elapsed time can't reveal which entry matched.
  - hasScope(want) treats ScopeAdmin as a wildcard over every other scope.
  - BearerAuth returns a MiddlewareFunc plugged into StdHTTPServerOptions.Middlewares. A nil BearerAuthScopes context value (as set by unauthenticated ops) short-circuits to pass-through; a missing / unknown token yields 401 with WWW-Authenticate; a valid token lacking any required scope yields 403 problem+json.
  - ParseTokensJSON + ErrNoTokensConfigured exposed for main to compose.

Daemon:
- cmd/argosd/main.go loadTokenStore merges two env sources:
  - ARGOS_API_TOKEN (unchanged shape) becomes a convenience single-entry admin token so existing dev setups keep working.
  - ARGOS_API_TOKENS is a JSON array of ScopedToken for production-style multi-token setups. Both are merged; at least one token must be configured. Wiring switches from api.Handler to api.HandlerWithOptions with the scope-aware middleware.

Tests:
- internal/api/auth_test.go is table-driven and covers NewTokenStore validation (empty / duplicate / unknown scope), ParseTokensJSON (empty, whitespace, malformed), and a 14-row matrix over the HandlerWithOptions chain verifying read/write/delete/admin enforcement including probe openness, 401 on missing/bad token, 403 on missing scope, and WWW-Authenticate presence. api coverage: 70.3% -> 76.2%.

Docs:
- CLAUDE.md lists the scope table and the two env-var forms.