### PR TITLE
feat(collector): ingest nodes from Kubernetes into the CMDB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Configure tokens via either or both env vars (merged at startup):
 At least one token must be configured; `/healthz` and `/readyz` stay open.
 - `internal/api/` — generated server (`api.gen.go`), hand-written handlers (`server.go`), `Store` interface (`store.go`) with `ErrNotFound` / `ErrConflict` sentinels. RFC 7807 `application/problem+json` for all errors.
 - `internal/store/` — PostgreSQL implementation of `api.Store` using `pgx/v5`. Cursor-paginated list, merge-patch updates, embedded `goose` migrations. Nodes are FK-linked to clusters with `ON DELETE CASCADE`.
-- `internal/collector/` — Kubernetes polling collector (v1 scope: fetches the API server version via `client-go` and refreshes the matching cluster record by name). Disabled by default; enable with `ARGOS_COLLECTOR_ENABLED=true` and `ARGOS_CLUSTER_NAME=...`.
+- `internal/collector/` — Kubernetes polling collector. Each tick fetches the API server version (refreshing the matching cluster record) and lists all nodes, upserting each by `(cluster_id, name)` into the `nodes` table. Disabled by default; enable with `ARGOS_COLLECTOR_ENABLED=true` and `ARGOS_CLUSTER_NAME=...`.
 - `migrations/` — timestamped SQL migrations, embedded in the binary via `migrations/embed.go`.
 - `.github/workflows/ci.yml` — GitHub Actions pipeline: codegen-drift check, `go vet`, `go build`, `go test -race` against a Postgres service container (so the integration tests gated on `PGX_TEST_DATABASE` run in CI), and `golangci-lint`.
 

--- a/cmd/argosd/main.go
+++ b/cmd/argosd/main.go
@@ -131,11 +131,11 @@ func maybeStartCollector(ctx context.Context, s api.Store) error {
 	}
 	kubeconfig := os.Getenv("ARGOS_KUBECONFIG")
 
-	fetcher, err := collector.NewKubeVersionFetcher(kubeconfig)
+	source, err := collector.NewKubeClient(kubeconfig)
 	if err != nil {
-		return fmt.Errorf("init kube fetcher: %w", err)
+		return fmt.Errorf("init kube client: %w", err)
 	}
-	coll := collector.New(s, fetcher, clusterName, interval, fetchTimeout)
+	coll := collector.New(s, source, clusterName, interval, fetchTimeout)
 
 	go func() {
 		if err := coll.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/jackc/pgx/v5 v5.9.1
 	github.com/oapi-codegen/runtime v1.4.0
 	github.com/pressly/goose/v3 v3.27.0
+	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.4
 )
 
@@ -64,7 +65,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.35.4 // indirect
-	k8s.io/apimachinery v0.35.4 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -240,6 +240,46 @@ func (m *memStore) DeleteNode(_ context.Context, id uuid.UUID) error {
 	return nil
 }
 
+func (m *memStore) UpsertNode(_ context.Context, in NodeCreate) (Node, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.byID[in.ClusterId]; !ok {
+		return Node{}, ErrNotFound
+	}
+	key := nodeNatKey(in.ClusterId, in.Name)
+	now := time.Now().UTC().Add(time.Duration(m.createdN) * time.Nanosecond)
+	m.createdN++
+
+	if existingID, exists := m.nodesByNatKey[key]; exists {
+		n := m.nodesByID[existingID]
+		n.DisplayName = in.DisplayName
+		n.KubeletVersion = in.KubeletVersion
+		n.OsImage = in.OsImage
+		n.Architecture = in.Architecture
+		n.Labels = in.Labels
+		n.UpdatedAt = &now
+		m.nodesByID[existingID] = n
+		return n, nil
+	}
+
+	id := uuid.New()
+	n := Node{
+		Id:             &id,
+		ClusterId:      in.ClusterId,
+		Name:           in.Name,
+		DisplayName:    in.DisplayName,
+		KubeletVersion: in.KubeletVersion,
+		OsImage:        in.OsImage,
+		Architecture:   in.Architecture,
+		Labels:         in.Labels,
+		CreatedAt:      &now,
+		UpdatedAt:      &now,
+	}
+	m.nodesByID[id] = n
+	m.nodesByNatKey[key] = id
+	return n, nil
+}
+
 func newTestHandler(t *testing.T, store Store) http.Handler {
 	t.Helper()
 	return Handler(NewServer("test", store))

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -56,4 +56,10 @@ type Store interface {
 
 	// DeleteNode removes a node by id. Returns ErrNotFound if absent.
 	DeleteNode(ctx context.Context, id uuid.UUID) error
+
+	// UpsertNode inserts a node when no row exists for (cluster_id, name),
+	// or updates the mutable fields of the existing row when it does. The
+	// returned Node always reflects the post-operation state. Returns
+	// ErrNotFound if the parent cluster does not exist.
+	UpsertNode(ctx context.Context, in NodeCreate) (Node, error)
 }

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -1,6 +1,6 @@
 // Package collector polls a Kubernetes cluster on an interval and refreshes
-// the matching cluster record in the CMDB. v1 scope fetches the Kubernetes
-// server version and writes it back via the Store.
+// the matching CMDB records. v1 scope fetches the server version and all
+// nodes, writing them back through the Store.
 package collector
 
 import (
@@ -15,24 +15,47 @@ import (
 	"github.com/sthalbert/argos/internal/api"
 )
 
+// NodeInfo is the subset of a Kubernetes Node the collector consumes. It
+// lives in this package (not in api) so the Kubernetes-facing KubeSource
+// interface stays decoupled from the CMDB wire types.
+type NodeInfo struct {
+	Name           string
+	KubeletVersion string
+	OsImage        string
+	Architecture   string
+	Labels         map[string]string
+}
+
 // VersionFetcher returns the Kubernetes API server version for the cluster
 // it was configured against (typically via kubeconfig or in-cluster config).
 type VersionFetcher interface {
 	ServerVersion(ctx context.Context) (string, error)
 }
 
-// clusterStore is the subset of api.Store the collector consumes.
-type clusterStore interface {
-	ListClusters(ctx context.Context, limit int, cursor string) ([]api.Cluster, string, error)
-	UpdateCluster(ctx context.Context, id uuid.UUID, in api.ClusterUpdate) (api.Cluster, error)
+// NodeLister returns every Node visible to the configured kubeconfig.
+type NodeLister interface {
+	ListNodes(ctx context.Context) ([]NodeInfo, error)
 }
 
-// Collector polls a VersionFetcher and updates a named cluster record in the
-// store. Errors encountered during a single tick are logged and the loop
-// continues to the next tick.
+// KubeSource is the composite contract the Collector consumes.
+type KubeSource interface {
+	VersionFetcher
+	NodeLister
+}
+
+// cmdbStore is the subset of api.Store the collector consumes.
+type cmdbStore interface {
+	ListClusters(ctx context.Context, limit int, cursor string) ([]api.Cluster, string, error)
+	UpdateCluster(ctx context.Context, id uuid.UUID, in api.ClusterUpdate) (api.Cluster, error)
+	UpsertNode(ctx context.Context, in api.NodeCreate) (api.Node, error)
+}
+
+// Collector polls a KubeSource and reconciles the results into the CMDB
+// store against a cluster record matched by name. Errors encountered during
+// a single tick are logged and the loop continues to the next tick.
 type Collector struct {
-	store        clusterStore
-	fetcher      VersionFetcher
+	store        cmdbStore
+	source       KubeSource
 	clusterName  string
 	interval     time.Duration
 	fetchTimeout time.Duration
@@ -40,10 +63,10 @@ type Collector struct {
 
 // New returns a Collector. fetchTimeout bounds each poll; interval is the
 // delay between polls.
-func New(store clusterStore, fetcher VersionFetcher, clusterName string, interval, fetchTimeout time.Duration) *Collector {
+func New(store cmdbStore, source KubeSource, clusterName string, interval, fetchTimeout time.Duration) *Collector {
 	return &Collector{
 		store:        store,
-		fetcher:      fetcher,
+		source:       source,
 		clusterName:  clusterName,
 		interval:     interval,
 		fetchTimeout: fetchTimeout,
@@ -71,13 +94,13 @@ func (c *Collector) Run(ctx context.Context) error {
 	}
 }
 
-// poll performs one polling cycle. Errors are logged and swallowed; the
-// caller's ticker is unaffected.
+// poll performs one polling cycle: refresh cluster version, then ingest nodes.
+// Errors are logged and swallowed; the caller's ticker is unaffected.
 func (c *Collector) poll(parent context.Context) {
 	ctx, cancel := context.WithTimeout(parent, c.fetchTimeout)
 	defer cancel()
 
-	version, err := c.fetcher.ServerVersion(ctx)
+	version, err := c.source.ServerVersion(ctx)
 	if err != nil {
 		slog.Warn("collector: fetch server version failed", "error", err, "cluster_name", c.clusterName)
 		return
@@ -92,22 +115,60 @@ func (c *Collector) poll(parent context.Context) {
 		slog.Error("collector: lookup cluster failed", "error", err, "cluster_name", c.clusterName)
 		return
 	}
-
 	if cluster.Id == nil {
 		slog.Error("collector: stored cluster has nil id", "cluster_name", c.clusterName)
 		return
 	}
 
-	if cluster.KubernetesVersion != nil && *cluster.KubernetesVersion == version {
-		slog.Debug("collector: version unchanged", "cluster_name", c.clusterName, "version", version)
+	if cluster.KubernetesVersion == nil || *cluster.KubernetesVersion != version {
+		if _, err := c.store.UpdateCluster(ctx, *cluster.Id, api.ClusterUpdate{KubernetesVersion: &version}); err != nil {
+			slog.Error("collector: update cluster failed", "error", err, "cluster_name", c.clusterName)
+			return
+		}
+		slog.Info("collector: refreshed cluster version", "cluster_name", c.clusterName, "version", version)
+	}
+
+	c.ingestNodes(ctx, *cluster.Id)
+}
+
+// ingestNodes lists nodes from the kube source and upserts each into the
+// store under the given cluster. Individual node failures are logged and
+// skipped; the loop continues so one bad node doesn't block the rest.
+func (c *Collector) ingestNodes(ctx context.Context, clusterID uuid.UUID) {
+	nodes, err := c.source.ListNodes(ctx)
+	if err != nil {
+		slog.Warn("collector: list nodes failed", "error", err, "cluster_name", c.clusterName)
 		return
 	}
 
-	if _, err := c.store.UpdateCluster(ctx, *cluster.Id, api.ClusterUpdate{KubernetesVersion: &version}); err != nil {
-		slog.Error("collector: update cluster failed", "error", err, "cluster_name", c.clusterName)
-		return
+	var upserted, failed int
+	for _, n := range nodes {
+		in := api.NodeCreate{
+			ClusterId:      clusterID,
+			Name:           n.Name,
+			KubeletVersion: ptrIfNonEmpty(n.KubeletVersion),
+			OsImage:        ptrIfNonEmpty(n.OsImage),
+			Architecture:   ptrIfNonEmpty(n.Architecture),
+		}
+		if len(n.Labels) > 0 {
+			labels := n.Labels
+			in.Labels = &labels
+		}
+		if _, err := c.store.UpsertNode(ctx, in); err != nil {
+			slog.Warn("collector: upsert node failed", "error", err, "node", n.Name, "cluster_name", c.clusterName)
+			failed++
+			continue
+		}
+		upserted++
 	}
-	slog.Info("collector: refreshed cluster version", "cluster_name", c.clusterName, "version", version)
+	slog.Info("collector: ingested nodes", "upserted", upserted, "failed", failed, "cluster_name", c.clusterName)
+}
+
+func ptrIfNonEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
 }
 
 var errClusterNotFound = errors.New("cluster not found by name")

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -13,13 +13,20 @@ import (
 	"github.com/sthalbert/argos/internal/api"
 )
 
-type fakeFetcher struct {
-	version string
-	err     error
+// fakeSource implements KubeSource with fixed results.
+type fakeSource struct {
+	version     string
+	versionErr  error
+	nodes       []NodeInfo
+	listNodeErr error
 }
 
-func (f *fakeFetcher) ServerVersion(_ context.Context) (string, error) {
-	return f.version, f.err
+func (f *fakeSource) ServerVersion(_ context.Context) (string, error) {
+	return f.version, f.versionErr
+}
+
+func (f *fakeSource) ListNodes(_ context.Context) ([]NodeInfo, error) {
+	return f.nodes, f.listNodeErr
 }
 
 type recordedUpdate struct {
@@ -28,11 +35,20 @@ type recordedUpdate struct {
 }
 
 type fakeStore struct {
-	mu        sync.Mutex
-	clusters  []api.Cluster
-	updates   []recordedUpdate
-	listErr   error
-	updateErr error
+	mu           sync.Mutex
+	clusters     []api.Cluster
+	updates      []recordedUpdate
+	upsertedNode []api.NodeCreate
+	listErr      error
+	updateErr    error
+	upsertErr    error
+	// nodeState mirrors per-(cluster_id, name) upsert history so tests can
+	// assert idempotent behaviour.
+	nodeState map[string]int // key: cluster_id/name, value: upsert count
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{nodeState: make(map[string]int)}
 }
 
 func (s *fakeStore) ListClusters(_ context.Context, _ int, _ string) ([]api.Cluster, string, error) {
@@ -64,16 +80,33 @@ func (s *fakeStore) UpdateCluster(_ context.Context, id uuid.UUID, in api.Cluste
 	return api.Cluster{}, api.ErrNotFound
 }
 
+func (s *fakeStore) UpsertNode(_ context.Context, in api.NodeCreate) (api.Node, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.upsertErr != nil {
+		return api.Node{}, s.upsertErr
+	}
+	s.upsertedNode = append(s.upsertedNode, in)
+	key := in.ClusterId.String() + "/" + in.Name
+	s.nodeState[key]++
+	id := uuid.New()
+	return api.Node{
+		Id:             &id,
+		ClusterId:      in.ClusterId,
+		Name:           in.Name,
+		KubeletVersion: in.KubeletVersion,
+	}, nil
+}
+
 func TestPollUpdatesVersionWhenChanged(t *testing.T) {
 	t.Parallel()
 	id := uuid.New()
 	old := "v1.28.0"
-	store := &fakeStore{
-		clusters: []api.Cluster{
-			{Id: &id, Name: "prod", KubernetesVersion: &old},
-		},
+	store := newFakeStore()
+	store.clusters = []api.Cluster{
+		{Id: &id, Name: "prod", KubernetesVersion: &old},
 	}
-	c := New(store, &fakeFetcher{version: "v1.29.5"}, "prod", time.Minute, time.Second)
+	c := New(store, &fakeSource{version: "v1.29.5"}, "prod", time.Minute, time.Second)
 
 	c.poll(context.Background())
 
@@ -95,12 +128,11 @@ func TestPollSkipsWhenVersionUnchanged(t *testing.T) {
 	t.Parallel()
 	id := uuid.New()
 	current := "v1.29.5"
-	store := &fakeStore{
-		clusters: []api.Cluster{
-			{Id: &id, Name: "prod", KubernetesVersion: &current},
-		},
+	store := newFakeStore()
+	store.clusters = []api.Cluster{
+		{Id: &id, Name: "prod", KubernetesVersion: &current},
 	}
-	c := New(store, &fakeFetcher{version: current}, "prod", time.Minute, time.Second)
+	c := New(store, &fakeSource{version: current}, "prod", time.Minute, time.Second)
 
 	c.poll(context.Background())
 
@@ -109,75 +141,183 @@ func TestPollSkipsWhenVersionUnchanged(t *testing.T) {
 	}
 }
 
-func TestPollSkipsOnFetcherError(t *testing.T) {
+func TestPollSkipsOnVersionError(t *testing.T) {
 	t.Parallel()
 	id := uuid.New()
-	store := &fakeStore{
-		clusters: []api.Cluster{{Id: &id, Name: "prod"}},
-	}
-	c := New(store, &fakeFetcher{err: errors.New("boom")}, "prod", time.Minute, time.Second)
+	store := newFakeStore()
+	store.clusters = []api.Cluster{{Id: &id, Name: "prod"}}
+	c := New(store, &fakeSource{versionErr: errors.New("boom")}, "prod", time.Minute, time.Second)
 
 	c.poll(context.Background())
 
-	if len(store.updates) != 0 {
-		t.Errorf("expected no updates on fetcher error, got %d", len(store.updates))
+	if len(store.updates) != 0 || len(store.upsertedNode) != 0 {
+		t.Errorf("expected no store writes on version error; updates=%d upserts=%d", len(store.updates), len(store.upsertedNode))
 	}
 }
 
-func TestPollSkipsOnListError(t *testing.T) {
+func TestPollSkipsOnListClustersError(t *testing.T) {
 	t.Parallel()
-	store := &fakeStore{listErr: errors.New("db down")}
-	c := New(store, &fakeFetcher{version: "v1.29.5"}, "prod", time.Minute, time.Second)
+	store := newFakeStore()
+	store.listErr = errors.New("db down")
+	c := New(store, &fakeSource{version: "v1.29.5"}, "prod", time.Minute, time.Second)
 
 	c.poll(context.Background())
 
-	if len(store.updates) != 0 {
-		t.Errorf("expected no updates on list error, got %d", len(store.updates))
+	if len(store.updates) != 0 || len(store.upsertedNode) != 0 {
+		t.Errorf("expected no store writes on list error")
 	}
 }
 
 func TestPollSkipsWhenClusterNotRegistered(t *testing.T) {
 	t.Parallel()
-	store := &fakeStore{clusters: []api.Cluster{}}
-	c := New(store, &fakeFetcher{version: "v1.29.5"}, "missing", time.Minute, time.Second)
+	store := newFakeStore()
+	c := New(store, &fakeSource{version: "v1.29.5"}, "missing", time.Minute, time.Second)
 
 	c.poll(context.Background())
 
-	if len(store.updates) != 0 {
-		t.Errorf("expected no updates when cluster missing, got %d", len(store.updates))
+	if len(store.updates) != 0 || len(store.upsertedNode) != 0 {
+		t.Errorf("expected no store writes when cluster missing")
 	}
 }
 
-type signalingFetcher struct {
+func TestPollIngestsNodes(t *testing.T) {
+	t.Parallel()
+	id := uuid.New()
+	store := newFakeStore()
+	store.clusters = []api.Cluster{{Id: &id, Name: "prod"}}
+
+	source := &fakeSource{
+		version: "v1.29.5",
+		nodes: []NodeInfo{
+			{Name: "node-a", KubeletVersion: "v1.29.5", OsImage: "Ubuntu 22.04", Architecture: "amd64"},
+			{Name: "node-b", KubeletVersion: "v1.29.5", Labels: map[string]string{"role": "worker"}},
+		},
+	}
+	c := New(store, source, "prod", time.Minute, time.Second)
+
+	c.poll(context.Background())
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.upsertedNode) != 2 {
+		t.Fatalf("upserted=%d, want 2", len(store.upsertedNode))
+	}
+	// Every upsert must carry the correct cluster id.
+	for _, up := range store.upsertedNode {
+		if up.ClusterId != id {
+			t.Errorf("upsert cluster_id=%v, want %v", up.ClusterId, id)
+		}
+	}
+	// Empty label map must NOT be written as a non-nil pointer.
+	if store.upsertedNode[0].Labels != nil {
+		t.Errorf("node-a labels = %v, want nil", store.upsertedNode[0].Labels)
+	}
+	// Non-empty label map must round-trip through a pointer.
+	if store.upsertedNode[1].Labels == nil || (*store.upsertedNode[1].Labels)["role"] != "worker" {
+		t.Errorf("node-b labels = %v, want {role:worker}", store.upsertedNode[1].Labels)
+	}
+}
+
+func TestPollIngestsNodesIsIdempotent(t *testing.T) {
+	t.Parallel()
+	id := uuid.New()
+	store := newFakeStore()
+	store.clusters = []api.Cluster{{Id: &id, Name: "prod"}}
+
+	source := &fakeSource{
+		version: "v1.29.5",
+		nodes:   []NodeInfo{{Name: "node-a"}},
+	}
+	c := New(store, source, "prod", time.Minute, time.Second)
+
+	c.poll(context.Background())
+	c.poll(context.Background())
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if got := store.nodeState[id.String()+"/node-a"]; got != 2 {
+		t.Errorf("expected node-a upsert count 2 (one per poll), got %d", got)
+	}
+}
+
+func TestPollContinuesOnPerNodeUpsertError(t *testing.T) {
+	t.Parallel()
+	id := uuid.New()
+	store := newFakeStore()
+	store.clusters = []api.Cluster{{Id: &id, Name: "prod"}}
+	store.upsertErr = errors.New("boom")
+
+	source := &fakeSource{
+		version: "v1.29.5",
+		nodes: []NodeInfo{
+			{Name: "node-a"}, {Name: "node-b"}, {Name: "node-c"},
+		},
+	}
+	c := New(store, source, "prod", time.Minute, time.Second)
+
+	// poll must not panic or return early on upsert error.
+	c.poll(context.Background())
+
+	// The version update already happened before UpsertNode errors.
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.updates) != 1 {
+		t.Errorf("expected cluster version update despite node upsert failures, got %d updates", len(store.updates))
+	}
+}
+
+func TestPollSkipsNodeIngestionOnListNodesError(t *testing.T) {
+	t.Parallel()
+	id := uuid.New()
+	store := newFakeStore()
+	store.clusters = []api.Cluster{{Id: &id, Name: "prod"}}
+
+	source := &fakeSource{
+		version:     "v1.29.5",
+		listNodeErr: errors.New("kube down"),
+	}
+	c := New(store, source, "prod", time.Minute, time.Second)
+
+	c.poll(context.Background())
+
+	if len(store.upsertedNode) != 0 {
+		t.Errorf("expected no node upserts when ListNodes errors; got %d", len(store.upsertedNode))
+	}
+}
+
+type signalingSource struct {
+	fakeSource
 	calls atomic.Int64
 	ch    chan struct{}
 }
 
-func (c *signalingFetcher) ServerVersion(_ context.Context) (string, error) {
-	c.calls.Add(1)
+func (s *signalingSource) ServerVersion(ctx context.Context) (string, error) {
+	s.calls.Add(1)
 	select {
-	case c.ch <- struct{}{}:
+	case s.ch <- struct{}{}:
 	default:
 	}
-	return "v1.29.5", nil
+	return s.fakeSource.ServerVersion(ctx)
 }
 
 func TestRunStopsOnContextCancel(t *testing.T) {
 	t.Parallel()
 	id := uuid.New()
-	store := &fakeStore{
-		clusters: []api.Cluster{{Id: &id, Name: "prod"}},
+	store := newFakeStore()
+	store.clusters = []api.Cluster{{Id: &id, Name: "prod"}}
+
+	source := &signalingSource{
+		fakeSource: fakeSource{version: "v1.29.5"},
+		ch:         make(chan struct{}, 4),
 	}
-	fetcher := &signalingFetcher{ch: make(chan struct{}, 4)}
-	c := New(store, fetcher, "prod", 20*time.Millisecond, time.Second)
+	c := New(store, source, "prod", 20*time.Millisecond, time.Second)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() { done <- c.Run(ctx) }()
 
-	// Wait deterministically for two ticks (startup + one ticker fire).
-	waitForSignal(t, fetcher.ch, 2*time.Second)
-	waitForSignal(t, fetcher.ch, 2*time.Second)
+	waitForSignal(t, source.ch, 2*time.Second)
+	waitForSignal(t, source.ch, 2*time.Second)
 
 	cancel()
 
@@ -190,7 +330,7 @@ func TestRunStopsOnContextCancel(t *testing.T) {
 		t.Fatal("Run did not return after cancel")
 	}
 
-	if got := fetcher.calls.Load(); got < 2 {
+	if got := source.calls.Load(); got < 2 {
 		t.Errorf("expected at least 2 fetches, got %d", got)
 	}
 }

--- a/internal/collector/kube.go
+++ b/internal/collector/kube.go
@@ -4,24 +4,24 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/client-go/discovery"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// KubeVersionFetcher fetches the Kubernetes API server version using
-// client-go. The target cluster is whatever the loaded kubeconfig points
-// at; only one cluster per KubeVersionFetcher instance is supported in v1.
-type KubeVersionFetcher struct {
-	discovery discovery.DiscoveryInterface
+// KubeClient talks to a single Kubernetes cluster via client-go. It
+// satisfies KubeSource (ServerVersion + ListNodes). The target cluster is
+// whatever the loaded kubeconfig points at.
+type KubeClient struct {
+	clientset *kubernetes.Clientset
 }
 
-// NewKubeVersionFetcher constructs a fetcher. Resolution order:
+// NewKubeClient constructs a client. Resolution order:
 //   - explicit kubeconfigPath when non-empty;
 //   - in-cluster config when running inside a pod;
 //   - the default kubectl loading rules (KUBECONFIG env var, then ~/.kube/config).
-func NewKubeVersionFetcher(kubeconfigPath string) (*KubeVersionFetcher, error) {
+func NewKubeClient(kubeconfigPath string) (*KubeClient, error) {
 	cfg, err := loadKubeConfig(kubeconfigPath)
 	if err != nil {
 		return nil, err
@@ -30,7 +30,7 @@ func NewKubeVersionFetcher(kubeconfigPath string) (*KubeVersionFetcher, error) {
 	if err != nil {
 		return nil, fmt.Errorf("kubernetes.NewForConfig: %w", err)
 	}
-	return &KubeVersionFetcher{discovery: cs.Discovery()}, nil
+	return &KubeClient{clientset: cs}, nil
 }
 
 func loadKubeConfig(kubeconfigPath string) (*rest.Config, error) {
@@ -55,10 +55,31 @@ func loadKubeConfig(kubeconfigPath string) (*rest.Config, error) {
 // ServerVersion returns the cluster's reported git version (e.g., "v1.29.5").
 // client-go's discovery.ServerVersion() does not accept a context, so the
 // parameter is retained for interface compatibility but unused.
-func (k *KubeVersionFetcher) ServerVersion(_ context.Context) (string, error) {
-	info, err := k.discovery.ServerVersion()
+func (k *KubeClient) ServerVersion(_ context.Context) (string, error) {
+	info, err := k.clientset.Discovery().ServerVersion()
 	if err != nil {
 		return "", err
 	}
 	return info.GitVersion, nil
+}
+
+// ListNodes returns every Node visible through the configured kubeconfig.
+// A single List call is used; paginating via Continue is unnecessary at
+// the cluster-wide node counts this project targets.
+func (k *KubeClient) ListNodes(ctx context.Context) ([]NodeInfo, error) {
+	list, err := k.clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list nodes: %w", err)
+	}
+	out := make([]NodeInfo, 0, len(list.Items))
+	for _, n := range list.Items {
+		out = append(out, NodeInfo{
+			Name:           n.Name,
+			KubeletVersion: n.Status.NodeInfo.KubeletVersion,
+			OsImage:        n.Status.NodeInfo.OSImage,
+			Architecture:   n.Status.NodeInfo.Architecture,
+			Labels:         n.Labels,
+		})
+	}
+	return out, nil
 }

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -454,6 +454,48 @@ func (p *PG) DeleteNode(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
+// UpsertNode inserts-or-updates a node keyed by (cluster_id, name). The
+// unique index on (cluster_id, name) drives the ON CONFLICT target. On
+// conflict only mutable columns are overwritten so created_at is preserved.
+func (p *PG) UpsertNode(ctx context.Context, in api.NodeCreate) (api.Node, error) {
+	id := uuid.New()
+	now := time.Now().UTC()
+
+	labelsJSON, err := marshalLabels(in.Labels)
+	if err != nil {
+		return api.Node{}, err
+	}
+
+	const q = `
+		INSERT INTO nodes (
+			id, cluster_id, name, display_name, kubelet_version,
+			os_image, architecture, labels, created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $9)
+		ON CONFLICT (cluster_id, name) DO UPDATE SET
+			display_name    = EXCLUDED.display_name,
+			kubelet_version = EXCLUDED.kubelet_version,
+			os_image        = EXCLUDED.os_image,
+			architecture    = EXCLUDED.architecture,
+			labels          = EXCLUDED.labels,
+			updated_at      = EXCLUDED.updated_at
+		RETURNING id, cluster_id, name, display_name, kubelet_version,
+		          os_image, architecture, labels, created_at, updated_at
+	`
+	row := p.pool.QueryRow(ctx, q,
+		id, in.ClusterId, in.Name, in.DisplayName, in.KubeletVersion,
+		in.OsImage, in.Architecture, labelsJSON, now,
+	)
+	n, err := scanNode(row)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
+			return api.Node{}, fmt.Errorf("cluster %s does not exist: %w", in.ClusterId, api.ErrNotFound)
+		}
+		return api.Node{}, fmt.Errorf("upsert node: %w", err)
+	}
+	return n, nil
+}
+
 func scanNode(row pgx.Row) (api.Node, error) {
 	var (
 		n               api.Node

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -167,6 +167,57 @@ func TestPGNodeCRUD(t *testing.T) {
 	}
 }
 
+func TestPGUpsertNode(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, err := pg.CreateCluster(ctx, api.ClusterCreate{Name: "upsert-test"})
+	if err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	kv1 := "v1.29.5"
+	first, err := pg.UpsertNode(ctx, api.NodeCreate{
+		ClusterId:      *cluster.Id,
+		Name:           "node-a",
+		KubeletVersion: &kv1,
+	})
+	if err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	if first.Id == nil {
+		t.Fatal("first.Id nil")
+	}
+
+	// Second upsert with new kubelet version must mutate the SAME row.
+	kv2 := "v1.29.6"
+	second, err := pg.UpsertNode(ctx, api.NodeCreate{
+		ClusterId:      *cluster.Id,
+		Name:           "node-a",
+		KubeletVersion: &kv2,
+	})
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if *second.Id != *first.Id {
+		t.Errorf("id changed across upsert: first=%v second=%v", *first.Id, *second.Id)
+	}
+	if second.KubeletVersion == nil || *second.KubeletVersion != kv2 {
+		t.Errorf("kubelet_version=%v, want %q", second.KubeletVersion, kv2)
+	}
+	if second.CreatedAt == nil || first.CreatedAt == nil || !second.CreatedAt.Equal(*first.CreatedAt) {
+		t.Errorf("created_at should be preserved on conflict: first=%v second=%v", first.CreatedAt, second.CreatedAt)
+	}
+	if second.UpdatedAt == nil || first.UpdatedAt == nil || !second.UpdatedAt.After(*first.UpdatedAt) {
+		t.Errorf("updated_at should advance on conflict: first=%v second=%v", first.UpdatedAt, second.UpdatedAt)
+	}
+
+	// Unknown cluster yields NotFound, not Conflict.
+	if _, err := pg.UpsertNode(ctx, api.NodeCreate{ClusterId: uuid.New(), Name: "x"}); !errors.Is(err, api.ErrNotFound) {
+		t.Errorf("upsert with unknown cluster: want ErrNotFound, got %v", err)
+	}
+}
+
 func TestPGListPagination(t *testing.T) {
 	pg := newTestPG(t)
 	ctx := context.Background()

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -32,7 +32,10 @@ func newTestPG(t *testing.T) *PG {
 		t.Fatalf("migrate: %v", err)
 	}
 	t.Cleanup(func() {
-		_, _ = pg.pool.Exec(context.Background(), "TRUNCATE clusters")
+		// CASCADE is required because nodes has a FK to clusters; without it
+		// a plain TRUNCATE fails when the nodes table is non-empty and test
+		// residue leaks across tests that share the same database.
+		_, _ = pg.pool.Exec(context.Background(), "TRUNCATE clusters CASCADE")
 		pg.Close()
 	})
 	return pg


### PR DESCRIPTION
The collector now populates the nodes table on every tick. Each poll:
  1. Fetches the Kubernetes server version and refreshes the cluster record when it changed (existing behaviour).
  2. Lists every node via client-go CoreV1().Nodes().List and upserts it into the store keyed on (cluster_id, name).

Store:
- internal/api/store.go grows UpsertNode(in NodeCreate) (Node, error). Separate contract from CreateNode so the collector does not have to implement Create/Update reconciliation logic itself.
- internal/store/pg.go implements the upsert via INSERT ... ON CONFLICT (cluster_id, name) DO UPDATE ... RETURNING. created_at is preserved across conflicts (not re-assigned from EXCLUDED); updated_at is bumped. FK violations on unknown cluster_id still surface as api.ErrNotFound.
- internal/api/server_test.go memStore mirrors the upsert semantics so handler-level tests keep passing without touching Postgres.
- internal/store/pg_test.go TestPGUpsertNode covers the ID-preserved / created_at-preserved / updated_at-advances contract plus the unknown- cluster NotFound mapping.

Collector:
- internal/collector/collector.go: VersionFetcher stays (backwards- compatible subset) but the Collector now consumes a composite KubeSource = VersionFetcher + NodeLister. NodeInfo carries the small set of fields the CMDB stores; the collector maps NodeInfo -> NodeCreate before each UpsertNode. Empty label maps are written as nil pointers, not pointer-to-empty, so the store sees absent rather than {} labels.
- internal/collector/kube.go: KubeVersionFetcher is renamed KubeClient. It retains the full *kubernetes.Clientset so it can serve both ServerVersion (discovery) and ListNodes (CoreV1().Nodes().List). Resolution order for the kubeconfig (explicit path / in-cluster / default loading rules) is unchanged.
- internal/collector/collector_test.go: fakeSource now satisfies KubeSource; fakeStore tracks upsert history keyed by (cluster_id, name) so tests can assert idempotency; signalingFetcher is renamed signalingSource and keeps the deterministic Run/cancel test green. New tests cover successful ingestion with/without labels, idempotency across two polls, per-node upsert errors not aborting the poll, and ListNodes errors short-circuiting ingestion while still allowing the cluster-version refresh to complete.

Daemon:
- cmd/argosd/main.go renames its local variable and calls collector.NewKubeClient (was NewKubeVersionFetcher). ARGOS_* env vars unchanged.

Collector coverage: 58.8% -> 62.4%.

Next up: Namespace resource (mirroring Node) and a GetClusterByName store method to drop the linear scan in findClusterByName.