### PR TITLE
ci: enforce Conventional Commits on PR commits and title

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,2 @@
+extends:
+  - '@commitlint/config-conventional'

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,32 @@
+name: Commit Lint
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: commitlint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  commits:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v6
+
+  pr-title:
+    name: Conventional PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add commit-lint workflow that runs on pull_request to main, gating merges on two independent jobs: per-commit linting via wagoid/commitlint-github-action and PR-title validation via amannn/action-semantic-pull-request. The latter is what matters under the squash-merge strategy, since the PR title becomes the single squashed commit on main.