### PR TITLE
refactor(collector): replace paginated scan with GetClusterByName

### DIFF
--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -87,6 +87,16 @@ func (m *memStore) GetCluster(_ context.Context, id uuid.UUID) (Cluster, error) 
 	return c, nil
 }
 
+func (m *memStore) GetClusterByName(_ context.Context, name string) (Cluster, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	id, ok := m.byName[name]
+	if !ok {
+		return Cluster{}, ErrNotFound
+	}
+	return m.byID[id], nil
+}
+
 func (m *memStore) ListClusters(_ context.Context, limit int, _ string) ([]Cluster, string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -27,6 +27,10 @@ type Store interface {
 	// GetCluster fetches a cluster by id. Returns ErrNotFound if absent.
 	GetCluster(ctx context.Context, id uuid.UUID) (Cluster, error)
 
+	// GetClusterByName fetches a cluster by its unique slug-like name.
+	// Returns ErrNotFound when no cluster carries that name.
+	GetClusterByName(ctx context.Context, name string) (Cluster, error)
+
 	// ListClusters returns up to limit clusters after the given opaque cursor,
 	// plus the cursor for the next page (empty when exhausted).
 	ListClusters(ctx context.Context, limit int, cursor string) (items []Cluster, nextCursor string, err error)

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -6,7 +6,6 @@ package collector
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -58,7 +57,7 @@ type KubeSource interface {
 
 // cmdbStore is the subset of api.Store the collector consumes.
 type cmdbStore interface {
-	ListClusters(ctx context.Context, limit int, cursor string) ([]api.Cluster, string, error)
+	GetClusterByName(ctx context.Context, name string) (api.Cluster, error)
 	UpdateCluster(ctx context.Context, id uuid.UUID, in api.ClusterUpdate) (api.Cluster, error)
 	UpsertNode(ctx context.Context, in api.NodeCreate) (api.Node, error)
 	UpsertNamespace(ctx context.Context, in api.NamespaceCreate) (api.Namespace, error)
@@ -120,9 +119,9 @@ func (c *Collector) poll(parent context.Context) {
 		return
 	}
 
-	cluster, err := c.findClusterByName(ctx, c.clusterName)
+	cluster, err := c.store.GetClusterByName(ctx, c.clusterName)
 	if err != nil {
-		if errors.Is(err, errClusterNotFound) {
+		if errors.Is(err, api.ErrNotFound) {
 			slog.Warn("collector: cluster not registered; POST /v1/clusters first", "cluster_name", c.clusterName)
 			return
 		}
@@ -216,27 +215,3 @@ func ptrIfNonEmpty(s string) *string {
 	return &s
 }
 
-var errClusterNotFound = errors.New("cluster not found by name")
-
-// findClusterByName scans paginated store output and returns the first match.
-// For v1 scope (a handful of clusters) a linear scan is adequate; a dedicated
-// GetByName store method is a follow-up.
-func (c *Collector) findClusterByName(ctx context.Context, name string) (api.Cluster, error) {
-	const pageSize = 200
-	cursor := ""
-	for {
-		items, next, err := c.store.ListClusters(ctx, pageSize, cursor)
-		if err != nil {
-			return api.Cluster{}, fmt.Errorf("list clusters: %w", err)
-		}
-		for _, cl := range items {
-			if cl.Name == name {
-				return cl, nil
-			}
-		}
-		if next == "" {
-			return api.Cluster{}, errClusterNotFound
-		}
-		cursor = next
-	}
-}

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -63,15 +63,18 @@ func newFakeStore() *fakeStore {
 	}
 }
 
-func (s *fakeStore) ListClusters(_ context.Context, _ int, _ string) ([]api.Cluster, string, error) {
+func (s *fakeStore) GetClusterByName(_ context.Context, name string) (api.Cluster, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.listErr != nil {
-		return nil, "", s.listErr
+		return api.Cluster{}, s.listErr
 	}
-	out := make([]api.Cluster, len(s.clusters))
-	copy(out, s.clusters)
-	return out, "", nil
+	for _, c := range s.clusters {
+		if c.Name == name {
+			return c, nil
+		}
+	}
+	return api.Cluster{}, api.ErrNotFound
 }
 
 func (s *fakeStore) UpdateCluster(_ context.Context, id uuid.UUID, in api.ClusterUpdate) (api.Cluster, error) {
@@ -185,7 +188,7 @@ func TestPollSkipsOnVersionError(t *testing.T) {
 	}
 }
 
-func TestPollSkipsOnListClustersError(t *testing.T) {
+func TestPollSkipsOnGetClusterByNameError(t *testing.T) {
 	t.Parallel()
 	store := newFakeStore()
 	store.listErr = errors.New("db down")
@@ -194,7 +197,7 @@ func TestPollSkipsOnListClustersError(t *testing.T) {
 	c.poll(context.Background())
 
 	if len(store.updates) != 0 || len(store.upsertedNode) != 0 {
-		t.Errorf("expected no store writes on list error")
+		t.Errorf("expected no store writes on lookup error")
 	}
 }
 

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -129,6 +129,25 @@ func (p *PG) GetCluster(ctx context.Context, id uuid.UUID) (api.Cluster, error) 
 	return c, nil
 }
 
+// GetClusterByName fetches a cluster by its unique name column.
+func (p *PG) GetClusterByName(ctx context.Context, name string) (api.Cluster, error) {
+	const q = `
+		SELECT id, name, display_name, environment, provider, region,
+		       kubernetes_version, api_endpoint, labels, created_at, updated_at
+		FROM clusters
+		WHERE name = $1
+	`
+	row := p.pool.QueryRow(ctx, q, name)
+	c, err := scanCluster(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return api.Cluster{}, api.ErrNotFound
+		}
+		return api.Cluster{}, fmt.Errorf("select cluster by name: %w", err)
+	}
+	return c, nil
+}
+
 // ListClusters returns up to limit clusters in (created_at DESC, id DESC) order,
 // starting after the opaque cursor if non-empty.
 func (p *PG) ListClusters(ctx context.Context, limit int, cursor string) ([]api.Cluster, string, error) {

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -315,6 +315,28 @@ func TestPGUpsertNamespace(t *testing.T) {
 	}
 }
 
+func TestPGGetClusterByName(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	created, err := pg.CreateCluster(ctx, api.ClusterCreate{Name: "by-name-test"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := pg.GetClusterByName(ctx, "by-name-test")
+	if err != nil {
+		t.Fatalf("lookup by name: %v", err)
+	}
+	if got.Id == nil || *got.Id != *created.Id {
+		t.Errorf("id mismatch: got=%v created=%v", got.Id, created.Id)
+	}
+
+	if _, err := pg.GetClusterByName(ctx, "does-not-exist"); !errors.Is(err, api.ErrNotFound) {
+		t.Errorf("missing cluster: want ErrNotFound, got %v", err)
+	}
+}
+
 func TestPGListPagination(t *testing.T) {
 	pg := newTestPG(t)
 	ctx := context.Background()


### PR DESCRIPTION
The collector's findClusterByName helper iterated ListClusters in pages just to find a single row by its unique name column. Replaces that with a targeted store lookup driven by the existing UNIQUE index on clusters.name.

- internal/api/store.go grows GetClusterByName(ctx, name) (Cluster, error).
- internal/store/pg.go implements it with a single-row SELECT; pgx.ErrNoRows maps to api.ErrNotFound like the other by-id getters.
- internal/api/server_test.go memStore gains the corresponding fake.
- internal/store/pg_test.go TestPGGetClusterByName covers the hit and miss paths.
- internal/collector/collector.go drops findClusterByName and the errClusterNotFound sentinel, shrinks the local cmdbStore contract (ListClusters no longer needed, replaced by GetClusterByName), and checks api.ErrNotFound directly in poll().
- internal/collector/collector_test.go replaces ListClusters on the fakeStore with GetClusterByName; TestPollSkipsOnListClustersError is renamed to reflect the new code path.

No behaviour change visible from the outside: poll still logs the same "cluster not registered" warning when the cluster is missing, and the collector coverage stays in the same ballpark.