### PR TITLE
ci: add GitHub Actions pipeline with lint, test, and codegen drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,4 +75,5 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
+          install-mode: goinstall
           args: --timeout=5m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: lint, vet, build, test
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: argos
+          POSTGRES_PASSWORD: argos
+          POSTGRES_DB: argos_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd=pg_isready
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+
+    env:
+      PGX_TEST_DATABASE: postgres://argos:argos@localhost:5432/argos_test?sslmode=disable
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify generated code is current
+        run: |
+          go generate ./...
+          if ! git diff --exit-code; then
+            echo "::error::Generated code is stale. Run 'make generate' and commit the result."
+            exit 1
+          fi
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go build
+        run: go build ./...
+
+      - name: go test (race + cover)
+        run: go test -race -coverprofile=coverage.out ./...
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.out
+          if-no-files-found: ignore
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          args: --timeout=5m

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,5 +62,6 @@ At least one token must be configured; `/healthz` and `/readyz` stay open.
 - `internal/store/` — PostgreSQL implementation of `api.Store` using `pgx/v5`. Cursor-paginated list, merge-patch updates, embedded `goose` migrations.
 - `internal/collector/` — Kubernetes polling collector (v1 scope: fetches the API server version via `client-go` and refreshes the matching cluster record by name). Disabled by default; enable with `ARGOS_COLLECTOR_ENABLED=true` and `ARGOS_CLUSTER_NAME=...`.
 - `migrations/` — timestamped SQL migrations, embedded in the binary via `migrations/embed.go`.
+- `.github/workflows/ci.yml` — GitHub Actions pipeline: codegen-drift check, `go vet`, `go build`, `go test -race` against a Postgres service container (so the integration tests gated on `PGX_TEST_DATABASE` run in CI), and `golangci-lint`.
 
 Follow-up work: extend the OpenAPI spec and collector to cover Node, Namespace, Workload, Pod; add bearer-token auth middleware; document how K8s kinds map to ANSSI cartography layers and how snapshots are versioned in PostgreSQL.

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -59,7 +59,7 @@ func (p *PG) Migrate(ctx context.Context) error {
 	}
 
 	db := stdlib.OpenDBFromPool(p.pool)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	if err := goose.UpContext(ctx, db, "."); err != nil {
 		return fmt.Errorf("goose up: %w", err)


### PR DESCRIPTION
Stops regressions before they hit main. Runs on every push to main and on every pull request targeting main.

Pipeline (Ubuntu, Go pulled from go.mod via actions/setup-go cache):
- Codegen freshness: runs 'go generate ./...' and fails the job if the working tree diverges, so a forgotten 'make generate' is caught here rather than in review.
- go vet ./...
- go build ./...
- go test -race -coverprofile=coverage.out ./... against a postgres:17 service container exposed on localhost:5432. PGX_TEST_DATABASE is set job-wide so the store integration tests gated on that env var now run for real in CI (they still skip locally when the var is absent).
- golangci-lint via golangci/golangci-lint-action@v6 with a 5m timeout.
- coverage.out is uploaded as an artifact for later inspection.

Concurrency group is keyed on ref so force-pushes and rapid PR updates cancel stale runs.

Quick lint pass on main revealed one errcheck hit that this PR also fixes: the stdlib *sql.DB returned by pgx's OpenDBFromPool adapter during goose migrations had an unchecked defer Close. Replaced with an explicit ignoring closure.