### PR TITLE
feat(api): add Node resource with CRUD, FK-linked to Cluster

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Configure tokens via either or both env vars (merged at startup):
 
 At least one token must be configured; `/healthz` and `/readyz` stay open.
 - `internal/api/` — generated server (`api.gen.go`), hand-written handlers (`server.go`), `Store` interface (`store.go`) with `ErrNotFound` / `ErrConflict` sentinels. RFC 7807 `application/problem+json` for all errors.
-- `internal/store/` — PostgreSQL implementation of `api.Store` using `pgx/v5`. Cursor-paginated list, merge-patch updates, embedded `goose` migrations.
+- `internal/store/` — PostgreSQL implementation of `api.Store` using `pgx/v5`. Cursor-paginated list, merge-patch updates, embedded `goose` migrations. Nodes are FK-linked to clusters with `ON DELETE CASCADE`.
 - `internal/collector/` — Kubernetes polling collector (v1 scope: fetches the API server version via `client-go` and refreshes the matching cluster record by name). Disabled by default; enable with `ARGOS_COLLECTOR_ENABLED=true` and `ARGOS_CLUSTER_NAME=...`.
 - `migrations/` — timestamped SQL migrations, embedded in the binary via `migrations/embed.go`.
 - `.github/workflows/ci.yml` — GitHub Actions pipeline: codegen-drift check, `go vet`, `go build`, `go test -race` against a Postgres service container (so the integration tests gated on `PGX_TEST_DATABASE` run in CI), and `golangci-lint`.

--- a/api/openapi/openapi.yaml
+++ b/api/openapi/openapi.yaml
@@ -26,6 +26,8 @@ tags:
     description: Liveness and readiness probes (unauthenticated).
   - name: clusters
     description: Kubernetes clusters registered in the CMDB.
+  - name: nodes
+    description: Kubernetes nodes (worker / control-plane machines) within a cluster.
 
 security:
   - BearerAuth: []
@@ -195,6 +197,137 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /v1/nodes:
+    get:
+      tags: [nodes]
+      summary: List nodes
+      operationId: listNodes
+      security:
+        - BearerAuth: [read]
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Cursor'
+        - $ref: '#/components/parameters/NodeClusterIdFilter'
+      responses:
+        '200':
+          description: Paged list of nodes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+    post:
+      tags: [nodes]
+      summary: Register a node
+      operationId: createNode
+      security:
+        - BearerAuth: [write]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeCreate'
+      responses:
+        '201':
+          description: Node created.
+          headers:
+            Location:
+              description: URI of the newly created node.
+              schema:
+                type: string
+                format: uri
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+
+  /v1/nodes/{id}:
+    parameters:
+      - $ref: '#/components/parameters/NodeId'
+    get:
+      tags: [nodes]
+      summary: Get a node
+      operationId: getNode
+      security:
+        - BearerAuth: [read]
+      responses:
+        '200':
+          description: Node details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    patch:
+      tags: [nodes]
+      summary: Update mutable fields of a node
+      description: |
+        Merge-patch semantics: fields omitted from the body are unchanged.
+        `cluster_id` and `name` are immutable after creation.
+      operationId: updateNode
+      security:
+        - BearerAuth: [write]
+      requestBody:
+        required: true
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/NodeUpdate'
+      responses:
+        '200':
+          description: Updated node.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    delete:
+      tags: [nodes]
+      summary: Delete a node
+      operationId: deleteNode
+      security:
+        - BearerAuth: [delete]
+      responses:
+        '204':
+          description: Node deleted.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
 components:
 
   securitySchemes:
@@ -221,6 +354,24 @@ components:
       in: path
       required: true
       description: Server-assigned cluster identifier.
+      schema:
+        type: string
+        format: uuid
+
+    NodeId:
+      name: id
+      in: path
+      required: true
+      description: Server-assigned node identifier.
+      schema:
+        type: string
+        format: uuid
+
+    NodeClusterIdFilter:
+      name: cluster_id
+      in: query
+      required: false
+      description: Return only nodes belonging to this cluster.
       schema:
         type: string
         format: uuid
@@ -421,6 +572,108 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Cluster'
+        next_cursor:
+          type: string
+          nullable: true
+          description: |
+            Opaque cursor to pass as `?cursor=` to fetch the next page.
+            Absent or null when no more pages remain.
+
+    NodeMutable:
+      description: Fields on a Node that clients may set and later update.
+      type: object
+      properties:
+        display_name:
+          type: string
+          maxLength: 256
+          description: Human-friendly label, free-form.
+        kubelet_version:
+          type: string
+          maxLength: 32
+          description: Kubelet git version as reported by Kubernetes (e.g. "v1.29.5").
+        os_image:
+          type: string
+          maxLength: 256
+          description: Node OS image string (e.g. "Ubuntu 22.04.3 LTS").
+        architecture:
+          type: string
+          maxLength: 32
+          description: |
+            CPU architecture. Open-ended; common values: amd64, arm64, ppc64le, s390x.
+        labels:
+          type: object
+          description: Arbitrary user-supplied string key/value labels.
+          additionalProperties:
+            type: string
+            maxLength: 256
+          maxProperties: 64
+
+    NodeCreate:
+      description: Payload to register a new node under a cluster.
+      allOf:
+        - $ref: '#/components/schemas/NodeMutable'
+        - type: object
+          required: [cluster_id, name]
+          properties:
+            cluster_id:
+              type: string
+              format: uuid
+              description: |
+                Parent cluster id. Immutable after creation; the cluster must
+                already exist or the create returns 404.
+            name:
+              type: string
+              description: |
+                Kubernetes node name (DNS-subdomain style). Unique per cluster.
+                Immutable after creation.
+              pattern: '^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$'
+              minLength: 2
+              maxLength: 253
+
+    NodeUpdate:
+      description: |
+        Merge-patch body. Only mutable fields; `cluster_id` and `name` are
+        immutable. Omitted fields are left unchanged.
+      allOf:
+        - $ref: '#/components/schemas/NodeMutable'
+
+    Node:
+      description: A Kubernetes node registered in the CMDB.
+      allOf:
+        - $ref: '#/components/schemas/NodeMutable'
+        - type: object
+          required: [id, cluster_id, name, created_at, updated_at]
+          properties:
+            id:
+              type: string
+              format: uuid
+              readOnly: true
+            cluster_id:
+              type: string
+              format: uuid
+            name:
+              type: string
+              pattern: '^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$'
+              minLength: 2
+              maxLength: 253
+            created_at:
+              type: string
+              format: date-time
+              readOnly: true
+            updated_at:
+              type: string
+              format: date-time
+              readOnly: true
+
+    NodeList:
+      description: Paged list of nodes.
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Node'
         next_cursor:
           type: string
           nullable: true

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -141,6 +141,85 @@ type Health struct {
 // HealthStatus defines model for Health.Status.
 type HealthStatus string
 
+// Node defines model for Node.
+type Node struct {
+	// Architecture CPU architecture. Open-ended; common values: amd64, arm64, ppc64le, s390x.
+	Architecture *string            `json:"architecture,omitempty"`
+	ClusterId    openapi_types.UUID `json:"cluster_id"`
+	CreatedAt    *time.Time         `json:"created_at,omitempty"`
+
+	// DisplayName Human-friendly label, free-form.
+	DisplayName *string             `json:"display_name,omitempty"`
+	Id          *openapi_types.UUID `json:"id,omitempty"`
+
+	// KubeletVersion Kubelet git version as reported by Kubernetes (e.g. "v1.29.5").
+	KubeletVersion *string `json:"kubelet_version,omitempty"`
+
+	// Labels Arbitrary user-supplied string key/value labels.
+	Labels *map[string]string `json:"labels,omitempty"`
+	Name   string             `json:"name"`
+
+	// OsImage Node OS image string (e.g. "Ubuntu 22.04.3 LTS").
+	OsImage   *string    `json:"os_image,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+}
+
+// NodeCreate defines model for NodeCreate.
+type NodeCreate struct {
+	// Architecture CPU architecture. Open-ended; common values: amd64, arm64, ppc64le, s390x.
+	Architecture *string `json:"architecture,omitempty"`
+
+	// ClusterId Parent cluster id. Immutable after creation; the cluster must
+	// already exist or the create returns 404.
+	ClusterId openapi_types.UUID `json:"cluster_id"`
+
+	// DisplayName Human-friendly label, free-form.
+	DisplayName *string `json:"display_name,omitempty"`
+
+	// KubeletVersion Kubelet git version as reported by Kubernetes (e.g. "v1.29.5").
+	KubeletVersion *string `json:"kubelet_version,omitempty"`
+
+	// Labels Arbitrary user-supplied string key/value labels.
+	Labels *map[string]string `json:"labels,omitempty"`
+
+	// Name Kubernetes node name (DNS-subdomain style). Unique per cluster.
+	// Immutable after creation.
+	Name string `json:"name"`
+
+	// OsImage Node OS image string (e.g. "Ubuntu 22.04.3 LTS").
+	OsImage *string `json:"os_image,omitempty"`
+}
+
+// NodeList Paged list of nodes.
+type NodeList struct {
+	Items []Node `json:"items"`
+
+	// NextCursor Opaque cursor to pass as `?cursor=` to fetch the next page.
+	// Absent or null when no more pages remain.
+	NextCursor *string `json:"next_cursor,omitempty"`
+}
+
+// NodeMutable Fields on a Node that clients may set and later update.
+type NodeMutable struct {
+	// Architecture CPU architecture. Open-ended; common values: amd64, arm64, ppc64le, s390x.
+	Architecture *string `json:"architecture,omitempty"`
+
+	// DisplayName Human-friendly label, free-form.
+	DisplayName *string `json:"display_name,omitempty"`
+
+	// KubeletVersion Kubelet git version as reported by Kubernetes (e.g. "v1.29.5").
+	KubeletVersion *string `json:"kubelet_version,omitempty"`
+
+	// Labels Arbitrary user-supplied string key/value labels.
+	Labels *map[string]string `json:"labels,omitempty"`
+
+	// OsImage Node OS image string (e.g. "Ubuntu 22.04.3 LTS").
+	OsImage *string `json:"os_image,omitempty"`
+}
+
+// NodeUpdate Fields on a Node that clients may set and later update.
+type NodeUpdate = NodeMutable
+
 // Problem RFC 7807 problem details.
 type Problem struct {
 	Detail *string `json:"detail,omitempty"`
@@ -164,6 +243,12 @@ type Cursor = string
 
 // Limit defines model for Limit.
 type Limit = int
+
+// NodeClusterIdFilter defines model for NodeClusterIdFilter.
+type NodeClusterIdFilter = openapi_types.UUID
+
+// NodeId defines model for NodeId.
+type NodeId = openapi_types.UUID
 
 // BadRequest RFC 7807 problem details.
 type BadRequest = Problem
@@ -189,11 +274,29 @@ type ListClustersParams struct {
 	Cursor *Cursor `form:"cursor,omitempty" json:"cursor,omitempty"`
 }
 
+// ListNodesParams defines parameters for ListNodes.
+type ListNodesParams struct {
+	// Limit Maximum number of items to return. Server clamps to [1, 200].
+	Limit *Limit `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Cursor Opaque cursor returned from a previous list response.
+	Cursor *Cursor `form:"cursor,omitempty" json:"cursor,omitempty"`
+
+	// ClusterId Return only nodes belonging to this cluster.
+	ClusterId *NodeClusterIdFilter `form:"cluster_id,omitempty" json:"cluster_id,omitempty"`
+}
+
 // CreateClusterJSONRequestBody defines body for CreateCluster for application/json ContentType.
 type CreateClusterJSONRequestBody = ClusterCreate
 
 // UpdateClusterApplicationMergePatchPlusJSONRequestBody defines body for UpdateCluster for application/merge-patch+json ContentType.
 type UpdateClusterApplicationMergePatchPlusJSONRequestBody = ClusterUpdate
+
+// CreateNodeJSONRequestBody defines body for CreateNode for application/json ContentType.
+type CreateNodeJSONRequestBody = NodeCreate
+
+// UpdateNodeApplicationMergePatchPlusJSONRequestBody defines body for UpdateNode for application/merge-patch+json ContentType.
+type UpdateNodeApplicationMergePatchPlusJSONRequestBody = NodeUpdate
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
@@ -218,6 +321,21 @@ type ServerInterface interface {
 	// Update mutable fields of a cluster
 	// (PATCH /v1/clusters/{id})
 	UpdateCluster(w http.ResponseWriter, r *http.Request, id ClusterId)
+	// List nodes
+	// (GET /v1/nodes)
+	ListNodes(w http.ResponseWriter, r *http.Request, params ListNodesParams)
+	// Register a node
+	// (POST /v1/nodes)
+	CreateNode(w http.ResponseWriter, r *http.Request)
+	// Delete a node
+	// (DELETE /v1/nodes/{id})
+	DeleteNode(w http.ResponseWriter, r *http.Request, id NodeId)
+	// Get a node
+	// (GET /v1/nodes/{id})
+	GetNode(w http.ResponseWriter, r *http.Request, id NodeId)
+	// Update mutable fields of a node
+	// (PATCH /v1/nodes/{id})
+	UpdateNode(w http.ResponseWriter, r *http.Request, id NodeId)
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -411,6 +529,168 @@ func (siw *ServerInterfaceWrapper) UpdateCluster(w http.ResponseWriter, r *http.
 	handler.ServeHTTP(w, r)
 }
 
+// ListNodes operation middleware
+func (siw *ServerInterfaceWrapper) ListNodes(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"read"})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListNodesParams
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "cursor" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "cursor", r.URL.Query(), &params.Cursor, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cursor", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "cluster_id" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "cluster_id", r.URL.Query(), &params.ClusterId, runtime.BindQueryParameterOptions{Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cluster_id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListNodes(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateNode operation middleware
+func (siw *ServerInterfaceWrapper) CreateNode(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"write"})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateNode(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteNode operation middleware
+func (siw *ServerInterfaceWrapper) DeleteNode(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id NodeId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"delete"})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteNode(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetNode operation middleware
+func (siw *ServerInterfaceWrapper) GetNode(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id NodeId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"read"})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetNode(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateNode operation middleware
+func (siw *ServerInterfaceWrapper) UpdateNode(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id NodeId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"write"})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateNode(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 type UnescapedCookieParamError struct {
 	ParamName string
 	Err       error
@@ -538,6 +818,11 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("DELETE "+options.BaseURL+"/v1/clusters/{id}", wrapper.DeleteCluster)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/clusters/{id}", wrapper.GetCluster)
 	m.HandleFunc("PATCH "+options.BaseURL+"/v1/clusters/{id}", wrapper.UpdateCluster)
+	m.HandleFunc("GET "+options.BaseURL+"/v1/nodes", wrapper.ListNodes)
+	m.HandleFunc("POST "+options.BaseURL+"/v1/nodes", wrapper.CreateNode)
+	m.HandleFunc("DELETE "+options.BaseURL+"/v1/nodes/{id}", wrapper.DeleteNode)
+	m.HandleFunc("GET "+options.BaseURL+"/v1/nodes/{id}", wrapper.GetNode)
+	m.HandleFunc("PATCH "+options.BaseURL+"/v1/nodes/{id}", wrapper.UpdateNode)
 
 	return m
 }
@@ -545,51 +830,61 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/9RabXPbxvH/Kjv4Z+YvOeCDZDuJmel0ZDlONJVtjRS3L0TVOuIW5IWHO/geqDAezvRD",
-	"9BP2k3T2DiBBEhSV1FHTNzYI7N3u7cNvH06fkkwXpVaonE0Gn5KSGVagQxN+nUpvHZozTj842syI0gmt",
-	"kkFyhWaGpsOsFWOFHLJICoKjciIXaLpJmggiLZmbJGmiWIHJIBE8SRODH70wyJOBMx7TxGYTLBhxybUp",
-	"mEsGifeB0s1LWmWdEWqcLBZpcuqN1WZboncl++gRsvAZDDpvSLDc6AIYlAZnQnsLUlgHBm2plcWljB89",
-	"mvlKyLhJ0hSsYD+foxq7STJ4fnTcJti5KITblusN+1kUvgDlixEa0DkIh4UFpyshuxCVCZlkRRk+XB+l",
-	"cNzv3+ySTwZWTfE45sxLlwye91OSlVgmg+M+/RIq/jpaSi2UwzGaZEFy18oIJn/J+CV+9GjDSTKtHKrw",
-	"yMpSiozRoXql0SOJxZc/WTrhp4YYXxjMk0Hyf72VW/XiV9u7iKsi000dSTI8cjCReTchS2uVS5E9qiQ1",
-	"T7gTbkLOZFA5sI45hAPsjrspcB/5I5A1DoOor7UZCc5RPaasP+opKhAWZkwKDiPvQLJsasFNEGymS4Q6",
-	"0GA0D291iSZIE6R+q91r7RV/TKEv0WpvMgSlHeTEPYjyXjHvJtqIX/BRxXkjrBVqDNqAUJUekRk04Ei7",
-	"3RDZ1T4NSAxySfkuTwbX9/OuFrzxjo0kJov0U1IaMoMTMeIyg8wh/8DcGv5x5rDjRIEBLhl/p+S8hssN",
-	"7EkJVFuwc++yiCZr2PbVswAY9c/jlODboSFd/f2adX7pd17cVP93bj7106+OF/XrL5IWHr7k/+HxFs18",
-	"cR0TSJA8bepujdPNchM9+gkzlyxuNg1/An/xIzQKHdpl9jI4FvSAHIQKAXP65tXLCEaR5DRw/Izmr22w",
-	"kV4DOVjpxx0pptjIqyl4JSjTscxoa1dSDtVZUUQ+wHI6TlAPBftQJenvaOUNC4UjPcAEF2wuNeMxE0bF",
-	"AwOFd7U9moo/F7YluV6wMfKY03VeL7OUNte1HFLu2sMDjEbcqzMwY9g8hAz+7D5kDypBnIaSWQvMwu2f",
-	"47s/3dLbHF02CXaj3aBkY+wO1cnIUqrRBpSXEu4mqEBpKLTBQGLBYMFEZUyiCR71sJgJp942yVK7tX9u",
-	"Hem1QMktaAUMKlpwE+Ygk4J0BgWbg0UHTHGQjD7HONy2ASvFB1S81EK1WLIRjScXZ2BjSfT+8hwOhIqw",
-	"IbRi8pA2XiGdEW2gw4UtJZt/aA+uH3zBVCc3AhWXc5BshDKF3CB2aOPueqwcP/+qhQOqmTBaFdh2ltf1",
-	"VtAgA8fGyxICZykVFWOhximURvPD7naEbjGdLnX0YYbGipgDNwqYykgNJVa0YLDUxsVioKHuIBMMk6Pu",
-	"8Yvu82GyKcrT4xZRgtKiWTkX0TQXa+beq8INPDYj4Qwzc/AWTcd6yvrIIdLDFOe9GZMeo7lsJWOTZUNl",
-	"K/8ujZ4Jji3B+l5xNHJOmzeUwQUxHHkiolicaOuIpN6nO1TvSlQdVBz5t5DpotAKgmR2AOMppoBTmwKj",
-	"f3SJyk5E7lIw9IXsx3iRglalQfrfTcKWD7A9IWS09/2Ui91B/j4E5m/PXVsA/gbNGDslIzgbaT7vAqVx",
-	"qJNQHrDjW7ilMLylQlXUCYrUWAhHzhipgBkEibkDr7IJU2PkpJdFmvyATNJZNxMn1eQ+PKGi7uY60dMG",
-	"xK00tzNUXnoh+TI6dB4g2XilyODMjLXl3b3JrhKjDVvrsnOL8eXrU/j6m/7XUJWzwNExIVvyVvxAT9sI",
-	"ZIw2dgdidyTOUMbGIAAnRPI05pWqpCZDUIdZ58R13sEwrawLtJaNseXbhnLiFqsFbVrazLBCWcdUhusV",
-	"bTvOr3xg2fI+f/Gi2fJSA7zZ9KaJE05i69Hii0Y/nbCR9m4wkkxN92aejeOHrzW3dLer0Ekw80a4+RXF",
-	"XtWKhz7kxEfnj13J65p96E6SLRC9OIt9CwhrPXLQ3nV03hkxxbtwhYqHauSkarWCZwwgMoKh7/efZmF5",
-	"eMTb7lAN1RU1khbGhikKV6eBRR6DoQLowC2V77cA8K9//DNWYlQKjNGtmk1bUd4Z4fA2UsbSPdDGggEO",
-	"REGQb+sdmQsBmTEp0fx/gObMIO13WO3HUSJtSPsZLPSMGt7YXtYsGS+EqlgyKesoZyM9w2+JmlIkh1wb",
-	"yL3zBiGs6GgCsrpasaSH0G1byJgxIWnQNvX2sdkO8mfCyTlY5oTN58DUfKMTH6oRvW504gH+A+aST0Q7",
-	"r1xr4lwZG1cqg1qw5LurH0OypyM8eXJCsPXkSUrl2ptXL8PbRnpr1CMWmIyzuzDqcBMcqpO3V1dncIXZ",
-	"W1+cSu05HFy9PT2Ej55JkVdNOOSGFXinzTT4x48TYZcgetDvHnX7h4T1DO6YnJKm7JTspBVkeoYUKJXn",
-	"nIsZKqQKWXEgm4vwi0Bxab8qB90uDQunl+9fBb/0I4sfPVVWFXcLd0JKYJzDW80xhbesQFuyDFP4mzZT",
-	"ajZSuNA8DRxD8h2qNe044eYwFYpTYVuWFEHK6WDrqJuMGafHhpUTKhzn1GyQMN8FdIVcS6nvYInvB7e7",
-	"hhe3h5XdfVEwM18rgDsZKmdEFi24aSXYNtLKIEu0oYJqrG3c4uTiLGnkwSQYidCOChRWimSQPA2vQh84",
-	"CejTm4S8+ws9jzEUuUuXPePJIPke3Q8VycYM8bjfv2eE8+tGN1X2b5ncXKGZiQyDq0kxw+4ajiaD65um",
-	"dpe+FryL1MTGljA6HjO5ocU9csJ588jrLP+KhlpwC1zfKesMMkrdJdWCKqP3B5w5NmIWD0M9Y5BlkzrL",
-	"bmnvMjL7bysvnJlgPUAhOMPyXGSh9X7ef/qYs7iGUEq7KNj9Vr1cB41dZp0d9erRwE53PhfWndZE6dpF",
-	"yI4yeUXSi6P/RbqXsLq8oFL6d7N6c2DSouVdI5NFmjyLUrRtvpS217ghCEuO9i9ZG+6GRU/3L1qN1Dc8",
-	"YL0yug7jw+RmsRHu1i3P1nCL5asb6g21bXGEOOGrR0CxoEPrXmo+/9wmqoaJi/W60RmPiy3/OPrczFtv",
-	"P6rhQTVXJdiaIONV3JzryK+ll748qysrhXdyXm+wGuS13/G11tCLP7An0ooX+1csb672uG4oiDd993I1",
-	"C82WXtjiwBvI1vsk+CKahqribcd+Fd43HXvNwZ7tniXFHXn3UdX8bP+K5f3VHjVXGtnQc9THPi2nO6uf",
-	"nZrsP2aoLkcH/6O2aUPv79HtN8uvy9CrP2UgVmFk1XJV35hnWSyYciKzg3pCpeuBldFFgLqR5vNQ5zVH",
-	"Vi3DrtbbmHV3iqO5X5t0ipW8X/4mx6omgg9KQI/i1VEgvnYB9EfOBZ8xEFpzQdTHxkSVUu2+3HAvr8gk",
-	"XA7E4Fk3AuV5CRxnKHUZbjjSxBtZDSMGvZ4kgom2bvBN/5t+iKhKhq2t7mvx4cAHE1DbnZHZw81D9Scu",
-	"VQFPNfXOi6L6wDvvbVd/0FOrZnGz+HcAAAD//zBlqu30JAAA",
+	"H4sIAAAAAAAC/+xb/XIbtxF/lZ1rZio5xw992Inp6WRkOU40sWWNZLV/iKoFHpYkQhxwBnCUGQ9n+hB9",
+	"wj5JZ4E78kgeRcmR1NTtPzZ53MMu9vOHXehzlOg00wqVs1Hnc5Qxw1J0aPy3Q5lbh+aI0xeONjEic0Kr",
+	"qBOdoRmjaTBrxUAhhySQguConOgLNM0ojgSRZswNozhSLMWoEwkexZHBj7kwyKOOMznGkU2GmDLi0tcm",
+	"ZS7qRHnuKd0ko7esM0INouk0jg5zY7VZlehdxj7mCIn/GQy63JBgfaNTYJAZHAudW5DCOjBoM60szmT8",
+	"mKOZzIUMi0RVwVL26Q2qgRtGnac7u3WCvRGpcKtyvWWfRJqnoPK0hwZ0H4TD1ILThZBNCMqERLI08z9c",
+	"7MSw225frpNPelZV8Tj2WS5d1HnajklWYhl1dtv0TajwbWcmtVAOB2i82Mea48zQr4V0WKPcUy8paCUn",
+	"oDRHCz2UWg2EGpC8bihs6QJrdRp+/uDNeheDk4C3cUGS68H9b0ovB+fxIfKS8VP8mKP1lk+0cqj8R5Zl",
+	"UiSMZG1lRvckpt/+aknwzxV23xjsR53oT615GLbCr7Z1Et4KTJd9SpKgyMEE5s2IIkOrvhTJo0pS8oRr",
+	"4YYUfAaVA+uYQ9jC5qAZA88DfwQywbYX9bU2PcE5qseU9b0eoQJhYcyk4NDLHUiWjCy4IYJNdIZQOgb0",
+	"Jv6pztB4abzUx9q91rnijyn0KVqdmwRBaQd94u5FOVcsd0NtxG/4qOK8FdZS0GsDQhV6RGbQgCPtNn3E",
+	"FutUSoiXS8p3/ahzcTPv4oW3uWM9idE0/hxlhszgRIi4xCBzyD8wtxCvnDlsOJGiD2/G3yk5KcN7KYhj",
+	"SgI1sb7xtZBCFmrBs32fYMuvuzGlG4eGdPX3C9b4rd14fln837j83I6f7U7Lx99ENTzyjP/O7U2r+e0i",
+	"JDwveVzV3QKny9kiuvcrJi6aXi4b/gB+yXtoFDqcpXowOBD0ATkI5QPm8O2rlyEZBZJDz/EezV/aYKkW",
+	"eHKwMh80pBhV60AMuRKEDFhitLVzKbvqKE0DH2B92o5XDwV7V0XxA1p5yUJ+S7cwwQmbSM14QA5B8cBA",
+	"4fW89M4V/0bYGjBywgbIAwbS/fI1S6VyUcseoix8uIXRiHuxB2YMm/iQwU/uQ3IryOY0ZMxaYBaufgjP",
+	"/nJFT/vokqG3G60GGRtgs6sOepZKjTagcinheogKlIZUG/QkFgymTBTGJBrvUbeLGb/rVZPMtFv658qW",
+	"XguU3IJWwKCgBTdkDhIpSGeQsglYdMAUB8no5xCHqzZgmfiAimdaqBpLVqLx4OQIbICQ56dvYEuokDaE",
+	"Vkxu08LzTGdEXdLhwmaSTT7UB9fPecpUo28EKi4nIFkPZQx9g9ighZuLsbL79FkNB1RjYbRKsW4vr8ul",
+	"oEIGjg1mEALHMYEKwpsxZEbz7eZqhK4wHc109GGMxopQA5cATGGkihILWjCYaeMCGKio28sE3Winufu8",
+	"+bQbLYuyt1sjildaMCvnIpjmZMHcG1W4lI9NTzjDzARyi6Zhc6r6yCHQwwgnrTGTOQZz2ULGKsuKyub+",
+	"nRk9FrzuCHCuOBo5ocUryuCCGPZyIqJYHGrriKRcp9lV7zJUDVQc+QtIdJpqBV4y24HBCGPAkY2B0T86",
+	"Q2WHou9iMPQL2Y/xNAatMoP0vxv6JW9he8qQwd43U07XB/m5D8wvr10rCfwtmgE2MkbprKf5pAlUxqEs",
+	"Qn2fO17AFYXhFQFVURYoUmMqHDljoAJmECT2HeQqGTI1QE56mcbRz8gk7XW5cBImz/0nVHQavIj0qJLi",
+	"5ppbGyovcyH5LDp036dkkytFBmdmoC1vbix2hRh1uZUOerfXNlHfgBLnp83Np7r4DwYqd5/u3QJvbF00",
+	"wqfm5ZPy2fYPjwgqF07094ww/WH+BnjpuxZ3xJZ38Zhl2OSPtfMmVxPWYccXXs6SMs2t6yomSbsTwE8e",
+	"eJlA4qUvekAW9tv7IbFt9NX6Ir2sO6KCrVfHZw2b97gmJATWTSRuN+E8AOLM95wCcrwDGL5n71zyrFWn",
+	"+l3I2Osip9IFbAEmkzPcBiP7btfvBcg+s/0PoONqhN0IjYnwi3GxSYbCYeJyU8Pl8OQcqhRNuAF/sJQ/",
+	"24+BmZT+y7Lk2b7EGOze8/anFb+vxXUPj5wJBEl06xHsL4EABsLNijOzm9Dr+KuEr9p+ECkb1JjCe9y7",
+	"M/A/l2xKZZz3cuVy2N1ttvebe/Dm/dmqXup2NV0TA3dFjguV6Yth4zx1XvkwKnAkM9hVcyQJtwWSZRdw",
+	"dRjw+hC++779HRTdReDomJA1WTL8QJ9WD4TGaGPXZImGxDHK0Kf1RQgCeRwSWdHhpN1E8TwDL/L226tl",
+	"naK1hY/cnOjCEvMX6lLeckoXyjqmElzEgvXH7jkkn01snj5/Xp3YtNurM5s4csJJrN1aeFAZB0Wsp3PX",
+	"6UmmRhsbAUvb97+W3OL1yJ12gkluhJuckUMXkxHfFj7Iw1kkNIlfl+x9szhaSQonR6GNDMLaHDno3DV0",
+	"v9FjijfhDBX35e+g6Hx7z+hAYATdvN3eS/zr/iNeNbuqq84SnaGFgWGKnN5pYIFHp6sAGnBF0OwKAP71",
+	"j3+Gok+hM0A37/3bgvLaCIdXgbJAb0Qb6hRsiZRSmC1XZC7APCYlmj/7k3JikNbbLtbjlLbxyq9nMNVj",
+	"QoOh21+yZDwVqmDJpCwPXaynx/iCqNGMKZS1gX5O5Q78Gw0/qCubR5b04IcfFhJmjD/D0zLl8mH24eVP",
+	"hJMTsMwJ258AU5OlwUhX9ehxZTDiy6RPZOQTwc5z1xo6l4U5glB9XZNLfjx773svtIUnTw7oFPnkSQzM",
+	"Q33/tFK8Ku0hC0yGuZ+fPLkhdtXB8dnZEZxhcpynh1LnHLbOjg+34WPOpOgXMxHoG5bitTYj7x/vh8LO",
+	"yuZWu7nTbG/T0ZvBNZMj0pQdkZ20gkSPkQKl8Jw3YowKCZIpDmRz4b9RUpzZr2gJXM0MC4en56+8X+Y9",
+	"ix9zAmkFdwvXQkpgnHt4FMMxS9FmLMEY/qbNiBBuDCeax56j74V01YJ2nHATGAnFCU9lGUWQ8uNZhKCb",
+	"hBmnB4ZlQ0IjEzTWK+FHn12hr6XU1zDL71tX62ZJV9uF3fM0ZWaycP5oJKicEUmw4LKVYNVIc4PMsg0B",
+	"hIG2YYmDk6Oo0paIvJF8tc9QsUxEnWjPP/IHkaHPPq2hb4P8Rp8H6FH+zGWPeNSJfkL3c0GyNNLdbbdv",
+	"mKjdbZJWNGNqBmlnaMYiQe9qUoyxuZBHo87FZVW7M1/z3kVqYgNLOTpsM7qkl1v+lFnd8iLLv6IRfcpQ",
+	"XF8r6wwyKt0ZQWOV0PMtzhzrMYvbHhUYZMmwrLIr2jsNzP7Tygsna6dD8xacYf2+SPwR72l77zFHoxWh",
+	"lHZBsJuterqYNNaZdbzTKic1a92ZjrKHJVG8cI9nDfack7TCzZVpvJGwuHtDEPXBrF6dX9Voed0EaxpH",
+	"+0GKusVn0rYqFzb8KzubX1mYtfuX9ja/NL/hsOQBi8jowjfeosvpUrjbWbfJVtxi9uhyGkeZtjWOEJpi",
+	"5UQuADq07qXmk/s2UdF/my7iRmdynK74x859M6+9jFJ03YomJKWtITJexM0bHfjVjDZOj0pkpfBaTsoF",
+	"qlea6q4I1WLo6R/YE+mN55vfmF0k2uC6HhAv++7pvAGXzLywxoGXMlvrs+DTYBpCxauO/co/rzr2goPt",
+	"rx/thRV581HVvL/5jdl1og1qLjSypOegj01ajtein7WabD9mqM5aB/+ltqnL3j+h22yWu1Xo+U1cYuVb",
+	"QTU3TSt9IospU04ktlP2eXTZ9jE69amup/nE47xq46dm9lg7D1h0p9DvumvRSefyfvtFjlW02W5VgB7F",
+	"q4NAfGHQ8EeuBfcYCLW1IOhjqVNJpfZ2tcHPXm6EvMee4sHx7mbKulvUDwqTZ/OrjRi5mGB9fQBZFcYv",
+	"HSh83wSN/SzuYXBxZSj9yKA4DBhXPcFPPe4NDpOCvyosfKf898jgWQU/XXbuamq8JWaeefwmwOy95StH",
+	"y2vUuh4n12uv/Tih+/XC47V2uFspL/446KFR8frR6hfg5DtVoC8HyZVB9CMj5HUuXcLjUEf+j43XYeN1",
+	"qf9GLmF5f4M5RM6i7qncS+A4Rqkzfw07jnIjixFdp9WSRDDU1nW+b3/f9hFVCLCy1E2DL9jKvfKR4oys",
+	"7e9RFH98V7S1CU+vvb1WHgPW3v5b/otCe/N64c8Vt661GaGBFpCHGy0bmWQKIWXJkMTf9gMqoaq3xGaM",
+	"ggGml9N/BwAA//8pD5mRLzsAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+
+	"github.com/google/uuid"
 )
 
 // Server implements ServerInterface for the Argos REST API.
@@ -114,6 +116,92 @@ func (s *Server) UpdateCluster(w http.ResponseWriter, r *http.Request, id Cluste
 func (s *Server) DeleteCluster(w http.ResponseWriter, r *http.Request, id ClusterId) {
 	if err := s.store.DeleteCluster(r.Context(), id); err != nil {
 		s.writeStoreError(w, "deleteCluster", err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ListNodes returns a paged list of nodes, optionally filtered by cluster_id.
+func (s *Server) ListNodes(w http.ResponseWriter, r *http.Request, params ListNodesParams) {
+	limit := 0
+	if params.Limit != nil {
+		limit = *params.Limit
+	}
+	cursor := ""
+	if params.Cursor != nil {
+		cursor = *params.Cursor
+	}
+
+	items, next, err := s.store.ListNodes(r.Context(), params.ClusterId, limit, cursor)
+	if err != nil {
+		s.writeStoreError(w, "listNodes", err)
+		return
+	}
+
+	resp := NodeList{Items: items}
+	if next != "" {
+		resp.NextCursor = &next
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// CreateNode registers a new node under a cluster.
+func (s *Server) CreateNode(w http.ResponseWriter, r *http.Request) {
+	var body NodeCreate
+	if err := decodeJSONBody(r, &body); err != nil {
+		writeProblem(w, http.StatusBadRequest, "Invalid request body", err.Error())
+		return
+	}
+	if body.Name == "" {
+		writeProblem(w, http.StatusBadRequest, "Missing field", "field 'name' is required")
+		return
+	}
+	if body.ClusterId == (uuid.UUID{}) {
+		writeProblem(w, http.StatusBadRequest, "Missing field", "field 'cluster_id' is required")
+		return
+	}
+
+	n, err := s.store.CreateNode(r.Context(), body)
+	if err != nil {
+		s.writeStoreError(w, "createNode", err)
+		return
+	}
+
+	if n.Id != nil {
+		w.Header().Set("Location", "/v1/nodes/"+n.Id.String())
+	}
+	writeJSON(w, http.StatusCreated, n)
+}
+
+// GetNode fetches a node by id.
+func (s *Server) GetNode(w http.ResponseWriter, r *http.Request, id NodeId) {
+	n, err := s.store.GetNode(r.Context(), id)
+	if err != nil {
+		s.writeStoreError(w, "getNode", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, n)
+}
+
+// UpdateNode applies merge-patch updates to a node.
+func (s *Server) UpdateNode(w http.ResponseWriter, r *http.Request, id NodeId) {
+	var body NodeUpdate
+	if err := decodeJSONBody(r, &body); err != nil {
+		writeProblem(w, http.StatusBadRequest, "Invalid request body", err.Error())
+		return
+	}
+	n, err := s.store.UpdateNode(r.Context(), id, body)
+	if err != nil {
+		s.writeStoreError(w, "updateNode", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, n)
+}
+
+// DeleteNode removes a node.
+func (s *Server) DeleteNode(w http.ResponseWriter, r *http.Request, id NodeId) {
+	if err := s.store.DeleteNode(r.Context(), id); err != nil {
+		s.writeStoreError(w, "deleteNode", err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -21,15 +21,23 @@ type memStore struct {
 	mu       sync.Mutex
 	byID     map[uuid.UUID]Cluster
 	byName   map[string]uuid.UUID
+	nodesByID     map[uuid.UUID]Node
+	nodesByNatKey map[string]uuid.UUID // "<cluster_id>/<name>" -> node id
 	pingErr  error
 	createdN int
 }
 
 func newMemStore() *memStore {
 	return &memStore{
-		byID:   make(map[uuid.UUID]Cluster),
-		byName: make(map[string]uuid.UUID),
+		byID:          make(map[uuid.UUID]Cluster),
+		byName:        make(map[string]uuid.UUID),
+		nodesByID:     make(map[uuid.UUID]Node),
+		nodesByNatKey: make(map[string]uuid.UUID),
 	}
+}
+
+func nodeNatKey(clusterID uuid.UUID, name string) string {
+	return clusterID.String() + "/" + name
 }
 
 func (m *memStore) Ping(_ context.Context) error { return m.pingErr }
@@ -130,6 +138,105 @@ func (m *memStore) DeleteCluster(_ context.Context, id uuid.UUID) error {
 	}
 	delete(m.byID, id)
 	delete(m.byName, c.Name)
+	return nil
+}
+
+func (m *memStore) CreateNode(_ context.Context, in NodeCreate) (Node, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.byID[in.ClusterId]; !ok {
+		return Node{}, ErrNotFound
+	}
+	key := nodeNatKey(in.ClusterId, in.Name)
+	if _, dup := m.nodesByNatKey[key]; dup {
+		return Node{}, fmt.Errorf("duplicate node: %w", ErrConflict)
+	}
+	id := uuid.New()
+	now := time.Now().UTC().Add(time.Duration(m.createdN) * time.Nanosecond)
+	m.createdN++
+	n := Node{
+		Id:             &id,
+		ClusterId:      in.ClusterId,
+		Name:           in.Name,
+		DisplayName:    in.DisplayName,
+		KubeletVersion: in.KubeletVersion,
+		OsImage:        in.OsImage,
+		Architecture:   in.Architecture,
+		Labels:         in.Labels,
+		CreatedAt:      &now,
+		UpdatedAt:      &now,
+	}
+	m.nodesByID[id] = n
+	m.nodesByNatKey[key] = id
+	return n, nil
+}
+
+func (m *memStore) GetNode(_ context.Context, id uuid.UUID) (Node, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n, ok := m.nodesByID[id]
+	if !ok {
+		return Node{}, ErrNotFound
+	}
+	return n, nil
+}
+
+func (m *memStore) ListNodes(_ context.Context, clusterID *uuid.UUID, limit int, _ string) ([]Node, string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if limit <= 0 {
+		limit = 50
+	}
+	out := make([]Node, 0, len(m.nodesByID))
+	for _, n := range m.nodesByID {
+		if clusterID != nil && n.ClusterId != *clusterID {
+			continue
+		}
+		out = append(out, n)
+	}
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, "", nil
+}
+
+func (m *memStore) UpdateNode(_ context.Context, id uuid.UUID, in NodeUpdate) (Node, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n, ok := m.nodesByID[id]
+	if !ok {
+		return Node{}, ErrNotFound
+	}
+	if in.DisplayName != nil {
+		n.DisplayName = in.DisplayName
+	}
+	if in.KubeletVersion != nil {
+		n.KubeletVersion = in.KubeletVersion
+	}
+	if in.OsImage != nil {
+		n.OsImage = in.OsImage
+	}
+	if in.Architecture != nil {
+		n.Architecture = in.Architecture
+	}
+	if in.Labels != nil {
+		n.Labels = in.Labels
+	}
+	now := time.Now().UTC()
+	n.UpdatedAt = &now
+	m.nodesByID[id] = n
+	return n, nil
+}
+
+func (m *memStore) DeleteNode(_ context.Context, id uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n, ok := m.nodesByID[id]
+	if !ok {
+		return ErrNotFound
+	}
+	delete(m.nodesByID, id)
+	delete(m.nodesByNatKey, nodeNatKey(n.ClusterId, n.Name))
 	return nil
 }
 
@@ -254,6 +361,124 @@ func TestClusterCRUD(t *testing.T) {
 
 	// Delete again → 404
 	del2 := do(h, http.MethodDelete, getURL, "")
+	if del2.Code != http.StatusNotFound {
+		t.Errorf("second delete status=%d", del2.Code)
+	}
+}
+
+func TestNodeCRUD(t *testing.T) {
+	t.Parallel()
+	store := newMemStore()
+	h := newTestHandler(t, store)
+
+	// Seed a cluster so node creates have a valid FK.
+	clusterResp := do(h, http.MethodPost, "/v1/clusters", `{"name":"prod-eu-west-1"}`)
+	if clusterResp.Code != http.StatusCreated {
+		t.Fatalf("seed cluster: status=%d body=%q", clusterResp.Code, clusterResp.Body.String())
+	}
+	var cluster Cluster
+	if err := json.Unmarshal(clusterResp.Body.Bytes(), &cluster); err != nil {
+		t.Fatalf("decode cluster: %v", err)
+	}
+	clusterIDStr := cluster.Id.String()
+
+	// Create node
+	createBody := fmt.Sprintf(`{"cluster_id":%q,"name":"node-1","kubelet_version":"v1.29.5"}`, clusterIDStr)
+	create := do(h, http.MethodPost, "/v1/nodes", createBody)
+	if create.Code != http.StatusCreated {
+		t.Fatalf("create node: status=%d body=%q", create.Code, create.Body.String())
+	}
+	if loc := create.Header().Get("Location"); !strings.HasPrefix(loc, "/v1/nodes/") {
+		t.Errorf("Location=%q", loc)
+	}
+	var node Node
+	if err := json.Unmarshal(create.Body.Bytes(), &node); err != nil {
+		t.Fatalf("decode node: %v", err)
+	}
+	if node.Id == nil {
+		t.Fatal("node.Id is nil")
+	}
+	if node.ClusterId != *cluster.Id {
+		t.Errorf("node.ClusterId=%v, want %v", node.ClusterId, *cluster.Id)
+	}
+
+	// Duplicate (cluster_id, name) → 409
+	dup := do(h, http.MethodPost, "/v1/nodes", createBody)
+	if dup.Code != http.StatusConflict {
+		t.Errorf("duplicate node status=%d", dup.Code)
+	}
+
+	// Create with unknown cluster_id → 404
+	missing := do(h, http.MethodPost, "/v1/nodes", fmt.Sprintf(`{"cluster_id":%q,"name":"x"}`, uuid.New().String()))
+	if missing.Code != http.StatusNotFound {
+		t.Errorf("missing cluster create status=%d", missing.Code)
+	}
+
+	// Get
+	nodeURL := "/v1/nodes/" + node.Id.String()
+	get := do(h, http.MethodGet, nodeURL, "")
+	if get.Code != http.StatusOK {
+		t.Fatalf("get node status=%d body=%q", get.Code, get.Body.String())
+	}
+
+	// Patch
+	patch := do(h, http.MethodPatch, nodeURL, `{"architecture":"arm64"}`)
+	if patch.Code != http.StatusOK {
+		t.Fatalf("patch status=%d body=%q", patch.Code, patch.Body.String())
+	}
+	var patched Node
+	if err := json.Unmarshal(patch.Body.Bytes(), &patched); err != nil {
+		t.Fatalf("decode patch: %v", err)
+	}
+	if patched.Architecture == nil || *patched.Architecture != "arm64" {
+		t.Errorf("architecture=%v", patched.Architecture)
+	}
+
+	// List all
+	list := do(h, http.MethodGet, "/v1/nodes", "")
+	if list.Code != http.StatusOK {
+		t.Fatalf("list status=%d", list.Code)
+	}
+	var page NodeList
+	if err := json.Unmarshal(list.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(page.Items) != 1 {
+		t.Errorf("list len=%d", len(page.Items))
+	}
+
+	// List filtered by cluster_id
+	filtered := do(h, http.MethodGet, "/v1/nodes?cluster_id="+clusterIDStr, "")
+	if filtered.Code != http.StatusOK {
+		t.Fatalf("filtered list status=%d", filtered.Code)
+	}
+	if err := json.Unmarshal(filtered.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode filtered list: %v", err)
+	}
+	if len(page.Items) != 1 {
+		t.Errorf("filtered list len=%d", len(page.Items))
+	}
+
+	// List filtered by a different cluster id → empty
+	empty := do(h, http.MethodGet, "/v1/nodes?cluster_id="+uuid.New().String(), "")
+	if empty.Code != http.StatusOK {
+		t.Fatalf("empty-filter list status=%d", empty.Code)
+	}
+	if err := json.Unmarshal(empty.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode empty list: %v", err)
+	}
+	if len(page.Items) != 0 {
+		t.Errorf("empty-filter list len=%d", len(page.Items))
+	}
+
+	// Delete
+	del := do(h, http.MethodDelete, nodeURL, "")
+	if del.Code != http.StatusNoContent {
+		t.Errorf("delete status=%d", del.Code)
+	}
+
+	// Delete again → 404
+	del2 := do(h, http.MethodDelete, nodeURL, "")
 	if del2.Code != http.StatusNotFound {
 		t.Errorf("second delete status=%d", del2.Code)
 	}

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -37,4 +37,23 @@ type Store interface {
 
 	// DeleteCluster removes a cluster by id. Returns ErrNotFound if absent.
 	DeleteCluster(ctx context.Context, id uuid.UUID) error
+
+	// CreateNode inserts a new node. Returns ErrNotFound when the parent
+	// cluster does not exist; ErrConflict when (cluster_id, name) already
+	// has a node.
+	CreateNode(ctx context.Context, in NodeCreate) (Node, error)
+
+	// GetNode fetches a node by id. Returns ErrNotFound if absent.
+	GetNode(ctx context.Context, id uuid.UUID) (Node, error)
+
+	// ListNodes returns up to limit nodes after the given opaque cursor. When
+	// clusterID is non-nil, results are filtered to that cluster.
+	ListNodes(ctx context.Context, clusterID *uuid.UUID, limit int, cursor string) (items []Node, nextCursor string, err error)
+
+	// UpdateNode applies the merge-patch fields set in in. Returns
+	// ErrNotFound if the node does not exist.
+	UpdateNode(ctx context.Context, id uuid.UUID, in NodeUpdate) (Node, error)
+
+	// DeleteNode removes a node by id. Returns ErrNotFound if absent.
+	DeleteNode(ctx context.Context, id uuid.UUID) error
 }

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -262,6 +262,241 @@ func (p *PG) DeleteCluster(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
+// CreateNode inserts a new node. Returns api.ErrNotFound when the parent
+// cluster does not exist (FK violation), api.ErrConflict on duplicate
+// (cluster_id, name).
+func (p *PG) CreateNode(ctx context.Context, in api.NodeCreate) (api.Node, error) {
+	id := uuid.New()
+	now := time.Now().UTC()
+
+	labelsJSON, err := marshalLabels(in.Labels)
+	if err != nil {
+		return api.Node{}, err
+	}
+
+	const q = `
+		INSERT INTO nodes (
+			id, cluster_id, name, display_name, kubelet_version,
+			os_image, architecture, labels, created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $9)
+	`
+	_, err = p.pool.Exec(ctx, q,
+		id, in.ClusterId, in.Name, in.DisplayName, in.KubeletVersion,
+		in.OsImage, in.Architecture, labelsJSON, now,
+	)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) {
+			switch pgErr.Code {
+			case "23505":
+				return api.Node{}, fmt.Errorf("node %q in cluster %s already exists: %w", in.Name, in.ClusterId, api.ErrConflict)
+			case "23503":
+				return api.Node{}, fmt.Errorf("cluster %s does not exist: %w", in.ClusterId, api.ErrNotFound)
+			}
+		}
+		return api.Node{}, fmt.Errorf("insert node: %w", err)
+	}
+
+	return api.Node{
+		Id:             &id,
+		ClusterId:      in.ClusterId,
+		Name:           in.Name,
+		DisplayName:    in.DisplayName,
+		KubeletVersion: in.KubeletVersion,
+		OsImage:        in.OsImage,
+		Architecture:   in.Architecture,
+		Labels:         in.Labels,
+		CreatedAt:      &now,
+		UpdatedAt:      &now,
+	}, nil
+}
+
+// GetNode fetches a node by id.
+func (p *PG) GetNode(ctx context.Context, id uuid.UUID) (api.Node, error) {
+	const q = `
+		SELECT id, cluster_id, name, display_name, kubelet_version,
+		       os_image, architecture, labels, created_at, updated_at
+		FROM nodes
+		WHERE id = $1
+	`
+	row := p.pool.QueryRow(ctx, q, id)
+	n, err := scanNode(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return api.Node{}, api.ErrNotFound
+		}
+		return api.Node{}, fmt.Errorf("select node: %w", err)
+	}
+	return n, nil
+}
+
+// ListNodes returns up to limit nodes sorted (created_at DESC, id DESC),
+// optionally filtered by cluster id.
+func (p *PG) ListNodes(ctx context.Context, clusterID *uuid.UUID, limit int, cursor string) ([]api.Node, string, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+
+	sb := strings.Builder{}
+	sb.WriteString(`SELECT id, cluster_id, name, display_name, kubelet_version,
+	                       os_image, architecture, labels, created_at, updated_at
+	                FROM nodes`)
+	args := make([]any, 0, 4)
+	conds := make([]string, 0, 2)
+
+	if clusterID != nil {
+		args = append(args, *clusterID)
+		conds = append(conds, fmt.Sprintf("cluster_id = $%d", len(args)))
+	}
+	if cursor != "" {
+		ts, cid, err := decodeCursor(cursor)
+		if err != nil {
+			return nil, "", err
+		}
+		args = append(args, ts)
+		tsIdx := len(args)
+		args = append(args, cid)
+		idIdx := len(args)
+		conds = append(conds, fmt.Sprintf("(created_at, id) < ($%d, $%d)", tsIdx, idIdx))
+	}
+	if len(conds) > 0 {
+		sb.WriteString(" WHERE ")
+		sb.WriteString(strings.Join(conds, " AND "))
+	}
+	args = append(args, limit+1)
+	fmt.Fprintf(&sb, " ORDER BY created_at DESC, id DESC LIMIT $%d", len(args))
+
+	rows, err := p.pool.Query(ctx, sb.String(), args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("query nodes: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]api.Node, 0, limit)
+	for rows.Next() {
+		n, err := scanNode(rows)
+		if err != nil {
+			return nil, "", fmt.Errorf("scan node: %w", err)
+		}
+		items = append(items, n)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", fmt.Errorf("iterate nodes: %w", err)
+	}
+
+	var next string
+	if len(items) > limit {
+		last := items[limit-1]
+		if last.CreatedAt != nil && last.Id != nil {
+			next = encodeCursor(*last.CreatedAt, *last.Id)
+		}
+		items = items[:limit]
+	}
+	return items, next, nil
+}
+
+// UpdateNode applies merge-patch semantics on mutable fields only.
+func (p *PG) UpdateNode(ctx context.Context, id uuid.UUID, in api.NodeUpdate) (api.Node, error) {
+	sets := make([]string, 0, 6)
+	args := make([]any, 0, 8)
+	idx := 1
+	appendSet := func(column string, value any) {
+		sets = append(sets, fmt.Sprintf("%s=$%d", column, idx))
+		args = append(args, value)
+		idx++
+	}
+
+	if in.DisplayName != nil {
+		appendSet("display_name", *in.DisplayName)
+	}
+	if in.KubeletVersion != nil {
+		appendSet("kubelet_version", *in.KubeletVersion)
+	}
+	if in.OsImage != nil {
+		appendSet("os_image", *in.OsImage)
+	}
+	if in.Architecture != nil {
+		appendSet("architecture", *in.Architecture)
+	}
+	if in.Labels != nil {
+		b, err := marshalLabels(in.Labels)
+		if err != nil {
+			return api.Node{}, err
+		}
+		appendSet("labels", b)
+	}
+	appendSet("updated_at", time.Now().UTC())
+	args = append(args, id)
+
+	q := fmt.Sprintf("UPDATE nodes SET %s WHERE id=$%d", strings.Join(sets, ", "), idx)
+	tag, err := p.pool.Exec(ctx, q, args...)
+	if err != nil {
+		return api.Node{}, fmt.Errorf("update node: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return api.Node{}, api.ErrNotFound
+	}
+	return p.GetNode(ctx, id)
+}
+
+// DeleteNode removes a node by id.
+func (p *PG) DeleteNode(ctx context.Context, id uuid.UUID) error {
+	tag, err := p.pool.Exec(ctx, "DELETE FROM nodes WHERE id=$1", id)
+	if err != nil {
+		return fmt.Errorf("delete node: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return api.ErrNotFound
+	}
+	return nil
+}
+
+func scanNode(row pgx.Row) (api.Node, error) {
+	var (
+		n               api.Node
+		id              uuid.UUID
+		clusterID       uuid.UUID
+		createdAt       time.Time
+		updatedAt       time.Time
+		displayName     sql.NullString
+		kubeletVersion  sql.NullString
+		osImage         sql.NullString
+		architecture    sql.NullString
+		labelsJSON      []byte
+	)
+	if err := row.Scan(
+		&id, &clusterID, &n.Name,
+		&displayName, &kubeletVersion, &osImage, &architecture,
+		&labelsJSON,
+		&createdAt, &updatedAt,
+	); err != nil {
+		return api.Node{}, err
+	}
+
+	n.Id = &id
+	n.ClusterId = clusterID
+	n.CreatedAt = &createdAt
+	n.UpdatedAt = &updatedAt
+	n.DisplayName = nullableString(displayName)
+	n.KubeletVersion = nullableString(kubeletVersion)
+	n.OsImage = nullableString(osImage)
+	n.Architecture = nullableString(architecture)
+
+	if len(labelsJSON) > 0 {
+		var labels map[string]string
+		if err := json.Unmarshal(labelsJSON, &labels); err != nil {
+			return api.Node{}, fmt.Errorf("unmarshal node labels: %w", err)
+		}
+		if len(labels) > 0 {
+			n.Labels = &labels
+		}
+	}
+	return n, nil
+}
+
 // marshalLabels encodes the optional labels map as JSON, preserving NULL-vs-empty semantics.
 func marshalLabels(labels *map[string]string) ([]byte, error) {
 	if labels == nil {

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -91,6 +91,82 @@ func TestPGClusterCRUD(t *testing.T) {
 	}
 }
 
+func TestPGNodeCRUD(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, err := pg.CreateCluster(ctx, api.ClusterCreate{Name: "nodes-test"})
+	if err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	kv := "v1.29.5"
+	node, err := pg.CreateNode(ctx, api.NodeCreate{
+		ClusterId:      *cluster.Id,
+		Name:           "node-a",
+		KubeletVersion: &kv,
+	})
+	if err != nil {
+		t.Fatalf("create node: %v", err)
+	}
+	if node.Id == nil {
+		t.Fatal("node.Id nil")
+	}
+
+	if _, err := pg.CreateNode(ctx, api.NodeCreate{ClusterId: *cluster.Id, Name: "node-a"}); !errors.Is(err, api.ErrConflict) {
+		t.Errorf("duplicate should be ErrConflict, got %v", err)
+	}
+
+	if _, err := pg.CreateNode(ctx, api.NodeCreate{ClusterId: uuid.New(), Name: "orphan"}); !errors.Is(err, api.ErrNotFound) {
+		t.Errorf("unknown cluster should be ErrNotFound, got %v", err)
+	}
+
+	got, err := pg.GetNode(ctx, *node.Id)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Name != "node-a" {
+		t.Errorf("name=%q", got.Name)
+	}
+	if got.KubeletVersion == nil || *got.KubeletVersion != kv {
+		t.Errorf("kubelet_version=%v", got.KubeletVersion)
+	}
+
+	arch := "arm64"
+	updated, err := pg.UpdateNode(ctx, *node.Id, api.NodeUpdate{Architecture: &arch})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.Architecture == nil || *updated.Architecture != arch {
+		t.Errorf("architecture=%v", updated.Architecture)
+	}
+
+	items, _, err := pg.ListNodes(ctx, cluster.Id, 10, "")
+	if err != nil {
+		t.Fatalf("list filtered: %v", err)
+	}
+	if len(items) != 1 {
+		t.Errorf("filtered list len=%d", len(items))
+	}
+
+	other := uuid.New()
+	items, _, err = pg.ListNodes(ctx, &other, 10, "")
+	if err != nil {
+		t.Fatalf("list foreign cluster: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("foreign-cluster list len=%d", len(items))
+	}
+
+	// FK cascade: deleting the cluster removes its nodes.
+	if err := pg.DeleteCluster(ctx, *cluster.Id); err != nil {
+		t.Fatalf("delete cluster: %v", err)
+	}
+	if _, err := pg.GetNode(ctx, *node.Id); !errors.Is(err, api.ErrNotFound) {
+		t.Errorf("node should have cascaded with cluster delete, got %v", err)
+	}
+}
+
 func TestPGListPagination(t *testing.T) {
 	pg := newTestPG(t)
 	ctx := context.Background()

--- a/migrations/00002_create_nodes.sql
+++ b/migrations/00002_create_nodes.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+CREATE TABLE nodes (
+    id               UUID PRIMARY KEY,
+    cluster_id       UUID NOT NULL REFERENCES clusters(id) ON DELETE CASCADE,
+    name             TEXT NOT NULL,
+    display_name     TEXT,
+    kubelet_version  TEXT,
+    os_image         TEXT,
+    architecture     TEXT,
+    labels           JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at       TIMESTAMPTZ NOT NULL,
+    updated_at       TIMESTAMPTZ NOT NULL,
+    UNIQUE (cluster_id, name)
+);
+
+CREATE INDEX nodes_cluster_id_idx ON nodes (cluster_id);
+CREATE INDEX nodes_created_at_id_idx ON nodes (created_at DESC, id DESC);
+
+-- +goose Down
+DROP INDEX IF EXISTS nodes_created_at_id_idx;
+DROP INDEX IF EXISTS nodes_cluster_id_idx;
+DROP TABLE IF EXISTS nodes;


### PR DESCRIPTION
Second cataloguable entity in the CMDB. Nodes belong to a cluster; the collector will populate them in a later PR.

Contract:
- api/openapi/openapi.yaml: new 'nodes' tag, /v1/nodes and /v1/nodes/{id} endpoints mirroring Cluster (list + paginated cursor + create + get + patch + delete) with the same per-op scope model (read / write / delete). List accepts ?cluster_id=<uuid> to filter by parent. Schemas NodeMutable / NodeCreate / NodeUpdate / Node / NodeList follow the allOf pattern already established for Cluster; cluster_id and name are immutable post-creation, other fields mutable via merge-patch.
- internal/api/api.gen.go regenerated.

Schema and persistence:
- migrations/00002_create_nodes.sql creates the nodes table with a UUID PK, a UUID foreign key to clusters(id) ON DELETE CASCADE, a (cluster_id, name) uniqueness constraint, and supporting indexes on cluster_id and (created_at DESC, id DESC) for the cursor-paginated list query.
- internal/store/pg.go: CreateNode / GetNode / ListNodes / UpdateNode / DeleteNode. CreateNode maps pg error 23505 to api.ErrConflict and 23503 (FK violation from an unknown cluster_id) to api.ErrNotFound so handlers translate them into 409 / 404 respectively. ListNodes filters by optional clusterID and reuses the existing (created_at, id) cursor encoding. UpdateNode builds a dynamic SET clause restricted to mutable fields.
- internal/api/server.go: handlers for the five new operations with the same store-error translation and Location-header behaviour as Cluster.

Testing:
- internal/api/server_test.go: memStore fake extended with node CRUD maps plus a 12-step TestNodeCRUD covering create / duplicate 409 / unknown-cluster 404 / get / patch / list / filtered-list / empty-filter / delete / second-delete 404.
- internal/store/pg_test.go: TestPGNodeCRUD gated on PGX_TEST_DATABASE covers the same shape plus the cascade-delete contract (deleting a cluster removes its nodes).

api coverage: 76.2% -> 75.2% (slight dip from the new memStore code; the handler matrix is still fully covered).

Next up: wire the collector to ingest nodes from the connected cluster, and add Namespace as a parallel resource.