### PR TITLE
feat(api): add Namespace resource and ingest namespaces in the collector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Configure tokens via either or both env vars (merged at startup):
 At least one token must be configured; `/healthz` and `/readyz` stay open.
 - `internal/api/` — generated server (`api.gen.go`), hand-written handlers (`server.go`), `Store` interface (`store.go`) with `ErrNotFound` / `ErrConflict` sentinels. RFC 7807 `application/problem+json` for all errors.
 - `internal/store/` — PostgreSQL implementation of `api.Store` using `pgx/v5`. Cursor-paginated list, merge-patch updates, embedded `goose` migrations. Nodes are FK-linked to clusters with `ON DELETE CASCADE`.
-- `internal/collector/` — Kubernetes polling collector. Each tick fetches the API server version (refreshing the matching cluster record) and lists all nodes, upserting each by `(cluster_id, name)` into the `nodes` table. Disabled by default; enable with `ARGOS_COLLECTOR_ENABLED=true` and `ARGOS_CLUSTER_NAME=...`.
+- `internal/collector/` — Kubernetes polling collector. Each tick fetches the API server version (refreshing the matching cluster record), lists all nodes (upserting each by `(cluster_id, name)` into the `nodes` table), and lists all namespaces (upserting into `namespaces`). Disabled by default; enable with `ARGOS_COLLECTOR_ENABLED=true` and `ARGOS_CLUSTER_NAME=...`.
 - `migrations/` — timestamped SQL migrations, embedded in the binary via `migrations/embed.go`.
 - `.github/workflows/ci.yml` — GitHub Actions pipeline: codegen-drift check, `go vet`, `go build`, `go test -race` against a Postgres service container (so the integration tests gated on `PGX_TEST_DATABASE` run in CI), and `golangci-lint`.
 

--- a/api/openapi/openapi.yaml
+++ b/api/openapi/openapi.yaml
@@ -28,6 +28,8 @@ tags:
     description: Kubernetes clusters registered in the CMDB.
   - name: nodes
     description: Kubernetes nodes (worker / control-plane machines) within a cluster.
+  - name: namespaces
+    description: Kubernetes namespaces within a cluster.
 
 security:
   - BearerAuth: []
@@ -328,6 +330,137 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /v1/namespaces:
+    get:
+      tags: [namespaces]
+      summary: List namespaces
+      operationId: listNamespaces
+      security:
+        - BearerAuth: [read]
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Cursor'
+        - $ref: '#/components/parameters/NamespaceClusterIdFilter'
+      responses:
+        '200':
+          description: Paged list of namespaces.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NamespaceList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+    post:
+      tags: [namespaces]
+      summary: Register a namespace
+      operationId: createNamespace
+      security:
+        - BearerAuth: [write]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NamespaceCreate'
+      responses:
+        '201':
+          description: Namespace created.
+          headers:
+            Location:
+              description: URI of the newly created namespace.
+              schema:
+                type: string
+                format: uri
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Namespace'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+
+  /v1/namespaces/{id}:
+    parameters:
+      - $ref: '#/components/parameters/NamespaceId'
+    get:
+      tags: [namespaces]
+      summary: Get a namespace
+      operationId: getNamespace
+      security:
+        - BearerAuth: [read]
+      responses:
+        '200':
+          description: Namespace details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Namespace'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    patch:
+      tags: [namespaces]
+      summary: Update mutable fields of a namespace
+      description: |
+        Merge-patch semantics: fields omitted from the body are unchanged.
+        `cluster_id` and `name` are immutable after creation.
+      operationId: updateNamespace
+      security:
+        - BearerAuth: [write]
+      requestBody:
+        required: true
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/NamespaceUpdate'
+      responses:
+        '200':
+          description: Updated namespace.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Namespace'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    delete:
+      tags: [namespaces]
+      summary: Delete a namespace
+      operationId: deleteNamespace
+      security:
+        - BearerAuth: [delete]
+      responses:
+        '204':
+          description: Namespace deleted.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
 components:
 
   securitySchemes:
@@ -372,6 +505,24 @@ components:
       in: query
       required: false
       description: Return only nodes belonging to this cluster.
+      schema:
+        type: string
+        format: uuid
+
+    NamespaceId:
+      name: id
+      in: path
+      required: true
+      description: Server-assigned namespace identifier.
+      schema:
+        type: string
+        format: uuid
+
+    NamespaceClusterIdFilter:
+      name: cluster_id
+      in: query
+      required: false
+      description: Return only namespaces belonging to this cluster.
       schema:
         type: string
         format: uuid
@@ -674,6 +825,101 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Node'
+        next_cursor:
+          type: string
+          nullable: true
+          description: |
+            Opaque cursor to pass as `?cursor=` to fetch the next page.
+            Absent or null when no more pages remain.
+
+    NamespaceMutable:
+      description: Fields on a Namespace that clients may set and later update.
+      type: object
+      properties:
+        display_name:
+          type: string
+          maxLength: 256
+          description: Human-friendly label, free-form.
+        phase:
+          type: string
+          maxLength: 32
+          description: |
+            Kubernetes namespace phase as last observed (e.g. "Active", "Terminating").
+            Open-ended to accommodate any additional phases Kubernetes introduces.
+        labels:
+          type: object
+          description: Arbitrary user-supplied string key/value labels.
+          additionalProperties:
+            type: string
+            maxLength: 256
+          maxProperties: 64
+
+    NamespaceCreate:
+      description: Payload to register a new namespace under a cluster.
+      allOf:
+        - $ref: '#/components/schemas/NamespaceMutable'
+        - type: object
+          required: [cluster_id, name]
+          properties:
+            cluster_id:
+              type: string
+              format: uuid
+              description: |
+                Parent cluster id. Immutable after creation; the cluster must
+                already exist or the create returns 404.
+            name:
+              type: string
+              description: |
+                Kubernetes namespace name (DNS-label style). Unique per cluster.
+                Immutable after creation.
+              pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+              minLength: 1
+              maxLength: 63
+
+    NamespaceUpdate:
+      description: |
+        Merge-patch body. Only mutable fields; `cluster_id` and `name` are
+        immutable. Omitted fields are left unchanged.
+      allOf:
+        - $ref: '#/components/schemas/NamespaceMutable'
+
+    Namespace:
+      description: A Kubernetes namespace registered in the CMDB.
+      allOf:
+        - $ref: '#/components/schemas/NamespaceMutable'
+        - type: object
+          required: [id, cluster_id, name, created_at, updated_at]
+          properties:
+            id:
+              type: string
+              format: uuid
+              readOnly: true
+            cluster_id:
+              type: string
+              format: uuid
+            name:
+              type: string
+              pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+              minLength: 1
+              maxLength: 63
+            created_at:
+              type: string
+              format: date-time
+              readOnly: true
+            updated_at:
+              type: string
+              format: date-time
+              readOnly: true
+
+    NamespaceList:
+      description: Paged list of namespaces.
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Namespace'
         next_cursor:
           type: string
           nullable: true

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -141,6 +141,71 @@ type Health struct {
 // HealthStatus defines model for Health.Status.
 type HealthStatus string
 
+// Namespace defines model for Namespace.
+type Namespace struct {
+	ClusterId openapi_types.UUID `json:"cluster_id"`
+	CreatedAt *time.Time         `json:"created_at,omitempty"`
+
+	// DisplayName Human-friendly label, free-form.
+	DisplayName *string             `json:"display_name,omitempty"`
+	Id          *openapi_types.UUID `json:"id,omitempty"`
+
+	// Labels Arbitrary user-supplied string key/value labels.
+	Labels *map[string]string `json:"labels,omitempty"`
+	Name   string             `json:"name"`
+
+	// Phase Kubernetes namespace phase as last observed (e.g. "Active", "Terminating").
+	// Open-ended to accommodate any additional phases Kubernetes introduces.
+	Phase     *string    `json:"phase,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+}
+
+// NamespaceCreate defines model for NamespaceCreate.
+type NamespaceCreate struct {
+	// ClusterId Parent cluster id. Immutable after creation; the cluster must
+	// already exist or the create returns 404.
+	ClusterId openapi_types.UUID `json:"cluster_id"`
+
+	// DisplayName Human-friendly label, free-form.
+	DisplayName *string `json:"display_name,omitempty"`
+
+	// Labels Arbitrary user-supplied string key/value labels.
+	Labels *map[string]string `json:"labels,omitempty"`
+
+	// Name Kubernetes namespace name (DNS-label style). Unique per cluster.
+	// Immutable after creation.
+	Name string `json:"name"`
+
+	// Phase Kubernetes namespace phase as last observed (e.g. "Active", "Terminating").
+	// Open-ended to accommodate any additional phases Kubernetes introduces.
+	Phase *string `json:"phase,omitempty"`
+}
+
+// NamespaceList Paged list of namespaces.
+type NamespaceList struct {
+	Items []Namespace `json:"items"`
+
+	// NextCursor Opaque cursor to pass as `?cursor=` to fetch the next page.
+	// Absent or null when no more pages remain.
+	NextCursor *string `json:"next_cursor,omitempty"`
+}
+
+// NamespaceMutable Fields on a Namespace that clients may set and later update.
+type NamespaceMutable struct {
+	// DisplayName Human-friendly label, free-form.
+	DisplayName *string `json:"display_name,omitempty"`
+
+	// Labels Arbitrary user-supplied string key/value labels.
+	Labels *map[string]string `json:"labels,omitempty"`
+
+	// Phase Kubernetes namespace phase as last observed (e.g. "Active", "Terminating").
+	// Open-ended to accommodate any additional phases Kubernetes introduces.
+	Phase *string `json:"phase,omitempty"`
+}
+
+// NamespaceUpdate Fields on a Namespace that clients may set and later update.
+type NamespaceUpdate = NamespaceMutable
+
 // Node defines model for Node.
 type Node struct {
 	// Architecture CPU architecture. Open-ended; common values: amd64, arm64, ppc64le, s390x.
@@ -244,6 +309,12 @@ type Cursor = string
 // Limit defines model for Limit.
 type Limit = int
 
+// NamespaceClusterIdFilter defines model for NamespaceClusterIdFilter.
+type NamespaceClusterIdFilter = openapi_types.UUID
+
+// NamespaceId defines model for NamespaceId.
+type NamespaceId = openapi_types.UUID
+
 // NodeClusterIdFilter defines model for NodeClusterIdFilter.
 type NodeClusterIdFilter = openapi_types.UUID
 
@@ -274,6 +345,18 @@ type ListClustersParams struct {
 	Cursor *Cursor `form:"cursor,omitempty" json:"cursor,omitempty"`
 }
 
+// ListNamespacesParams defines parameters for ListNamespaces.
+type ListNamespacesParams struct {
+	// Limit Maximum number of items to return. Server clamps to [1, 200].
+	Limit *Limit `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Cursor Opaque cursor returned from a previous list response.
+	Cursor *Cursor `form:"cursor,omitempty" json:"cursor,omitempty"`
+
+	// ClusterId Return only namespaces belonging to this cluster.
+	ClusterId *NamespaceClusterIdFilter `form:"cluster_id,omitempty" json:"cluster_id,omitempty"`
+}
+
 // ListNodesParams defines parameters for ListNodes.
 type ListNodesParams struct {
 	// Limit Maximum number of items to return. Server clamps to [1, 200].
@@ -291,6 +374,12 @@ type CreateClusterJSONRequestBody = ClusterCreate
 
 // UpdateClusterApplicationMergePatchPlusJSONRequestBody defines body for UpdateCluster for application/merge-patch+json ContentType.
 type UpdateClusterApplicationMergePatchPlusJSONRequestBody = ClusterUpdate
+
+// CreateNamespaceJSONRequestBody defines body for CreateNamespace for application/json ContentType.
+type CreateNamespaceJSONRequestBody = NamespaceCreate
+
+// UpdateNamespaceApplicationMergePatchPlusJSONRequestBody defines body for UpdateNamespace for application/merge-patch+json ContentType.
+type UpdateNamespaceApplicationMergePatchPlusJSONRequestBody = NamespaceUpdate
 
 // CreateNodeJSONRequestBody defines body for CreateNode for application/json ContentType.
 type CreateNodeJSONRequestBody = NodeCreate
@@ -321,6 +410,21 @@ type ServerInterface interface {
 	// Update mutable fields of a cluster
 	// (PATCH /v1/clusters/{id})
 	UpdateCluster(w http.ResponseWriter, r *http.Request, id ClusterId)
+	// List namespaces
+	// (GET /v1/namespaces)
+	ListNamespaces(w http.ResponseWriter, r *http.Request, params ListNamespacesParams)
+	// Register a namespace
+	// (POST /v1/namespaces)
+	CreateNamespace(w http.ResponseWriter, r *http.Request)
+	// Delete a namespace
+	// (DELETE /v1/namespaces/{id})
+	DeleteNamespace(w http.ResponseWriter, r *http.Request, id NamespaceId)
+	// Get a namespace
+	// (GET /v1/namespaces/{id})
+	GetNamespace(w http.ResponseWriter, r *http.Request, id NamespaceId)
+	// Update mutable fields of a namespace
+	// (PATCH /v1/namespaces/{id})
+	UpdateNamespace(w http.ResponseWriter, r *http.Request, id NamespaceId)
 	// List nodes
 	// (GET /v1/nodes)
 	ListNodes(w http.ResponseWriter, r *http.Request, params ListNodesParams)
@@ -520,6 +624,168 @@ func (siw *ServerInterfaceWrapper) UpdateCluster(w http.ResponseWriter, r *http.
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.UpdateCluster(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListNamespaces operation middleware
+func (siw *ServerInterfaceWrapper) ListNamespaces(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"read"})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListNamespacesParams
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "cursor" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "cursor", r.URL.Query(), &params.Cursor, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cursor", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "cluster_id" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "cluster_id", r.URL.Query(), &params.ClusterId, runtime.BindQueryParameterOptions{Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cluster_id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListNamespaces(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateNamespace operation middleware
+func (siw *ServerInterfaceWrapper) CreateNamespace(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"write"})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateNamespace(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteNamespace operation middleware
+func (siw *ServerInterfaceWrapper) DeleteNamespace(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id NamespaceId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"delete"})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteNamespace(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetNamespace operation middleware
+func (siw *ServerInterfaceWrapper) GetNamespace(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id NamespaceId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"read"})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetNamespace(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateNamespace operation middleware
+func (siw *ServerInterfaceWrapper) UpdateNamespace(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id NamespaceId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"write"})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateNamespace(w, r, id)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -818,6 +1084,11 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("DELETE "+options.BaseURL+"/v1/clusters/{id}", wrapper.DeleteCluster)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/clusters/{id}", wrapper.GetCluster)
 	m.HandleFunc("PATCH "+options.BaseURL+"/v1/clusters/{id}", wrapper.UpdateCluster)
+	m.HandleFunc("GET "+options.BaseURL+"/v1/namespaces", wrapper.ListNamespaces)
+	m.HandleFunc("POST "+options.BaseURL+"/v1/namespaces", wrapper.CreateNamespace)
+	m.HandleFunc("DELETE "+options.BaseURL+"/v1/namespaces/{id}", wrapper.DeleteNamespace)
+	m.HandleFunc("GET "+options.BaseURL+"/v1/namespaces/{id}", wrapper.GetNamespace)
+	m.HandleFunc("PATCH "+options.BaseURL+"/v1/namespaces/{id}", wrapper.UpdateNamespace)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/nodes", wrapper.ListNodes)
 	m.HandleFunc("POST "+options.BaseURL+"/v1/nodes", wrapper.CreateNode)
 	m.HandleFunc("DELETE "+options.BaseURL+"/v1/nodes/{id}", wrapper.DeleteNode)
@@ -830,61 +1101,67 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xb/XIbtxF/lZ1rZio5xw992Inp6WRkOU40sWWNZLV/iKoFHpYkQhxwBnCUGQ9n+hB9",
-	"wj5JZ4E78kgeRcmR1NTtPzZ53MMu9vOHXehzlOg00wqVs1Hnc5Qxw1J0aPy3Q5lbh+aI0xeONjEic0Kr",
-	"qBOdoRmjaTBrxUAhhySQguConOgLNM0ojgSRZswNozhSLMWoEwkexZHBj7kwyKOOMznGkU2GmDLi0tcm",
-	"ZS7qRHnuKd0ko7esM0INouk0jg5zY7VZlehdxj7mCIn/GQy63JBgfaNTYJAZHAudW5DCOjBoM60szmT8",
-	"mKOZzIUMi0RVwVL26Q2qgRtGnac7u3WCvRGpcKtyvWWfRJqnoPK0hwZ0H4TD1ILThZBNCMqERLI08z9c",
-	"7MSw225frpNPelZV8Tj2WS5d1HnajklWYhl1dtv0TajwbWcmtVAOB2i82Mea48zQr4V0WKPcUy8paCUn",
-	"oDRHCz2UWg2EGpC8bihs6QJrdRp+/uDNeheDk4C3cUGS68H9b0ovB+fxIfKS8VP8mKP1lk+0cqj8R5Zl",
-	"UiSMZG1lRvckpt/+aknwzxV23xjsR53oT615GLbCr7Z1Et4KTJd9SpKgyMEE5s2IIkOrvhTJo0pS8oRr",
-	"4YYUfAaVA+uYQ9jC5qAZA88DfwQywbYX9bU2PcE5qseU9b0eoQJhYcyk4NDLHUiWjCy4IYJNdIZQOgb0",
-	"Jv6pztB4abzUx9q91rnijyn0KVqdmwRBaQd94u5FOVcsd0NtxG/4qOK8FdZS0GsDQhV6RGbQgCPtNn3E",
-	"FutUSoiXS8p3/ahzcTPv4oW3uWM9idE0/hxlhszgRIi4xCBzyD8wtxCvnDlsOJGiD2/G3yk5KcN7KYhj",
-	"SgI1sb7xtZBCFmrBs32fYMuvuzGlG4eGdPX3C9b4rd14fln837j83I6f7U7Lx99ENTzyjP/O7U2r+e0i",
-	"JDwveVzV3QKny9kiuvcrJi6aXi4b/gB+yXtoFDqcpXowOBD0ATkI5QPm8O2rlyEZBZJDz/EezV/aYKkW",
-	"eHKwMh80pBhV60AMuRKEDFhitLVzKbvqKE0DH2B92o5XDwV7V0XxA1p5yUJ+S7cwwQmbSM14QA5B8cBA",
-	"4fW89M4V/0bYGjBywgbIAwbS/fI1S6VyUcseoix8uIXRiHuxB2YMm/iQwU/uQ3IryOY0ZMxaYBaufgjP",
-	"/nJFT/vokqG3G60GGRtgs6sOepZKjTagcinheogKlIZUG/QkFgymTBTGJBrvUbeLGb/rVZPMtFv658qW",
-	"XguU3IJWwKCgBTdkDhIpSGeQsglYdMAUB8no5xCHqzZgmfiAimdaqBpLVqLx4OQIbICQ56dvYEuokDaE",
-	"Vkxu08LzTGdEXdLhwmaSTT7UB9fPecpUo28EKi4nIFkPZQx9g9ighZuLsbL79FkNB1RjYbRKsW4vr8ul",
-	"oEIGjg1mEALHMYEKwpsxZEbz7eZqhK4wHc109GGMxopQA5cATGGkihILWjCYaeMCGKio28sE3Winufu8",
-	"+bQbLYuyt1sjildaMCvnIpjmZMHcG1W4lI9NTzjDzARyi6Zhc6r6yCHQwwgnrTGTOQZz2ULGKsuKyub+",
-	"nRk9FrzuCHCuOBo5ocUryuCCGPZyIqJYHGrriKRcp9lV7zJUDVQc+QtIdJpqBV4y24HBCGPAkY2B0T86",
-	"Q2WHou9iMPQL2Y/xNAatMoP0vxv6JW9he8qQwd43U07XB/m5D8wvr10rCfwtmgE2MkbprKf5pAlUxqEs",
-	"Qn2fO17AFYXhFQFVURYoUmMqHDljoAJmECT2HeQqGTI1QE56mcbRz8gk7XW5cBImz/0nVHQavIj0qJLi",
-	"5ppbGyovcyH5LDp036dkkytFBmdmoC1vbix2hRh1uZUOerfXNlHfgBLnp83Np7r4DwYqd5/u3QJvbF00",
-	"wqfm5ZPy2fYPjwgqF07094ww/WH+BnjpuxZ3xJZ38Zhl2OSPtfMmVxPWYccXXs6SMs2t6yomSbsTwE8e",
-	"eJlA4qUvekAW9tv7IbFt9NX6Ir2sO6KCrVfHZw2b97gmJATWTSRuN+E8AOLM95wCcrwDGL5n71zyrFWn",
-	"+l3I2Osip9IFbAEmkzPcBiP7btfvBcg+s/0PoONqhN0IjYnwi3GxSYbCYeJyU8Pl8OQcqhRNuAF/sJQ/",
-	"24+BmZT+y7Lk2b7EGOze8/anFb+vxXUPj5wJBEl06xHsL4EABsLNijOzm9Dr+KuEr9p+ECkb1JjCe9y7",
-	"M/A/l2xKZZz3cuVy2N1ttvebe/Dm/dmqXup2NV0TA3dFjguV6Yth4zx1XvkwKnAkM9hVcyQJtwWSZRdw",
-	"dRjw+hC++779HRTdReDomJA1WTL8QJ9WD4TGaGPXZImGxDHK0Kf1RQgCeRwSWdHhpN1E8TwDL/L226tl",
-	"naK1hY/cnOjCEvMX6lLeckoXyjqmElzEgvXH7jkkn01snj5/Xp3YtNurM5s4csJJrN1aeFAZB0Wsp3PX",
-	"6UmmRhsbAUvb97+W3OL1yJ12gkluhJuckUMXkxHfFj7Iw1kkNIlfl+x9szhaSQonR6GNDMLaHDno3DV0",
-	"v9FjijfhDBX35e+g6Hx7z+hAYATdvN3eS/zr/iNeNbuqq84SnaGFgWGKnN5pYIFHp6sAGnBF0OwKAP71",
-	"j3+Gok+hM0A37/3bgvLaCIdXgbJAb0Qb6hRsiZRSmC1XZC7APCYlmj/7k3JikNbbLtbjlLbxyq9nMNVj",
-	"QoOh21+yZDwVqmDJpCwPXaynx/iCqNGMKZS1gX5O5Q78Gw0/qCubR5b04IcfFhJmjD/D0zLl8mH24eVP",
-	"hJMTsMwJ258AU5OlwUhX9ehxZTDiy6RPZOQTwc5z1xo6l4U5glB9XZNLfjx773svtIUnTw7oFPnkSQzM",
-	"Q33/tFK8Ku0hC0yGuZ+fPLkhdtXB8dnZEZxhcpynh1LnHLbOjg+34WPOpOgXMxHoG5bitTYj7x/vh8LO",
-	"yuZWu7nTbG/T0ZvBNZMj0pQdkZ20gkSPkQKl8Jw3YowKCZIpDmRz4b9RUpzZr2gJXM0MC4en56+8X+Y9",
-	"ix9zAmkFdwvXQkpgnHt4FMMxS9FmLMEY/qbNiBBuDCeax56j74V01YJ2nHATGAnFCU9lGUWQ8uNZhKCb",
-	"hBmnB4ZlQ0IjEzTWK+FHn12hr6XU1zDL71tX62ZJV9uF3fM0ZWaycP5oJKicEUmw4LKVYNVIc4PMsg0B",
-	"hIG2YYmDk6Oo0paIvJF8tc9QsUxEnWjPP/IHkaHPPq2hb4P8Rp8H6FH+zGWPeNSJfkL3c0GyNNLdbbdv",
-	"mKjdbZJWNGNqBmlnaMYiQe9qUoyxuZBHo87FZVW7M1/z3kVqYgNLOTpsM7qkl1v+lFnd8iLLv6IRfcpQ",
-	"XF8r6wwyKt0ZQWOV0PMtzhzrMYvbHhUYZMmwrLIr2jsNzP7Tygsna6dD8xacYf2+SPwR72l77zFHoxWh",
-	"lHZBsJuterqYNNaZdbzTKic1a92ZjrKHJVG8cI9nDfack7TCzZVpvJGwuHtDEPXBrF6dX9Voed0EaxpH",
-	"+0GKusVn0rYqFzb8KzubX1mYtfuX9ja/NL/hsOQBi8jowjfeosvpUrjbWbfJVtxi9uhyGkeZtjWOEJpi",
-	"5UQuADq07qXmk/s2UdF/my7iRmdynK74x859M6+9jFJ03YomJKWtITJexM0bHfjVjDZOj0pkpfBaTsoF",
-	"qlea6q4I1WLo6R/YE+mN55vfmF0k2uC6HhAv++7pvAGXzLywxoGXMlvrs+DTYBpCxauO/co/rzr2goPt",
-	"rx/thRV581HVvL/5jdl1og1qLjSypOegj01ajtein7WabD9mqM5aB/+ltqnL3j+h22yWu1Xo+U1cYuVb",
-	"QTU3TSt9IospU04ktlP2eXTZ9jE69amup/nE47xq46dm9lg7D1h0p9DvumvRSefyfvtFjlW02W5VgB7F",
-	"q4NAfGHQ8EeuBfcYCLW1IOhjqVNJpfZ2tcHPXm6EvMee4sHx7mbKulvUDwqTZ/OrjRi5mGB9fQBZFcYv",
-	"HSh83wSN/SzuYXBxZSj9yKA4DBhXPcFPPe4NDpOCvyosfKf898jgWQU/XXbuamq8JWaeefwmwOy95StH",
-	"y2vUuh4n12uv/Tih+/XC47V2uFspL/446KFR8frR6hfg5DtVoC8HyZVB9CMj5HUuXcLjUEf+j43XYeN1",
-	"qf9GLmF5f4M5RM6i7qncS+A4Rqkzfw07jnIjixFdp9WSRDDU1nW+b3/f9hFVCLCy1E2DL9jKvfKR4oys",
-	"7e9RFH98V7S1CU+vvb1WHgPW3v5b/otCe/N64c8Vt661GaGBFpCHGy0bmWQKIWXJkMTf9gMqoaq3xGaM",
-	"ggGml9N/BwAA//8pD5mRLzsAAA==",
+	"H4sIAAAAAAAC/+xc63Lbtpd/lTPczqydUrJ8Sdoos9NxnKb1NHE8drz7wfLGEHEkoQIBBgDlqBnN7EPs",
+	"E+6T7ADgTRJ1S2z9E7dfbIoEcA7O9ceDI30OIhknUqAwOmh/DhKiSIwGlft0wlNtUJ1S+4GijhRLDJMi",
+	"aAeXqEaoGkRr1hdIIfJDgVEUhvUYqmYQBswOTYgZBGEgSIxBO2A0CAOFH1OmkAZto1IMAx0NMCaWSk+q",
+	"mJigHaSpG2nGiZ2ljWKiH0wmYXCSKi3VPEfvEvIxRYjcY1BoUmUZ6ykZA4FE4YjJVANn2oBCnUihseDx",
+	"Y4pqXDLpFwmqjMXk0xsUfTMI2k/3D+oYe8NiZub5eks+sTiNQaRxFxXIHjCDsQYjMyab4IUJESdx4h5c",
+	"74dw0GrdLOKPO1JV9ij2SMpN0H7aCi2vlmTQPmjZT0z4T/sF10wY7KNybJ+RGHVCIiy0/ZpxgzUSvnDs",
+	"ghR8DCKfpaGLXIo+E33LuRkwnRvDQun6xx+cgjdRfcHqOhZZcLgFmzyTdEPxSbpdyUm6ntAkfXh5Texk",
+	"74AuzLwk9AI/pqid90RSGBTukiQJZxGxvO4lSnY5xj/+qS3jnyvkflDYC9rBv+2VoWzPP9V7536WJzrr",
+	"l9wyihSUJ94MbHSRosdZtFVOcppwx8zABjCFwoA2xCDsYLPfDIGmnj46s951rL6WqssoRbFNXt/LIQpg",
+	"GkaEMwrd1AAn0VCDGSDoSCYIuWFAd+zuygSV48ZxfSbNa5kKuk2mL1DLVEUIQhroWeqOlStBUjOQiv2F",
+	"W2XnLdPaOr1UwEQmRyQKFRgr3abz2GydShp2fHH+rhe0r5fTzia8TQ3pcgwm4ecgUVYNhnmPixQSg/QD",
+	"MVP+SonBhmExOvcm9J3g49y9Z5w4tEGgxtdXTvMhZCqfPjtySSr/eBDacGNQWVn99zVp/NVqPL/J/jdu",
+	"PrfCZweT/PYPQQ2NNKFfub1JNb5d+4DnOA+rspuidFMsIrt/YmSCyc2s4o/hj7SLSqDBItSDwj6zF0iB",
+	"CecwJ29fvfTByA85cRTvUf25DmZygRsOmqf9BmfDah4IIRXMoisSKal1yWVHnMaxpwOkZ7fjxGOdvSOC",
+	"8AG1PKMht6U1VHBOxlwS6tGXFzwQEHhXpt5S8G+YrgF056SP1ONI2cunaZsqp6XsYN7UxRpKs9SzPRCl",
+	"yNi5DH4yH6K1YK+RkBCtgWi4/cXf+49be7eHJho4vdnVICF9bHbEcVfbVCMViJRzuBugACEhlgrdEA0K",
+	"Y8IyZdoxzqLW8xm363mVFNLN7XNuS68ZcqpBCiCQjQUzIAYizqzMICZj0GiACAqc2MfeD+d1QBL2AQVN",
+	"JBM1mqx44/H5KWgPw68u3sAOEz5sMCkI37ULl5FOsbqgQ5lOOBl/qHeu39OYiEZPMRSUj4GTLvIQegqx",
+	"YRduTvvKwdNnNRRQjJiSIsa6vbzOl4LKMDCkX0AIHIUWVFi8GUKiJN1tznvoHNFhIaMPI1Sa+Rw4A2Ay",
+	"JVWEmI0FhYlUxoOBirgdT9AJ9psHz5tPO8EsK4cHNaw4oXm1Usq8as6n1L1ShDPxWHWZUUSNIdWoGjq1",
+	"WR8p+PEwxPHeiPAUvbp0xmOVZEVkpX0nSo4YrXsFuBIUFR/bxSvCoMwS7KZ2kPXFgdTGDsnXaXbEuwRF",
+	"AwVF+gIiGcdSgONMt6E/xBBwqEMg9o9MUOgB65kQlH1i9UdoHIIUiUL73wzckmvo3kZIr+/lIyeLnfzK",
+	"OeaX5665AP4WVR8bCbHhrCvpuAk2jUOehHoudryAW+uGtxaosjxBWTHGzFhj9KOAKASOPQOpiAZE9JFa",
+	"uUzC4Hck3O51NnFaTJ66KxT2jfo6kMNKiCslt9BVXqaM08I7ZM+FZJUKYRVOVF9q2lyZ7DI26mJr8Yq8",
+	"vsiLKUvwYvneufr9LvzW4OXhFPDYrwUeO9eN7OpJfmv3ly2Cy6k3+3tGmmUlZAnWLMtAG6LNjc1nFk25",
+	"t92yftiERZDyheM4Hxmn2nQE4VbYY8BPDo8pP8RtISuvaThqHfl4t9Jw63N3rSjtFey8OrtsuOQA2ow5",
+	"7jbhygPlxNXzPKLcBCTfp63O2Nm8iX0VXi5FkdqsBmQKQRdWsQ6GLouJX4uiy/D3N8DRc563FEkXo78U",
+	"Sz88wP1uAN6A6HXjhBtr7YgTa+xdh49pAYCPI8NG2AlC6ATvUcVMEIv9LCKuoj5reiRyyM8qB4gYQykj",
+	"T0RXYz4TRkmaWpeajTGHB2sBuMJeNoVw8wnhi0FcGbJunYFmqI4o7IgS18G6sO5M0k32IeljhUQHTw/X",
+	"KMYUeab5GEGRpMvxkKSbQ6ENLOa7RkFWdiUA0mmXSpve7gkE3bN1PjAMsrKoRUCSrgd+JL0H3GMj298B",
+	"8lQ8bDnasWr50qKhigbMYGRSVUPl5PwKqiOasKQ4Q2L67CgEomL7L0miZ0ccQ9CHz1uf1knM2ygrDtMu",
+	"cjSLy3t/+AHQZ6aoXBC9qrQ3epS1Pak/sJj0a1ThLO7dJbjHOZlcGFfdVJgUDg6araPmIbx5fzkvl7pd",
+	"TRb4wMaYrJqZvhU4lh+RzndKvD6Bn35u/QTZ0StQNITxmijpH9ir+Wq5UlLpBVGiwXGE3B9iuyQEfnjo",
+	"A1l2/Gt3E4RlBJ6m7bZXSzpGrTMbWR7o/BLlhLqQNxvSmdCGCF/gW3UmUdYri5agp8+fV1uCWq35pqAw",
+	"MMxwrN2av1HpNwpIV6am3eVEDFeeksxs3z3NqYWLy5p2JxilipnxpTXorG3EnZkfp75Q60/QX+fk3Ul6",
+	"MBcUzk/9GTswrVOkIFPTkL1GlwjahEsU1KW/46wtwFlGGzwh6KSt1mHkprtLvG12REdcRjJBDX1FhMle",
+	"1DyNdkcANODWQrNbAPi///lfn/St6/TRlI0ROht5p5jBWz8yQ292rM9TsMNiG8J0viIxHuYRzlH9uztG",
+	"iBTa9Xaz9agN23jr1lMYy5FFg74VIidJaMxERpJwnlekSVeO8IUd7V9Xe1JBL7XpDtyMhutiyk/WtJWD",
+	"6wzREBGl3AGHXSZf3jeGOP4jZvgYNDFM98buPXa6a6QjuvZ2pWvEpUkXyKxNeD2XpjUwJvFNFkz0ZE0s",
+	"+fXyvTuYslt48uRY9aV+8iQE4qC+u1tJXpWzMw2E+6Yo15ZjBtgRx2eXl6dwidFZGp9wmVLYuTw72YWP",
+	"KeGslzWMQE+RGO+kGjr7eD9gukibO63mfrO1C0wDgTvCh1ZSemj1JAVEcoTWUTLLecNGKNBCMkHB6py5",
+	"TzYoFvrLzktuC8XCycXVK2eXaVfjx9SCtIy6hjvGORBKHTwKy5JQCP8l1dAi3BDOJQ0dRXdQ1BFT0jHM",
+	"jGHIBLV4KkmsBwnXu4bgZRMRZWRfkWRg0cgYlXZC+NVFV+hJzuUdFPF953ZRo83tbqb3NI6JGk+9fzQi",
+	"FEaxyGtwVkswr6RSIUW0sQChL7Vf4vj8NKic2QROSS7bJyhIwoJ2cOhuuReRgYs+ewN3RvSXve6jQ/mF",
+	"yZ7SoB38hub3bMhMv9tBq7Wk3WizNqPspKqmy+gS1YhF6EyNsxE2p+Jo0L6+qUq3sDVnXVZMpK9tjPbb",
+	"DG7s5D33llnd8jTJ/0TFejZCUXkntFFIbOpOLDQWkb2/Q4khXaJx16EChSQa5Fl2TnoXnti/Wnj+zdpI",
+	"f7INRpFej0XuFe9p63CbfWMVpoQ0nrHlWr2YDhqL1Dra38vbWBaas32VPckHhVON4guwZzlkz7dGT8KV",
+	"A7PmbgtRH0zr1eaeGikvau+ZhMGR56Ju8YLbvUo3q5uyv3rKVCOim3S4elLZ/jljAdPI6NoV3oKbyYy7",
+	"66LapCtmUdy6mYRBInWNIfiiWN6u5AEdavNS0vF9qyirv02mcaNRKU7m7GP/vonXdupmVbesCGnD1gAJ",
+	"zfzmjfT0avo+Lk5zZCXwjo/zBar93nX907UYevINW6Kd8Xz1jKLLeoXpOkA8a7sXZQEuKqywxoBnItve",
+	"Z0YnXjUWFc8b9it3v2rYUwZ2tLjvya9Im1sV89HqGUWv9QoxZxKZkbOXxyophwvRz0JJtrbpqkXp4DvV",
+	"TV30/g3NarVslqHLr3pZUq4UVPNVpkqdSGNMhGGRbud1HpmXfZSMXajrSjp2OK9a+KlpzKo9D5g2J1/v",
+	"2jTpxCW/P36RYWVltrUS0Fas2jNEpw4avuVccI+OUJsLvDxmKpU21a6XG8rGk6W496wc9uDId/XIhV/Y",
+	"e1DUPN3QsxI3V1t6Hh9yFlWDyM2rcnMVei7blB4GP882820ZQVe6sObtpOxDujcUXUj+UeHojWLnloG3",
+	"qBhwrf3PBdg14fe0Z6wC4KUtPXIIvlLei2H4Eom2tu3xjxeMr6GgzYBD9bvuDw3JF5/rfgFI3zy3fTlM",
+	"n+1R3DJQX2r1OVSvJKd/wPoisL52PpF0FVZ3I74FmF7zmxAPi9DzhrPV4Ny3nD1CXJ4pvzAh93klGpf0",
+	"wYB42UW6bQzuOgJrkrGk94m8Jf0HdG8NdHs7nTXuamhcF2XnFr8SYFtreezYul6sSxB1rfRa23HdRwyh",
+	"F+lhQ+Dsf+ro+8LMm2Sgr4DLZefotpHyApMuQLLLI//g44X4eEHoX0rFL+9+j8F7zrTsbbrnQHGEXCbu",
+	"RyXCIFU866lr7+1xO2AgtWn/3Pq55TwqY2BuqWWdarCTOuGj9TOrbdf4nP2UWNaHYvH0wq+b5HX7hV/X",
+	"mf19NL18Pf/jazt3Ug1RwR5YC1eSNxJOBEJMooFlf9d1lDFR/VpHQcgrYDmV8hfyli1UvuRMbib/HwAA",
+	"//8ULbQij1EAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -207,6 +207,92 @@ func (s *Server) DeleteNode(w http.ResponseWriter, r *http.Request, id NodeId) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// ListNamespaces returns a paged list of namespaces, optionally filtered by cluster_id.
+func (s *Server) ListNamespaces(w http.ResponseWriter, r *http.Request, params ListNamespacesParams) {
+	limit := 0
+	if params.Limit != nil {
+		limit = *params.Limit
+	}
+	cursor := ""
+	if params.Cursor != nil {
+		cursor = *params.Cursor
+	}
+
+	items, next, err := s.store.ListNamespaces(r.Context(), params.ClusterId, limit, cursor)
+	if err != nil {
+		s.writeStoreError(w, "listNamespaces", err)
+		return
+	}
+
+	resp := NamespaceList{Items: items}
+	if next != "" {
+		resp.NextCursor = &next
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// CreateNamespace registers a new namespace under a cluster.
+func (s *Server) CreateNamespace(w http.ResponseWriter, r *http.Request) {
+	var body NamespaceCreate
+	if err := decodeJSONBody(r, &body); err != nil {
+		writeProblem(w, http.StatusBadRequest, "Invalid request body", err.Error())
+		return
+	}
+	if body.Name == "" {
+		writeProblem(w, http.StatusBadRequest, "Missing field", "field 'name' is required")
+		return
+	}
+	if body.ClusterId == (uuid.UUID{}) {
+		writeProblem(w, http.StatusBadRequest, "Missing field", "field 'cluster_id' is required")
+		return
+	}
+
+	n, err := s.store.CreateNamespace(r.Context(), body)
+	if err != nil {
+		s.writeStoreError(w, "createNamespace", err)
+		return
+	}
+
+	if n.Id != nil {
+		w.Header().Set("Location", "/v1/namespaces/"+n.Id.String())
+	}
+	writeJSON(w, http.StatusCreated, n)
+}
+
+// GetNamespace fetches a namespace by id.
+func (s *Server) GetNamespace(w http.ResponseWriter, r *http.Request, id NamespaceId) {
+	n, err := s.store.GetNamespace(r.Context(), id)
+	if err != nil {
+		s.writeStoreError(w, "getNamespace", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, n)
+}
+
+// UpdateNamespace applies merge-patch updates.
+func (s *Server) UpdateNamespace(w http.ResponseWriter, r *http.Request, id NamespaceId) {
+	var body NamespaceUpdate
+	if err := decodeJSONBody(r, &body); err != nil {
+		writeProblem(w, http.StatusBadRequest, "Invalid request body", err.Error())
+		return
+	}
+	n, err := s.store.UpdateNamespace(r.Context(), id, body)
+	if err != nil {
+		s.writeStoreError(w, "updateNamespace", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, n)
+}
+
+// DeleteNamespace removes a namespace.
+func (s *Server) DeleteNamespace(w http.ResponseWriter, r *http.Request, id NamespaceId) {
+	if err := s.store.DeleteNamespace(r.Context(), id); err != nil {
+		s.writeStoreError(w, "deleteNamespace", err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func (s *Server) writeStoreError(w http.ResponseWriter, op string, err error) {
 	switch {
 	case errors.Is(err, ErrNotFound):

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -18,13 +18,15 @@ import (
 // memStore is an in-memory api.Store implementation used to exercise the
 // HTTP handlers without a PostgreSQL dependency.
 type memStore struct {
-	mu       sync.Mutex
-	byID     map[uuid.UUID]Cluster
-	byName   map[string]uuid.UUID
+	mu            sync.Mutex
+	byID          map[uuid.UUID]Cluster
+	byName        map[string]uuid.UUID
 	nodesByID     map[uuid.UUID]Node
 	nodesByNatKey map[string]uuid.UUID // "<cluster_id>/<name>" -> node id
-	pingErr  error
-	createdN int
+	nsByID        map[uuid.UUID]Namespace
+	nsByNatKey    map[string]uuid.UUID // "<cluster_id>/<name>" -> namespace id
+	pingErr       error
+	createdN      int
 }
 
 func newMemStore() *memStore {
@@ -33,10 +35,16 @@ func newMemStore() *memStore {
 		byName:        make(map[string]uuid.UUID),
 		nodesByID:     make(map[uuid.UUID]Node),
 		nodesByNatKey: make(map[string]uuid.UUID),
+		nsByID:        make(map[uuid.UUID]Namespace),
+		nsByNatKey:    make(map[string]uuid.UUID),
 	}
 }
 
 func nodeNatKey(clusterID uuid.UUID, name string) string {
+	return clusterID.String() + "/" + name
+}
+
+func nsNatKey(clusterID uuid.UUID, name string) string {
 	return clusterID.String() + "/" + name
 }
 
@@ -238,6 +246,133 @@ func (m *memStore) DeleteNode(_ context.Context, id uuid.UUID) error {
 	delete(m.nodesByID, id)
 	delete(m.nodesByNatKey, nodeNatKey(n.ClusterId, n.Name))
 	return nil
+}
+
+func (m *memStore) CreateNamespace(_ context.Context, in NamespaceCreate) (Namespace, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.byID[in.ClusterId]; !ok {
+		return Namespace{}, ErrNotFound
+	}
+	key := nsNatKey(in.ClusterId, in.Name)
+	if _, dup := m.nsByNatKey[key]; dup {
+		return Namespace{}, fmt.Errorf("duplicate namespace: %w", ErrConflict)
+	}
+	id := uuid.New()
+	now := time.Now().UTC().Add(time.Duration(m.createdN) * time.Nanosecond)
+	m.createdN++
+	n := Namespace{
+		Id:          &id,
+		ClusterId:   in.ClusterId,
+		Name:        in.Name,
+		DisplayName: in.DisplayName,
+		Phase:       in.Phase,
+		Labels:      in.Labels,
+		CreatedAt:   &now,
+		UpdatedAt:   &now,
+	}
+	m.nsByID[id] = n
+	m.nsByNatKey[key] = id
+	return n, nil
+}
+
+func (m *memStore) GetNamespace(_ context.Context, id uuid.UUID) (Namespace, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n, ok := m.nsByID[id]
+	if !ok {
+		return Namespace{}, ErrNotFound
+	}
+	return n, nil
+}
+
+func (m *memStore) ListNamespaces(_ context.Context, clusterID *uuid.UUID, limit int, _ string) ([]Namespace, string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if limit <= 0 {
+		limit = 50
+	}
+	out := make([]Namespace, 0, len(m.nsByID))
+	for _, n := range m.nsByID {
+		if clusterID != nil && n.ClusterId != *clusterID {
+			continue
+		}
+		out = append(out, n)
+	}
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, "", nil
+}
+
+func (m *memStore) UpdateNamespace(_ context.Context, id uuid.UUID, in NamespaceUpdate) (Namespace, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n, ok := m.nsByID[id]
+	if !ok {
+		return Namespace{}, ErrNotFound
+	}
+	if in.DisplayName != nil {
+		n.DisplayName = in.DisplayName
+	}
+	if in.Phase != nil {
+		n.Phase = in.Phase
+	}
+	if in.Labels != nil {
+		n.Labels = in.Labels
+	}
+	now := time.Now().UTC()
+	n.UpdatedAt = &now
+	m.nsByID[id] = n
+	return n, nil
+}
+
+func (m *memStore) DeleteNamespace(_ context.Context, id uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n, ok := m.nsByID[id]
+	if !ok {
+		return ErrNotFound
+	}
+	delete(m.nsByID, id)
+	delete(m.nsByNatKey, nsNatKey(n.ClusterId, n.Name))
+	return nil
+}
+
+func (m *memStore) UpsertNamespace(_ context.Context, in NamespaceCreate) (Namespace, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.byID[in.ClusterId]; !ok {
+		return Namespace{}, ErrNotFound
+	}
+	key := nsNatKey(in.ClusterId, in.Name)
+	now := time.Now().UTC().Add(time.Duration(m.createdN) * time.Nanosecond)
+	m.createdN++
+
+	if existingID, exists := m.nsByNatKey[key]; exists {
+		n := m.nsByID[existingID]
+		n.DisplayName = in.DisplayName
+		n.Phase = in.Phase
+		n.Labels = in.Labels
+		n.UpdatedAt = &now
+		m.nsByID[existingID] = n
+		return n, nil
+	}
+
+	id := uuid.New()
+	n := Namespace{
+		Id:          &id,
+		ClusterId:   in.ClusterId,
+		Name:        in.Name,
+		DisplayName: in.DisplayName,
+		Phase:       in.Phase,
+		Labels:      in.Labels,
+		CreatedAt:   &now,
+		UpdatedAt:   &now,
+	}
+	m.nsByID[id] = n
+	m.nsByNatKey[key] = id
+	return n, nil
 }
 
 func (m *memStore) UpsertNode(_ context.Context, in NodeCreate) (Node, error) {
@@ -519,6 +654,100 @@ func TestNodeCRUD(t *testing.T) {
 
 	// Delete again → 404
 	del2 := do(h, http.MethodDelete, nodeURL, "")
+	if del2.Code != http.StatusNotFound {
+		t.Errorf("second delete status=%d", del2.Code)
+	}
+}
+
+func TestNamespaceCRUD(t *testing.T) {
+	t.Parallel()
+	store := newMemStore()
+	h := newTestHandler(t, store)
+
+	clusterResp := do(h, http.MethodPost, "/v1/clusters", `{"name":"prod-ns"}`)
+	if clusterResp.Code != http.StatusCreated {
+		t.Fatalf("seed cluster: status=%d body=%q", clusterResp.Code, clusterResp.Body.String())
+	}
+	var cluster Cluster
+	if err := json.Unmarshal(clusterResp.Body.Bytes(), &cluster); err != nil {
+		t.Fatalf("decode cluster: %v", err)
+	}
+	clusterIDStr := cluster.Id.String()
+
+	createBody := fmt.Sprintf(`{"cluster_id":%q,"name":"kube-system","phase":"Active"}`, clusterIDStr)
+	create := do(h, http.MethodPost, "/v1/namespaces", createBody)
+	if create.Code != http.StatusCreated {
+		t.Fatalf("create ns: status=%d body=%q", create.Code, create.Body.String())
+	}
+	if loc := create.Header().Get("Location"); !strings.HasPrefix(loc, "/v1/namespaces/") {
+		t.Errorf("Location=%q", loc)
+	}
+	var ns Namespace
+	if err := json.Unmarshal(create.Body.Bytes(), &ns); err != nil {
+		t.Fatalf("decode ns: %v", err)
+	}
+	if ns.Id == nil {
+		t.Fatal("ns.Id nil")
+	}
+
+	dup := do(h, http.MethodPost, "/v1/namespaces", createBody)
+	if dup.Code != http.StatusConflict {
+		t.Errorf("duplicate namespace status=%d", dup.Code)
+	}
+
+	missing := do(h, http.MethodPost, "/v1/namespaces", fmt.Sprintf(`{"cluster_id":%q,"name":"x"}`, uuid.New().String()))
+	if missing.Code != http.StatusNotFound {
+		t.Errorf("missing cluster create status=%d", missing.Code)
+	}
+
+	nsURL := "/v1/namespaces/" + ns.Id.String()
+
+	get := do(h, http.MethodGet, nsURL, "")
+	if get.Code != http.StatusOK {
+		t.Fatalf("get ns status=%d body=%q", get.Code, get.Body.String())
+	}
+
+	patch := do(h, http.MethodPatch, nsURL, `{"phase":"Terminating"}`)
+	if patch.Code != http.StatusOK {
+		t.Fatalf("patch status=%d body=%q", patch.Code, patch.Body.String())
+	}
+	var patched Namespace
+	if err := json.Unmarshal(patch.Body.Bytes(), &patched); err != nil {
+		t.Fatalf("decode patch: %v", err)
+	}
+	if patched.Phase == nil || *patched.Phase != "Terminating" {
+		t.Errorf("phase=%v", patched.Phase)
+	}
+
+	list := do(h, http.MethodGet, "/v1/namespaces", "")
+	if list.Code != http.StatusOK {
+		t.Fatalf("list status=%d", list.Code)
+	}
+	var page NamespaceList
+	if err := json.Unmarshal(list.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(page.Items) != 1 {
+		t.Errorf("list len=%d", len(page.Items))
+	}
+
+	filtered := do(h, http.MethodGet, "/v1/namespaces?cluster_id="+clusterIDStr, "")
+	if filtered.Code != http.StatusOK {
+		t.Fatalf("filtered list status=%d", filtered.Code)
+	}
+	if err := json.Unmarshal(filtered.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode filtered list: %v", err)
+	}
+	if len(page.Items) != 1 {
+		t.Errorf("filtered list len=%d", len(page.Items))
+	}
+
+	del := do(h, http.MethodDelete, nsURL, "")
+	if del.Code != http.StatusNoContent {
+		t.Errorf("delete status=%d", del.Code)
+	}
+
+	del2 := do(h, http.MethodDelete, nsURL, "")
 	if del2.Code != http.StatusNotFound {
 		t.Errorf("second delete status=%d", del2.Code)
 	}

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -62,4 +62,26 @@ type Store interface {
 	// returned Node always reflects the post-operation state. Returns
 	// ErrNotFound if the parent cluster does not exist.
 	UpsertNode(ctx context.Context, in NodeCreate) (Node, error)
+
+	// CreateNamespace inserts a new namespace. Returns ErrNotFound when the
+	// parent cluster does not exist; ErrConflict when (cluster_id, name)
+	// already has a namespace.
+	CreateNamespace(ctx context.Context, in NamespaceCreate) (Namespace, error)
+
+	// GetNamespace fetches a namespace by id. Returns ErrNotFound if absent.
+	GetNamespace(ctx context.Context, id uuid.UUID) (Namespace, error)
+
+	// ListNamespaces returns up to limit namespaces after the given opaque
+	// cursor. When clusterID is non-nil, results are filtered to that cluster.
+	ListNamespaces(ctx context.Context, clusterID *uuid.UUID, limit int, cursor string) (items []Namespace, nextCursor string, err error)
+
+	// UpdateNamespace applies the merge-patch fields set in in. Returns
+	// ErrNotFound if the namespace does not exist.
+	UpdateNamespace(ctx context.Context, id uuid.UUID, in NamespaceUpdate) (Namespace, error)
+
+	// DeleteNamespace removes a namespace by id. Returns ErrNotFound if absent.
+	DeleteNamespace(ctx context.Context, id uuid.UUID) error
+
+	// UpsertNamespace mirrors UpsertNode for namespaces.
+	UpsertNamespace(ctx context.Context, in NamespaceCreate) (Namespace, error)
 }

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -26,6 +26,13 @@ type NodeInfo struct {
 	Labels         map[string]string
 }
 
+// NamespaceInfo is the subset of a Kubernetes Namespace the collector consumes.
+type NamespaceInfo struct {
+	Name   string
+	Phase  string
+	Labels map[string]string
+}
+
 // VersionFetcher returns the Kubernetes API server version for the cluster
 // it was configured against (typically via kubeconfig or in-cluster config).
 type VersionFetcher interface {
@@ -37,10 +44,16 @@ type NodeLister interface {
 	ListNodes(ctx context.Context) ([]NodeInfo, error)
 }
 
+// NamespaceLister returns every Namespace visible to the configured kubeconfig.
+type NamespaceLister interface {
+	ListNamespaces(ctx context.Context) ([]NamespaceInfo, error)
+}
+
 // KubeSource is the composite contract the Collector consumes.
 type KubeSource interface {
 	VersionFetcher
 	NodeLister
+	NamespaceLister
 }
 
 // cmdbStore is the subset of api.Store the collector consumes.
@@ -48,6 +61,7 @@ type cmdbStore interface {
 	ListClusters(ctx context.Context, limit int, cursor string) ([]api.Cluster, string, error)
 	UpdateCluster(ctx context.Context, id uuid.UUID, in api.ClusterUpdate) (api.Cluster, error)
 	UpsertNode(ctx context.Context, in api.NodeCreate) (api.Node, error)
+	UpsertNamespace(ctx context.Context, in api.NamespaceCreate) (api.Namespace, error)
 }
 
 // Collector polls a KubeSource and reconciles the results into the CMDB
@@ -129,6 +143,7 @@ func (c *Collector) poll(parent context.Context) {
 	}
 
 	c.ingestNodes(ctx, *cluster.Id)
+	c.ingestNamespaces(ctx, *cluster.Id)
 }
 
 // ingestNodes lists nodes from the kube source and upserts each into the
@@ -162,6 +177,36 @@ func (c *Collector) ingestNodes(ctx context.Context, clusterID uuid.UUID) {
 		upserted++
 	}
 	slog.Info("collector: ingested nodes", "upserted", upserted, "failed", failed, "cluster_name", c.clusterName)
+}
+
+// ingestNamespaces lists namespaces from the kube source and upserts each
+// into the store under the given cluster.
+func (c *Collector) ingestNamespaces(ctx context.Context, clusterID uuid.UUID) {
+	namespaces, err := c.source.ListNamespaces(ctx)
+	if err != nil {
+		slog.Warn("collector: list namespaces failed", "error", err, "cluster_name", c.clusterName)
+		return
+	}
+
+	var upserted, failed int
+	for _, ns := range namespaces {
+		in := api.NamespaceCreate{
+			ClusterId: clusterID,
+			Name:      ns.Name,
+			Phase:     ptrIfNonEmpty(ns.Phase),
+		}
+		if len(ns.Labels) > 0 {
+			labels := ns.Labels
+			in.Labels = &labels
+		}
+		if _, err := c.store.UpsertNamespace(ctx, in); err != nil {
+			slog.Warn("collector: upsert namespace failed", "error", err, "namespace", ns.Name, "cluster_name", c.clusterName)
+			failed++
+			continue
+		}
+		upserted++
+	}
+	slog.Info("collector: ingested namespaces", "upserted", upserted, "failed", failed, "cluster_name", c.clusterName)
 }
 
 func ptrIfNonEmpty(s string) *string {

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -15,10 +15,12 @@ import (
 
 // fakeSource implements KubeSource with fixed results.
 type fakeSource struct {
-	version     string
-	versionErr  error
-	nodes       []NodeInfo
-	listNodeErr error
+	version          string
+	versionErr       error
+	nodes            []NodeInfo
+	listNodeErr      error
+	namespaces       []NamespaceInfo
+	listNamespaceErr error
 }
 
 func (f *fakeSource) ServerVersion(_ context.Context) (string, error) {
@@ -29,26 +31,36 @@ func (f *fakeSource) ListNodes(_ context.Context) ([]NodeInfo, error) {
 	return f.nodes, f.listNodeErr
 }
 
+func (f *fakeSource) ListNamespaces(_ context.Context) ([]NamespaceInfo, error) {
+	return f.namespaces, f.listNamespaceErr
+}
+
 type recordedUpdate struct {
 	id    uuid.UUID
 	patch api.ClusterUpdate
 }
 
 type fakeStore struct {
-	mu           sync.Mutex
-	clusters     []api.Cluster
-	updates      []recordedUpdate
-	upsertedNode []api.NodeCreate
-	listErr      error
-	updateErr    error
-	upsertErr    error
+	mu               sync.Mutex
+	clusters         []api.Cluster
+	updates          []recordedUpdate
+	upsertedNode     []api.NodeCreate
+	upsertedNS       []api.NamespaceCreate
+	listErr          error
+	updateErr        error
+	upsertErr        error
+	upsertNSErr      error
 	// nodeState mirrors per-(cluster_id, name) upsert history so tests can
 	// assert idempotent behaviour.
 	nodeState map[string]int // key: cluster_id/name, value: upsert count
+	nsState   map[string]int
 }
 
 func newFakeStore() *fakeStore {
-	return &fakeStore{nodeState: make(map[string]int)}
+	return &fakeStore{
+		nodeState: make(map[string]int),
+		nsState:   make(map[string]int),
+	}
 }
 
 func (s *fakeStore) ListClusters(_ context.Context, _ int, _ string) ([]api.Cluster, string, error) {
@@ -95,6 +107,24 @@ func (s *fakeStore) UpsertNode(_ context.Context, in api.NodeCreate) (api.Node, 
 		ClusterId:      in.ClusterId,
 		Name:           in.Name,
 		KubeletVersion: in.KubeletVersion,
+	}, nil
+}
+
+func (s *fakeStore) UpsertNamespace(_ context.Context, in api.NamespaceCreate) (api.Namespace, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.upsertNSErr != nil {
+		return api.Namespace{}, s.upsertNSErr
+	}
+	s.upsertedNS = append(s.upsertedNS, in)
+	key := in.ClusterId.String() + "/" + in.Name
+	s.nsState[key]++
+	id := uuid.New()
+	return api.Namespace{
+		Id:        &id,
+		ClusterId: in.ClusterId,
+		Name:      in.Name,
+		Phase:     in.Phase,
 	}, nil
 }
 
@@ -282,6 +312,52 @@ func TestPollSkipsNodeIngestionOnListNodesError(t *testing.T) {
 
 	if len(store.upsertedNode) != 0 {
 		t.Errorf("expected no node upserts when ListNodes errors; got %d", len(store.upsertedNode))
+	}
+}
+
+func TestPollIngestsNamespaces(t *testing.T) {
+	t.Parallel()
+	id := uuid.New()
+	store := newFakeStore()
+	store.clusters = []api.Cluster{{Id: &id, Name: "prod"}}
+
+	source := &fakeSource{
+		version: "v1.29.5",
+		namespaces: []NamespaceInfo{
+			{Name: "default", Phase: "Active"},
+			{Name: "kube-system", Phase: "Active", Labels: map[string]string{"role": "system"}},
+		},
+	}
+	c := New(store, source, "prod", time.Minute, time.Second)
+
+	c.poll(context.Background())
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.upsertedNS) != 2 {
+		t.Fatalf("upserted=%d, want 2", len(store.upsertedNS))
+	}
+	if store.upsertedNS[1].Labels == nil || (*store.upsertedNS[1].Labels)["role"] != "system" {
+		t.Errorf("kube-system labels not round-tripped: %v", store.upsertedNS[1].Labels)
+	}
+}
+
+func TestPollSkipsNamespaceIngestionOnListError(t *testing.T) {
+	t.Parallel()
+	id := uuid.New()
+	store := newFakeStore()
+	store.clusters = []api.Cluster{{Id: &id, Name: "prod"}}
+
+	source := &fakeSource{
+		version:          "v1.29.5",
+		listNamespaceErr: errors.New("kube down"),
+	}
+	c := New(store, source, "prod", time.Minute, time.Second)
+
+	c.poll(context.Background())
+
+	if len(store.upsertedNS) != 0 {
+		t.Errorf("expected no namespace upserts on list error; got %d", len(store.upsertedNS))
 	}
 }
 

--- a/internal/collector/kube.go
+++ b/internal/collector/kube.go
@@ -83,3 +83,20 @@ func (k *KubeClient) ListNodes(ctx context.Context) ([]NodeInfo, error) {
 	}
 	return out, nil
 }
+
+// ListNamespaces returns every Namespace visible through the configured kubeconfig.
+func (k *KubeClient) ListNamespaces(ctx context.Context) ([]NamespaceInfo, error) {
+	list, err := k.clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list namespaces: %w", err)
+	}
+	out := make([]NamespaceInfo, 0, len(list.Items))
+	for _, n := range list.Items {
+		out = append(out, NamespaceInfo{
+			Name:   n.Name,
+			Phase:  string(n.Status.Phase),
+			Labels: n.Labels,
+		})
+	}
+	return out, nil
+}

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -454,6 +454,262 @@ func (p *PG) DeleteNode(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
+// CreateNamespace inserts a new namespace.
+func (p *PG) CreateNamespace(ctx context.Context, in api.NamespaceCreate) (api.Namespace, error) {
+	id := uuid.New()
+	now := time.Now().UTC()
+
+	labelsJSON, err := marshalLabels(in.Labels)
+	if err != nil {
+		return api.Namespace{}, err
+	}
+
+	const q = `
+		INSERT INTO namespaces (
+			id, cluster_id, name, display_name, phase,
+			labels, created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $7)
+	`
+	_, err = p.pool.Exec(ctx, q,
+		id, in.ClusterId, in.Name, in.DisplayName, in.Phase,
+		labelsJSON, now,
+	)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) {
+			switch pgErr.Code {
+			case "23505":
+				return api.Namespace{}, fmt.Errorf("namespace %q in cluster %s already exists: %w", in.Name, in.ClusterId, api.ErrConflict)
+			case "23503":
+				return api.Namespace{}, fmt.Errorf("cluster %s does not exist: %w", in.ClusterId, api.ErrNotFound)
+			}
+		}
+		return api.Namespace{}, fmt.Errorf("insert namespace: %w", err)
+	}
+
+	return api.Namespace{
+		Id:          &id,
+		ClusterId:   in.ClusterId,
+		Name:        in.Name,
+		DisplayName: in.DisplayName,
+		Phase:       in.Phase,
+		Labels:      in.Labels,
+		CreatedAt:   &now,
+		UpdatedAt:   &now,
+	}, nil
+}
+
+// GetNamespace fetches a namespace by id.
+func (p *PG) GetNamespace(ctx context.Context, id uuid.UUID) (api.Namespace, error) {
+	const q = `
+		SELECT id, cluster_id, name, display_name, phase,
+		       labels, created_at, updated_at
+		FROM namespaces
+		WHERE id = $1
+	`
+	row := p.pool.QueryRow(ctx, q, id)
+	n, err := scanNamespace(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return api.Namespace{}, api.ErrNotFound
+		}
+		return api.Namespace{}, fmt.Errorf("select namespace: %w", err)
+	}
+	return n, nil
+}
+
+// ListNamespaces returns up to limit namespaces sorted (created_at DESC, id DESC).
+func (p *PG) ListNamespaces(ctx context.Context, clusterID *uuid.UUID, limit int, cursor string) ([]api.Namespace, string, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+
+	sb := strings.Builder{}
+	sb.WriteString(`SELECT id, cluster_id, name, display_name, phase,
+	                       labels, created_at, updated_at
+	                FROM namespaces`)
+	args := make([]any, 0, 4)
+	conds := make([]string, 0, 2)
+
+	if clusterID != nil {
+		args = append(args, *clusterID)
+		conds = append(conds, fmt.Sprintf("cluster_id = $%d", len(args)))
+	}
+	if cursor != "" {
+		ts, cid, err := decodeCursor(cursor)
+		if err != nil {
+			return nil, "", err
+		}
+		args = append(args, ts)
+		tsIdx := len(args)
+		args = append(args, cid)
+		idIdx := len(args)
+		conds = append(conds, fmt.Sprintf("(created_at, id) < ($%d, $%d)", tsIdx, idIdx))
+	}
+	if len(conds) > 0 {
+		sb.WriteString(" WHERE ")
+		sb.WriteString(strings.Join(conds, " AND "))
+	}
+	args = append(args, limit+1)
+	fmt.Fprintf(&sb, " ORDER BY created_at DESC, id DESC LIMIT $%d", len(args))
+
+	rows, err := p.pool.Query(ctx, sb.String(), args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("query namespaces: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]api.Namespace, 0, limit)
+	for rows.Next() {
+		n, err := scanNamespace(rows)
+		if err != nil {
+			return nil, "", fmt.Errorf("scan namespace: %w", err)
+		}
+		items = append(items, n)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", fmt.Errorf("iterate namespaces: %w", err)
+	}
+
+	var next string
+	if len(items) > limit {
+		last := items[limit-1]
+		if last.CreatedAt != nil && last.Id != nil {
+			next = encodeCursor(*last.CreatedAt, *last.Id)
+		}
+		items = items[:limit]
+	}
+	return items, next, nil
+}
+
+// UpdateNamespace applies merge-patch semantics on mutable fields.
+func (p *PG) UpdateNamespace(ctx context.Context, id uuid.UUID, in api.NamespaceUpdate) (api.Namespace, error) {
+	sets := make([]string, 0, 4)
+	args := make([]any, 0, 6)
+	idx := 1
+	appendSet := func(column string, value any) {
+		sets = append(sets, fmt.Sprintf("%s=$%d", column, idx))
+		args = append(args, value)
+		idx++
+	}
+
+	if in.DisplayName != nil {
+		appendSet("display_name", *in.DisplayName)
+	}
+	if in.Phase != nil {
+		appendSet("phase", *in.Phase)
+	}
+	if in.Labels != nil {
+		b, err := marshalLabels(in.Labels)
+		if err != nil {
+			return api.Namespace{}, err
+		}
+		appendSet("labels", b)
+	}
+	appendSet("updated_at", time.Now().UTC())
+	args = append(args, id)
+
+	q := fmt.Sprintf("UPDATE namespaces SET %s WHERE id=$%d", strings.Join(sets, ", "), idx)
+	tag, err := p.pool.Exec(ctx, q, args...)
+	if err != nil {
+		return api.Namespace{}, fmt.Errorf("update namespace: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return api.Namespace{}, api.ErrNotFound
+	}
+	return p.GetNamespace(ctx, id)
+}
+
+// DeleteNamespace removes a namespace by id.
+func (p *PG) DeleteNamespace(ctx context.Context, id uuid.UUID) error {
+	tag, err := p.pool.Exec(ctx, "DELETE FROM namespaces WHERE id=$1", id)
+	if err != nil {
+		return fmt.Errorf("delete namespace: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return api.ErrNotFound
+	}
+	return nil
+}
+
+// UpsertNamespace inserts-or-updates a namespace keyed by (cluster_id, name).
+func (p *PG) UpsertNamespace(ctx context.Context, in api.NamespaceCreate) (api.Namespace, error) {
+	id := uuid.New()
+	now := time.Now().UTC()
+
+	labelsJSON, err := marshalLabels(in.Labels)
+	if err != nil {
+		return api.Namespace{}, err
+	}
+
+	const q = `
+		INSERT INTO namespaces (
+			id, cluster_id, name, display_name, phase,
+			labels, created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $7)
+		ON CONFLICT (cluster_id, name) DO UPDATE SET
+			display_name = EXCLUDED.display_name,
+			phase        = EXCLUDED.phase,
+			labels       = EXCLUDED.labels,
+			updated_at   = EXCLUDED.updated_at
+		RETURNING id, cluster_id, name, display_name, phase,
+		          labels, created_at, updated_at
+	`
+	row := p.pool.QueryRow(ctx, q,
+		id, in.ClusterId, in.Name, in.DisplayName, in.Phase,
+		labelsJSON, now,
+	)
+	n, err := scanNamespace(row)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
+			return api.Namespace{}, fmt.Errorf("cluster %s does not exist: %w", in.ClusterId, api.ErrNotFound)
+		}
+		return api.Namespace{}, fmt.Errorf("upsert namespace: %w", err)
+	}
+	return n, nil
+}
+
+func scanNamespace(row pgx.Row) (api.Namespace, error) {
+	var (
+		n           api.Namespace
+		id          uuid.UUID
+		clusterID   uuid.UUID
+		createdAt   time.Time
+		updatedAt   time.Time
+		displayName sql.NullString
+		phase       sql.NullString
+		labelsJSON  []byte
+	)
+	if err := row.Scan(
+		&id, &clusterID, &n.Name,
+		&displayName, &phase,
+		&labelsJSON,
+		&createdAt, &updatedAt,
+	); err != nil {
+		return api.Namespace{}, err
+	}
+	n.Id = &id
+	n.ClusterId = clusterID
+	n.CreatedAt = &createdAt
+	n.UpdatedAt = &updatedAt
+	n.DisplayName = nullableString(displayName)
+	n.Phase = nullableString(phase)
+	if len(labelsJSON) > 0 {
+		var labels map[string]string
+		if err := json.Unmarshal(labelsJSON, &labels); err != nil {
+			return api.Namespace{}, fmt.Errorf("unmarshal namespace labels: %w", err)
+		}
+		if len(labels) > 0 {
+			n.Labels = &labels
+		}
+	}
+	return n, nil
+}
+
 // UpsertNode inserts-or-updates a node keyed by (cluster_id, name). The
 // unique index on (cluster_id, name) drives the ON CONFLICT target. On
 // conflict only mutable columns are overwritten so created_at is preserved.

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -221,6 +221,100 @@ func TestPGUpsertNode(t *testing.T) {
 	}
 }
 
+func TestPGNamespaceCRUD(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, err := pg.CreateCluster(ctx, api.ClusterCreate{Name: "ns-test"})
+	if err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	phase := "Active"
+	ns, err := pg.CreateNamespace(ctx, api.NamespaceCreate{
+		ClusterId: *cluster.Id,
+		Name:      "kube-system",
+		Phase:     &phase,
+	})
+	if err != nil {
+		t.Fatalf("create ns: %v", err)
+	}
+
+	if _, err := pg.CreateNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "kube-system"}); !errors.Is(err, api.ErrConflict) {
+		t.Errorf("duplicate should be ErrConflict, got %v", err)
+	}
+	if _, err := pg.CreateNamespace(ctx, api.NamespaceCreate{ClusterId: uuid.New(), Name: "x"}); !errors.Is(err, api.ErrNotFound) {
+		t.Errorf("unknown cluster should be ErrNotFound, got %v", err)
+	}
+
+	newPhase := "Terminating"
+	updated, err := pg.UpdateNamespace(ctx, *ns.Id, api.NamespaceUpdate{Phase: &newPhase})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.Phase == nil || *updated.Phase != newPhase {
+		t.Errorf("phase=%v", updated.Phase)
+	}
+
+	items, _, err := pg.ListNamespaces(ctx, cluster.Id, 10, "")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(items) != 1 {
+		t.Errorf("list len=%d", len(items))
+	}
+
+	// Cascade: deleting cluster removes namespaces.
+	if err := pg.DeleteCluster(ctx, *cluster.Id); err != nil {
+		t.Fatalf("delete cluster: %v", err)
+	}
+	if _, err := pg.GetNamespace(ctx, *ns.Id); !errors.Is(err, api.ErrNotFound) {
+		t.Errorf("namespace should have cascaded, got %v", err)
+	}
+}
+
+func TestPGUpsertNamespace(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, err := pg.CreateCluster(ctx, api.ClusterCreate{Name: "ns-upsert"})
+	if err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	phaseA := "Active"
+	first, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
+		ClusterId: *cluster.Id,
+		Name:      "default",
+		Phase:     &phaseA,
+	})
+	if err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+
+	phaseB := "Terminating"
+	second, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
+		ClusterId: *cluster.Id,
+		Name:      "default",
+		Phase:     &phaseB,
+	})
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if *second.Id != *first.Id {
+		t.Errorf("id changed across upsert: first=%v second=%v", *first.Id, *second.Id)
+	}
+	if second.Phase == nil || *second.Phase != phaseB {
+		t.Errorf("phase=%v", second.Phase)
+	}
+	if !second.CreatedAt.Equal(*first.CreatedAt) {
+		t.Errorf("created_at changed: first=%v second=%v", first.CreatedAt, second.CreatedAt)
+	}
+	if !second.UpdatedAt.After(*first.UpdatedAt) {
+		t.Errorf("updated_at did not advance: first=%v second=%v", first.UpdatedAt, second.UpdatedAt)
+	}
+}
+
 func TestPGListPagination(t *testing.T) {
 	pg := newTestPG(t)
 	ctx := context.Background()

--- a/migrations/00003_create_namespaces.sql
+++ b/migrations/00003_create_namespaces.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+CREATE TABLE namespaces (
+    id            UUID PRIMARY KEY,
+    cluster_id    UUID NOT NULL REFERENCES clusters(id) ON DELETE CASCADE,
+    name          TEXT NOT NULL,
+    display_name  TEXT,
+    phase         TEXT,
+    labels        JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at    TIMESTAMPTZ NOT NULL,
+    updated_at    TIMESTAMPTZ NOT NULL,
+    UNIQUE (cluster_id, name)
+);
+
+CREATE INDEX namespaces_cluster_id_idx ON namespaces (cluster_id);
+CREATE INDEX namespaces_created_at_id_idx ON namespaces (created_at DESC, id DESC);
+
+-- +goose Down
+DROP INDEX IF EXISTS namespaces_created_at_id_idx;
+DROP INDEX IF EXISTS namespaces_cluster_id_idx;
+DROP TABLE IF EXISTS namespaces;


### PR DESCRIPTION
Mirrors the Node pattern end-to-end, bundled with collector ingestion now that the shape is well-understood.

Contract:
- api/openapi/openapi.yaml: new 'namespaces' tag, /v1/namespaces and /v1/namespaces/{id} endpoints with the same per-op scope model (read / write / delete) and cursor pagination. List accepts ?cluster_id=<uuid> to filter. Schemas NamespaceMutable / Create / Update / Namespace / List mirror Node. cluster_id and name are immutable post-creation; mutable fields are display_name, phase, labels. name pattern follows K8s DNS-label rules (max 63 chars).
- internal/api/api.gen.go regenerated.

Schema and persistence:
- migrations/00003_create_namespaces.sql creates the namespaces table with a UUID PK, FK cluster_id -> clusters(id) ON DELETE CASCADE, (cluster_id, name) uniqueness, and supporting indexes.
- internal/api/store.go adds six new methods: CreateNamespace, GetNamespace, ListNamespaces, UpdateNamespace, DeleteNamespace, UpsertNamespace. UpsertNamespace mirrors UpsertNode: INSERT ... ON CONFLICT (cluster_id, name) DO UPDATE ... RETURNING with created_at preserved and updated_at bumped.
- internal/store/pg.go implements the six methods with the same 23505 -> Conflict, 23503 -> NotFound error-code mapping used by Node.

Handlers and tests:
- internal/api/server.go: five handlers mirroring Node.
- internal/api/server_test.go: memStore fake extended with namespace maps; TestNamespaceCRUD covers create / duplicate 409 / unknown- cluster 404 / get / patch / list / filtered-list / delete.
- internal/store/pg_test.go: TestPGNamespaceCRUD verifies CASCADE on cluster delete; TestPGUpsertNamespace verifies the id-preserved / created_at-preserved / updated_at-advances upsert contract.

Collector:
- internal/collector/collector.go: KubeSource composite grows NamespaceLister; cmdbStore grows UpsertNamespace. poll() runs ingestNamespaces after ingestNodes so one failing ingest doesn't block the other. NamespaceInfo DTO mirrors NodeInfo semantics (empty labels kept as nil pointer, not pointer-to-empty).
- internal/collector/kube.go: KubeClient.ListNamespaces via CoreV1().Namespaces().List, mapping corev1.Namespace -> NamespaceInfo.
- internal/collector/collector_test.go: fakeSource implements ListNamespaces; fakeStore tracks upserted namespaces. New tests cover namespace ingestion with labels and short-circuiting when ListNamespaces errors.

No new env vars; namespace ingestion runs on the existing ARGOS_COLLECTOR_ENABLED toggle.