### PR TITLE
feat(ui): admin panel (users + tokens + sessions) — PR 2/3

### DIFF
--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -415,7 +415,16 @@ func (s *Server) ListSessions(w http.ResponseWriter, r *http.Request, params Lis
 }
 
 func (s *Server) RevokeSession(w http.ResponseWriter, r *http.Request, id SessionId) {
-	if err := s.store.DeleteSession(r.Context(), id); err != nil {
+	// Path parameter is OpenAPI-typed as `string, maxLength: 64` for
+	// backwards-compat; parse as UUID here (that's the public_id form
+	// ListSessions surfaces). Anything that doesn't parse cleanly
+	// is a 400 — don't dignify cookie-value guesses with 404.
+	publicID, err := uuid.Parse(id)
+	if err != nil {
+		writeProblem(w, http.StatusBadRequest, "Invalid session id", "expected a UUID")
+		return
+	}
+	if err := s.store.DeleteSessionByPublicID(r.Context(), publicID); err != nil {
 		s.writeStoreError(w, "revokeSession", err)
 		return
 	}

--- a/internal/api/server_auth_fake_test.go
+++ b/internal/api/server_auth_fake_test.go
@@ -29,6 +29,7 @@ type memAuthState struct {
 
 type memSession struct {
 	id         string
+	publicID   uuid.UUID
 	userID     uuid.UUID
 	created    time.Time
 	lastUsed   time.Time
@@ -238,6 +239,7 @@ func (m *memStore) CreateSession(_ context.Context, in SessionInsert) error {
 	defer m.mu.Unlock()
 	m.authState.sessions[in.ID] = memSession{
 		id:        in.ID,
+		publicID:  uuid.New(),
 		userID:    in.UserID,
 		created:   in.CreatedAt,
 		lastUsed:  in.CreatedAt,
@@ -304,6 +306,18 @@ func (m *memStore) DeleteSession(_ context.Context, id string) error {
 	return nil
 }
 
+func (m *memStore) DeleteSessionByPublicID(_ context.Context, publicID uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for id, s := range m.authState.sessions {
+		if s.publicID == publicID {
+			delete(m.authState.sessions, id)
+			return nil
+		}
+	}
+	return ErrNotFound
+}
+
 func (m *memStore) DeleteSessionsForUser(_ context.Context, userID uuid.UUID) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -338,12 +352,8 @@ func (m *memStore) ListSessions(_ context.Context, limit int, _ string) ([]Sessi
 		}
 		uid := s.userID
 		u := m.authState.users[s.userID]
-		masked := s.id
-		if len(masked) > 8 {
-			masked = masked[:8] + "…"
-		}
 		out = append(out, Session{
-			Id:         masked,
+			Id:         s.publicID.String(),
 			UserId:     uid,
 			Username:   &u.Username,
 			CreatedAt:  s.created,

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -318,8 +318,13 @@ type Store interface {
 	// needs after a session resolves.
 	GetUserForAuth(ctx context.Context, id uuid.UUID) (auth.User, error)
 
-	// DeleteSession revokes a single session by id.
+	// DeleteSession revokes a single session by its cookie-value id.
+	// Used by the logout handler which reads the cookie from ctx.
 	DeleteSession(ctx context.Context, id string) error
+
+	// DeleteSessionByPublicID revokes by the UUID public handle. Used
+	// by the admin revoke endpoint so cookie values never leave the DB.
+	DeleteSessionByPublicID(ctx context.Context, publicID uuid.UUID) error
 
 	// DeleteSessionsForUser revokes all active sessions for a user. Called
 	// when the user is disabled or changes their password.

--- a/internal/store/pg_auth.go
+++ b/internal/store/pg_auth.go
@@ -314,10 +314,13 @@ func (p *PG) CreateSession(ctx context.Context, in api.SessionInsert) error {
 	if in.SourceIP == "" {
 		sourceIP = nil
 	}
+	// public_id is populated by the DB (gen_random_uuid() default would
+	// work too, but explicit here keeps the SQL self-contained).
+	publicID := uuid.New()
 	_, err := p.pool.Exec(ctx,
-		`INSERT INTO sessions (id, user_id, created_at, last_used_at, expires_at, user_agent, source_ip)
-		 VALUES ($1, $2, $3, $3, $4, $5, $6)`,
-		in.ID, in.UserID, in.CreatedAt, in.ExpiresAt, userAgent, sourceIP,
+		`INSERT INTO sessions (id, public_id, user_id, created_at, last_used_at, expires_at, user_agent, source_ip)
+		 VALUES ($1, $2, $3, $4, $4, $5, $6, $7)`,
+		in.ID, publicID, in.UserID, in.CreatedAt, in.ExpiresAt, userAgent, sourceIP,
 	)
 	if err != nil {
 		return fmt.Errorf("insert session: %w", err)
@@ -353,10 +356,25 @@ func (p *PG) TouchSession(ctx context.Context, id string, now, newExpiry time.Ti
 	return nil
 }
 
+// DeleteSession revokes the session whose cookie value is `id`. Used by
+// the logout handler, where the caller has the cookie from ctx.
 func (p *PG) DeleteSession(ctx context.Context, id string) error {
 	tag, err := p.pool.Exec(ctx, `DELETE FROM sessions WHERE id = $1`, id)
 	if err != nil {
 		return fmt.Errorf("delete session: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return api.ErrNotFound
+	}
+	return nil
+}
+
+// DeleteSessionByPublicID revokes by public_id, the UUID handle surfaced
+// to admins. Admins never see cookie values, so they use this path.
+func (p *PG) DeleteSessionByPublicID(ctx context.Context, publicID uuid.UUID) error {
+	tag, err := p.pool.Exec(ctx, `DELETE FROM sessions WHERE public_id = $1`, publicID)
+	if err != nil {
+		return fmt.Errorf("delete session by public_id: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
 		return api.ErrNotFound
@@ -372,6 +390,9 @@ func (p *PG) DeleteSessionsForUser(ctx context.Context, userID uuid.UUID) error 
 	return nil
 }
 
+// ListSessions returns active sessions, surfacing each row's public_id
+// (not the cookie value) as the API-facing `id`. Cookie values never
+// leave the database.
 func (p *PG) ListSessions(ctx context.Context, limit int, cursor string) ([]api.Session, string, error) {
 	if limit <= 0 {
 		limit = 50
@@ -380,7 +401,7 @@ func (p *PG) ListSessions(ctx context.Context, limit int, cursor string) ([]api.
 		limit = 200
 	}
 	sb := strings.Builder{}
-	sb.WriteString(`SELECT s.id, s.user_id, u.username, s.created_at, s.last_used_at,
+	sb.WriteString(`SELECT s.public_id, s.user_id, u.username, s.created_at, s.last_used_at,
 	                       s.expires_at, s.user_agent, s.source_ip
 	                FROM sessions s
 	                JOIN users u ON u.id = s.user_id
@@ -393,14 +414,12 @@ func (p *PG) ListSessions(ctx context.Context, limit int, cursor string) ([]api.
 		}
 		args = append(args, ts)
 		tsIdx := len(args)
-		// Session id is TEXT, not UUID — we cast the cid to text so the
-		// cursor tuple comparison works on a homogeneous type.
-		args = append(args, cid.String())
+		args = append(args, cid)
 		idIdx := len(args)
-		sb.WriteString(fmt.Sprintf(" AND (s.created_at, s.id) < ($%d, $%d)", tsIdx, idIdx))
+		sb.WriteString(fmt.Sprintf(" AND (s.created_at, s.public_id) < ($%d, $%d)", tsIdx, idIdx))
 	}
 	args = append(args, limit+1)
-	fmt.Fprintf(&sb, " ORDER BY s.created_at DESC, s.id DESC LIMIT $%d", len(args))
+	fmt.Fprintf(&sb, " ORDER BY s.created_at DESC, s.public_id DESC LIMIT $%d", len(args))
 
 	rows, err := p.pool.Query(ctx, sb.String(), args...)
 	if err != nil {
@@ -409,39 +428,37 @@ func (p *PG) ListSessions(ctx context.Context, limit int, cursor string) ([]api.
 	defer rows.Close()
 
 	items := make([]api.Session, 0, limit)
+	var lastPublicID uuid.UUID
 	for rows.Next() {
 		var (
-			s          api.Session
-			userAgent  *string
-			sourceIP   *string
-			username   string
+			s         api.Session
+			publicID  uuid.UUID
+			userAgent *string
+			sourceIP  *string
+			username  string
 		)
 		if err := rows.Scan(
-			&s.Id, &s.UserId, &username,
+			&publicID, &s.UserId, &username,
 			&s.CreatedAt, &s.LastUsedAt, &s.ExpiresAt,
 			&userAgent, &sourceIP,
 		); err != nil {
 			return nil, "", fmt.Errorf("scan session: %w", err)
 		}
+		s.Id = publicID.String()
 		s.Username = &username
 		s.UserAgent = userAgent
 		s.SourceIp = sourceIP
-		// Mask the id so the admin list doesn't leak cookie values
-		// wholesale. First 8 chars is enough to disambiguate.
-		if len(s.Id) > 8 {
-			s.Id = s.Id[:8] + "…"
-		}
 		items = append(items, s)
+		lastPublicID = publicID
 	}
 	if err := rows.Err(); err != nil {
 		return nil, "", fmt.Errorf("iterate sessions: %w", err)
 	}
 
-	// Cursor pagination uses the UN-masked ids; since we already
-	// truncated, disable next-page generation past the first batch.
-	// Admin sessions lists are typically short; revisit if needed.
 	var next string
 	if len(items) > limit {
+		last := items[limit-1]
+		next = encodeCursor(last.CreatedAt, lastPublicID)
 		items = items[:limit]
 	}
 	return items, next, nil

--- a/migrations/00015_sessions_public_id.sql
+++ b/migrations/00015_sessions_public_id.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+-- Add a server-generated UUID to sessions so admins can address a row
+-- without ever seeing the cookie value. The cookie value stays as the
+-- primary key (used by the middleware for lookup); the new `public_id`
+-- is what the admin-facing list / revoke endpoints expose.
+--
+-- Matters for security: if an admin (or a database reader) could see
+-- another user's cookie value, they could impersonate that user. The
+-- public_id has no authentication weight — it's purely a handle.
+ALTER TABLE sessions
+    ADD COLUMN public_id UUID;
+
+-- Backfill existing rows (none in production yet — this is the first
+-- post-ADR-0007 migration — but be safe).
+UPDATE sessions SET public_id = gen_random_uuid() WHERE public_id IS NULL;
+
+ALTER TABLE sessions
+    ALTER COLUMN public_id SET NOT NULL,
+    ADD CONSTRAINT sessions_public_id_uniq UNIQUE (public_id);
+
+-- +goose Down
+ALTER TABLE sessions
+    DROP CONSTRAINT IF EXISTS sessions_public_id_uniq,
+    DROP COLUMN IF EXISTS public_id;

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -23,6 +23,10 @@ import {
   NodeDetail,
   IngressDetail,
 } from './pages/Details';
+import AdminLayout from './pages/admin/AdminLayout';
+import UsersPage from './pages/admin/Users';
+import TokensPage from './pages/admin/Tokens';
+import SessionsPage from './pages/admin/Sessions';
 
 // --- auth gate ----------------------------------------------------------
 
@@ -67,6 +71,17 @@ function RequireAuth({ auth, children }: { auth: AuthState; children: React.Reac
   return <>{children}</>;
 }
 
+// RequireAdmin wraps the admin routes. Server-side the /v1/admin/*
+// endpoints already enforce admin; this is just UX — redirect
+// non-admins back to /clusters instead of letting them browse pages
+// that will 403 every request.
+function RequireAdmin({ auth, children }: { auth: AuthState; children: React.ReactNode }) {
+  if (auth.status === 'ready' && auth.me.role !== 'admin') {
+    return <Navigate to="/clusters" replace />;
+  }
+  return <>{children}</>;
+}
+
 // --- chrome -------------------------------------------------------------
 
 function Chrome({ me, children }: { me: api.Me; children: React.ReactNode }) {
@@ -100,6 +115,7 @@ function Chrome({ me, children }: { me: api.Me; children: React.ReactNode }) {
             {link('/persistentvolumes', 'PVs')}
             {link('/persistentvolumeclaims', 'PVCs')}
             {link('/search/image', 'Search')}
+            {me.role === 'admin' && link('/admin/users', 'Admin')}
           </nav>
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -170,6 +186,21 @@ export default function App() {
       <Route path="/persistentvolumeclaims" element={authed(<PersistentVolumeClaims />)} />
 
       <Route path="/search/image" element={authed(<ImageSearch />)} />
+
+      {/* Admin panel — only renders the layout when the caller is admin. */}
+      <Route
+        path="/admin"
+        element={authed(
+          <RequireAdmin auth={auth}>
+            <AdminLayout />
+          </RequireAdmin>,
+        )}
+      >
+        <Route index element={<Navigate to="users" replace />} />
+        <Route path="users" element={<UsersPage />} />
+        <Route path="tokens" element={<TokensPage />} />
+        <Route path="sessions" element={<SessionsPage />} />
+      </Route>
 
       <Route path="*" element={<Navigate to="/clusters" replace />} />
     </Routes>

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -92,6 +92,107 @@ export function changePassword(currentPassword: string, newPassword: string): Pr
   });
 }
 
+// --- Admin --------------------------------------------------------------
+
+export interface User {
+  id: string;
+  username: string;
+  role: Role;
+  must_change_password?: boolean;
+  created_at: string;
+  updated_at: string;
+  last_login_at?: string | null;
+  disabled_at?: string | null;
+}
+
+export interface UserCreate {
+  username: string;
+  password: string;
+  role: Role;
+  must_change_password?: boolean;
+}
+
+export interface UserUpdate {
+  role?: Role;
+  password?: string;
+  must_change_password?: boolean;
+  disabled?: boolean;
+}
+
+export function listUsers() {
+  return request<PagedResponse<User>>('/v1/admin/users?limit=200');
+}
+export function createUser(in_: UserCreate) {
+  return request<User>('/v1/admin/users', { method: 'POST', body: JSON.stringify(in_) });
+}
+export function updateUser(id: string, patch: UserUpdate) {
+  return request<User>(`/v1/admin/users/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(patch),
+    headers: { 'Content-Type': 'application/merge-patch+json' },
+  });
+}
+export function deleteUser(id: string) {
+  return request<void>(`/v1/admin/users/${id}`, { method: 'DELETE' });
+}
+
+// Scopes that an admin may grant to a machine token. The backend
+// rejects `admin` and `audit` for tokens (admin-only endpoints are
+// session-only for accountability).
+export type TokenScope = 'read' | 'write' | 'delete';
+
+export interface ApiToken {
+  id: string;
+  name: string;
+  prefix: string;
+  scopes: string[];
+  created_by_user_id: string;
+  created_at: string;
+  last_used_at?: string | null;
+  expires_at?: string | null;
+  revoked_at?: string | null;
+}
+
+// Returned only by createApiToken — carries the plaintext token that
+// must be shown to the user exactly once.
+export interface ApiTokenMint extends ApiToken {
+  token: string;
+}
+
+export interface ApiTokenCreate {
+  name: string;
+  scopes: TokenScope[];
+  expires_at?: string | null;
+}
+
+export function listApiTokens() {
+  return request<PagedResponse<ApiToken>>('/v1/admin/tokens?limit=200');
+}
+export function createApiToken(in_: ApiTokenCreate) {
+  return request<ApiTokenMint>('/v1/admin/tokens', { method: 'POST', body: JSON.stringify(in_) });
+}
+export function revokeApiToken(id: string) {
+  return request<void>(`/v1/admin/tokens/${id}`, { method: 'DELETE' });
+}
+
+export interface Session {
+  id: string; // server returns a masked "<first8>…" value, never the full cookie value
+  user_id: string;
+  username?: string;
+  created_at: string;
+  last_used_at: string;
+  expires_at: string;
+  user_agent?: string | null;
+  source_ip?: string | null;
+}
+
+export function listSessions() {
+  return request<PagedResponse<Session>>('/v1/admin/sessions?limit=200');
+}
+export function revokeSession(id: string) {
+  return request<void>(`/v1/admin/sessions/${id}`, { method: 'DELETE' });
+}
+
 // Shared shapes ------------------------------------------------------------
 
 export interface PagedResponse<T> {

--- a/ui/src/pages/admin/AdminLayout.tsx
+++ b/ui/src/pages/admin/AdminLayout.tsx
@@ -1,0 +1,28 @@
+import { NavLink, Outlet } from 'react-router-dom';
+
+// AdminLayout wraps the three admin sub-pages with a shared tab-style
+// sub-nav. The outer <Chrome> (top nav + role pill + sign-out) comes
+// from App.tsx; this layout sits inside <main>.
+
+export default function AdminLayout() {
+  const tab = (to: string, label: string) => (
+    <NavLink
+      to={to}
+      className={({ isActive }) => 'admin-tab' + (isActive ? ' active' : '')}
+      end
+    >
+      {label}
+    </NavLink>
+  );
+  return (
+    <>
+      <h2>Admin</h2>
+      <nav className="admin-subnav">
+        {tab('/admin/users', 'Users')}
+        {tab('/admin/tokens', 'Machine tokens')}
+        {tab('/admin/sessions', 'Active sessions')}
+      </nav>
+      <Outlet />
+    </>
+  );
+}

--- a/ui/src/pages/admin/Sessions.tsx
+++ b/ui/src/pages/admin/Sessions.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import * as api from '../../api';
+import { useResource } from '../../hooks';
+import { AsyncView, Dash, SectionTitle } from '../../components';
+
+// Admin Sessions page. Read-only table with a revoke action. The `id`
+// column is the server-side public UUID, never the cookie value —
+// admins can address a row without being able to impersonate the user
+// by copying it into their own browser.
+
+export default function SessionsPage() {
+  const [nonce, setNonce] = useState(0);
+  const reload = () => setNonce((n) => n + 1);
+  const state = useResource(() => api.listSessions(), [nonce]);
+
+  return (
+    <AsyncView state={state}>
+      {(resp) => (
+        <>
+          <SectionTitle count={resp.items.length}>Active sessions</SectionTitle>
+          <p className="muted" style={{ fontSize: '0.85rem', marginTop: 0 }}>
+            Only non-expired sessions are listed. Revoking a session logs that
+            user's tab out server-side — the next request the browser makes
+            bounces back to the login page.
+          </p>
+          {resp.items.length === 0 ? (
+            <p className="muted">No active sessions.</p>
+          ) : (
+            <table className="entities">
+              <thead>
+                <tr>
+                  <th>User</th>
+                  <th>Created</th>
+                  <th>Last used</th>
+                  <th>Expires</th>
+                  <th>User agent</th>
+                  <th>Source IP</th>
+                  <th style={{ textAlign: 'right' }}>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {resp.items.map((s) => (
+                  <SessionRow key={s.id} session={s} reload={reload} />
+                ))}
+              </tbody>
+            </table>
+          )}
+        </>
+      )}
+    </AsyncView>
+  );
+}
+
+function SessionRow({ session, reload }: { session: api.Session; reload: () => void }) {
+  const [busy, setBusy] = useState(false);
+  const revoke = async () => {
+    if (!confirm(`Revoke session for ${session.username || session.user_id}?`)) return;
+    setBusy(true);
+    try {
+      await api.revokeSession(session.id);
+      reload();
+    } catch (err) {
+      alert(err instanceof api.ApiError ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <tr>
+      <td>
+        <strong>{session.username || session.user_id}</strong>
+      </td>
+      <td>{formatTs(session.created_at)}</td>
+      <td>{formatTs(session.last_used_at)}</td>
+      <td>{formatTs(session.expires_at)}</td>
+      <td>
+        {session.user_agent ? (
+          <span className="muted" style={{ fontSize: '0.8rem' }}>
+            {session.user_agent}
+          </span>
+        ) : (
+          <Dash />
+        )}
+      </td>
+      <td>{session.source_ip ? <code>{session.source_ip}</code> : <Dash />}</td>
+      <td style={{ textAlign: 'right' }}>
+        <button onClick={revoke} disabled={busy} className="danger">
+          Revoke
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+function formatTs(ts: string): string {
+  try {
+    return new Date(ts).toLocaleString();
+  } catch {
+    return ts;
+  }
+}

--- a/ui/src/pages/admin/Tokens.tsx
+++ b/ui/src/pages/admin/Tokens.tsx
@@ -1,0 +1,284 @@
+import { FormEvent, useState } from 'react';
+import * as api from '../../api';
+import { useResource } from '../../hooks';
+import { AsyncView, Dash, SectionTitle } from '../../components';
+
+// Admin Tokens page. The one-shot plaintext reveal is the load-bearing
+// piece: after a successful mint we render a callout with the full
+// plaintext + a copy button, and this is the only time it's ever shown.
+// Dismissing the callout doesn't let the value come back — persist it
+// to state, but the backend does not.
+
+type Reload = () => void;
+
+export default function TokensPage() {
+  const [nonce, setNonce] = useState(0);
+  const reload: Reload = () => setNonce((n) => n + 1);
+  const [minted, setMinted] = useState<api.ApiTokenMint | null>(null);
+  const state = useResource(() => api.listApiTokens(), [nonce]);
+
+  return (
+    <AsyncView state={state}>
+      {(resp) => (
+        <>
+          {minted && <MintedReveal minted={minted} onDismiss={() => setMinted(null)} />}
+          <MintForm
+            reload={() => {
+              reload();
+            }}
+            onMinted={setMinted}
+          />
+          <SectionTitle count={resp.items.length}>Machine tokens</SectionTitle>
+          <TokenTable tokens={resp.items} reload={reload} />
+        </>
+      )}
+    </AsyncView>
+  );
+}
+
+function MintedReveal({
+  minted,
+  onDismiss,
+}: {
+  minted: api.ApiTokenMint;
+  onDismiss: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(minted.token);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2500);
+    } catch {
+      // Some browsers require https or explicit user gesture; fall back
+      // to selection. The value is in the <code> below either way.
+    }
+  };
+
+  return (
+    <div className="reveal-callout">
+      <div className="reveal-header">
+        <strong>Token minted — shown once, copy it now</strong>
+        <button onClick={onDismiss}>Dismiss</button>
+      </div>
+      <p className="muted" style={{ marginTop: '0.25rem', fontSize: '0.85rem' }}>
+        argosd stores only the argon2id hash. Once you dismiss this banner the
+        plaintext is gone — if you lose it, revoke the token and mint a new one.
+      </p>
+      <div className="reveal-value">
+        <code>{minted.token}</code>
+        <button onClick={copy} className="primary">
+          {copied ? 'Copied ✓' : 'Copy'}
+        </button>
+      </div>
+      <p className="muted" style={{ fontSize: '0.8rem' }}>
+        Name: <strong>{minted.name}</strong> · Scopes:{' '}
+        <code>{minted.scopes.join(', ')}</code> · Prefix: <code>{minted.prefix}</code>
+      </p>
+    </div>
+  );
+}
+
+function MintForm({
+  reload,
+  onMinted,
+}: {
+  reload: Reload;
+  onMinted: (m: api.ApiTokenMint) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [scopes, setScopes] = useState<Record<api.TokenScope, boolean>>({
+    read: true,
+    write: false,
+    delete: false,
+  });
+  const [expiresAt, setExpiresAt] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!name.trim()) {
+      setError('Name required.');
+      return;
+    }
+    const sel: api.TokenScope[] = (Object.keys(scopes) as api.TokenScope[]).filter(
+      (k) => scopes[k],
+    );
+    if (sel.length === 0) {
+      setError('At least one scope required.');
+      return;
+    }
+    setBusy(true);
+    try {
+      const minted = await api.createApiToken({
+        name: name.trim(),
+        scopes: sel,
+        expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
+      });
+      onMinted(minted);
+      setName('');
+      setExpiresAt('');
+      setOpen(false);
+      reload();
+    } catch (err) {
+      setError(err instanceof api.ApiError ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <div className="admin-actions">
+        <button className="primary" onClick={() => setOpen(true)}>
+          + Mint token
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form className="admin-form" onSubmit={submit}>
+      <h3>Mint machine token</h3>
+      <div className="admin-form-row">
+        <div>
+          <label>Name</label>
+          <input
+            autoFocus
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. ci-release-pipeline"
+          />
+        </div>
+        <div>
+          <label>Expires (optional)</label>
+          <input
+            type="datetime-local"
+            value={expiresAt}
+            onChange={(e) => setExpiresAt(e.target.value)}
+          />
+        </div>
+      </div>
+      <div>
+        <label>Scopes</label>
+        <div className="scope-checkboxes">
+          {(['read', 'write', 'delete'] as api.TokenScope[]).map((s) => (
+            <label key={s} className="scope-checkbox">
+              <input
+                type="checkbox"
+                checked={scopes[s]}
+                onChange={(e) => setScopes({ ...scopes, [s]: e.target.checked })}
+              />
+              <code>{s}</code>
+            </label>
+          ))}
+        </div>
+        <p className="muted" style={{ fontSize: '0.8rem' }}>
+          Tokens can only carry read / write / delete. Admin-only endpoints
+          are session-only for accountability.
+        </p>
+      </div>
+      <div className="admin-form-actions">
+        <button type="submit" disabled={busy} className="primary">
+          {busy ? 'Minting…' : 'Mint token'}
+        </button>
+        <button type="button" onClick={() => setOpen(false)} disabled={busy}>
+          Cancel
+        </button>
+      </div>
+      {error && <div className="error">{error}</div>}
+    </form>
+  );
+}
+
+function TokenTable({ tokens, reload }: { tokens: api.ApiToken[]; reload: Reload }) {
+  if (tokens.length === 0) return <p className="muted">No tokens minted yet.</p>;
+  return (
+    <table className="entities">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Prefix</th>
+          <th>Scopes</th>
+          <th>Last used</th>
+          <th>Expires</th>
+          <th>Status</th>
+          <th style={{ textAlign: 'right' }}>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {tokens.map((t) => (
+          <TokenRow key={t.id} token={t} reload={reload} />
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function TokenRow({ token, reload }: { token: api.ApiToken; reload: Reload }) {
+  const [busy, setBusy] = useState(false);
+  const revoke = async () => {
+    if (!confirm(`Revoke token "${token.name}"? API calls carrying it start failing immediately.`)) {
+      return;
+    }
+    setBusy(true);
+    try {
+      await api.revokeApiToken(token.id);
+      reload();
+    } catch (err) {
+      alert(err instanceof api.ApiError ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const status = tokenStatus(token);
+  return (
+    <tr>
+      <td>
+        <strong>{token.name}</strong>
+      </td>
+      <td>
+        <code>{token.prefix}</code>
+      </td>
+      <td>
+        <code>{token.scopes.join(', ')}</code>
+      </td>
+      <td>{token.last_used_at ? formatTs(token.last_used_at) : <Dash />}</td>
+      <td>{token.expires_at ? formatTs(token.expires_at) : <Dash />}</td>
+      <td>
+        <span className={`pill ${status.cls}`}>{status.label}</span>
+      </td>
+      <td style={{ textAlign: 'right' }}>
+        {status.label === 'Active' ? (
+          <button onClick={revoke} disabled={busy} className="danger">
+            Revoke
+          </button>
+        ) : (
+          <span className="muted" style={{ fontSize: '0.85rem' }}>
+            —
+          </span>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+function tokenStatus(t: api.ApiToken): { label: string; cls: string } {
+  if (t.revoked_at) return { label: 'Revoked', cls: 'status-bad' };
+  if (t.expires_at && new Date(t.expires_at) < new Date()) {
+    return { label: 'Expired', cls: 'status-warn' };
+  }
+  return { label: 'Active', cls: 'status-ok' };
+}
+
+function formatTs(ts: string): string {
+  try {
+    return new Date(ts).toLocaleString();
+  } catch {
+    return ts;
+  }
+}

--- a/ui/src/pages/admin/Users.tsx
+++ b/ui/src/pages/admin/Users.tsx
@@ -1,0 +1,239 @@
+import { FormEvent, useState } from 'react';
+import * as api from '../../api';
+import { useResource } from '../../hooks';
+import { AsyncView, Dash, SectionTitle } from '../../components';
+
+// Admin Users page: list of humans, new-user collapsible form, inline
+// row actions. Destructive actions (delete, disable, reset-password)
+// prompt for confirmation before firing.
+
+type Reload = () => void;
+
+export default function UsersPage() {
+  const [nonce, setNonce] = useState(0);
+  const reload: Reload = () => setNonce((n) => n + 1);
+  const state = useResource(() => api.listUsers(), [nonce]);
+
+  return (
+    <>
+      <AsyncView state={state}>
+        {(resp) => (
+          <>
+            <NewUserForm reload={reload} />
+            <SectionTitle count={resp.items.length}>Users</SectionTitle>
+            <UserTable users={resp.items} reload={reload} />
+          </>
+        )}
+      </AsyncView>
+    </>
+  );
+}
+
+function NewUserForm({ reload }: { reload: Reload }) {
+  const [open, setOpen] = useState(false);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [role, setRole] = useState<api.Role>('viewer');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!username.trim() || password.length < 12) {
+      setError('Username required, password must be at least 12 characters.');
+      return;
+    }
+    setBusy(true);
+    try {
+      await api.createUser({
+        username: username.trim(),
+        password,
+        role,
+        must_change_password: true,
+      });
+      setUsername('');
+      setPassword('');
+      setRole('viewer');
+      setOpen(false);
+      reload();
+    } catch (err) {
+      setError(err instanceof api.ApiError ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <div className="admin-actions">
+        <button className="primary" onClick={() => setOpen(true)}>
+          + New user
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form className="admin-form" onSubmit={submit}>
+      <h3>New user</h3>
+      <div className="admin-form-row">
+        <div>
+          <label>Username</label>
+          <input
+            autoFocus
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            pattern="[a-zA-Z0-9._-]+"
+          />
+        </div>
+        <div>
+          <label>Password (12+ chars)</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        <div>
+          <label>Role</label>
+          <select value={role} onChange={(e) => setRole(e.target.value as api.Role)}>
+            <option value="viewer">viewer</option>
+            <option value="auditor">auditor</option>
+            <option value="editor">editor</option>
+            <option value="admin">admin</option>
+          </select>
+        </div>
+      </div>
+      <p className="muted" style={{ fontSize: '0.8rem', marginTop: '0.5rem' }}>
+        New users have <code>must_change_password=true</code>; they'll rotate on first login.
+      </p>
+      <div className="admin-form-actions">
+        <button type="submit" disabled={busy} className="primary">
+          {busy ? 'Creating…' : 'Create user'}
+        </button>
+        <button type="button" onClick={() => setOpen(false)} disabled={busy}>
+          Cancel
+        </button>
+      </div>
+      {error && <div className="error">{error}</div>}
+    </form>
+  );
+}
+
+function UserTable({ users, reload }: { users: api.User[]; reload: Reload }) {
+  if (users.length === 0) return <p className="muted">No users.</p>;
+  return (
+    <table className="entities">
+      <thead>
+        <tr>
+          <th>Username</th>
+          <th>Role</th>
+          <th>Status</th>
+          <th>Last login</th>
+          <th>Created</th>
+          <th style={{ textAlign: 'right' }}>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {users.map((u) => (
+          <UserRow key={u.id} user={u} reload={reload} />
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function UserRow({ user, reload }: { user: api.User; reload: Reload }) {
+  const [busy, setBusy] = useState(false);
+
+  const withBusy = async (fn: () => Promise<unknown>) => {
+    setBusy(true);
+    try {
+      await fn();
+      reload();
+    } catch (err) {
+      alert(err instanceof api.ApiError ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const changeRole = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const role = e.target.value as api.Role;
+    if (role === user.role) return;
+    if (!confirm(`Change ${user.username}'s role to ${role}?`)) return;
+    withBusy(() => api.updateUser(user.id, { role }));
+  };
+
+  const toggleDisable = () => {
+    const disabled = !user.disabled_at;
+    const verb = disabled ? 'Disable' : 'Re-enable';
+    if (!confirm(`${verb} ${user.username}? ${disabled ? 'All active sessions will be revoked.' : ''}`)) return;
+    withBusy(() => api.updateUser(user.id, { disabled }));
+  };
+
+  const resetPassword = () => {
+    const pw = prompt(`Enter a new password for ${user.username} (12+ chars). They'll be forced to rotate on next login.`);
+    if (!pw) return;
+    if (pw.length < 12) {
+      alert('Password must be at least 12 characters.');
+      return;
+    }
+    withBusy(() => api.updateUser(user.id, { password: pw }));
+  };
+
+  const deleteUser = () => {
+    if (!confirm(`Delete ${user.username}? This also revokes every session they hold.`)) return;
+    withBusy(() => api.deleteUser(user.id));
+  };
+
+  return (
+    <tr>
+      <td>
+        <strong>{user.username}</strong>
+        {user.must_change_password && (
+          <span className="pill status-warn" style={{ marginLeft: '0.5rem', fontSize: '0.7rem' }}>
+            must change pw
+          </span>
+        )}
+      </td>
+      <td>
+        <select value={user.role} onChange={changeRole} disabled={busy}>
+          <option value="viewer">viewer</option>
+          <option value="auditor">auditor</option>
+          <option value="editor">editor</option>
+          <option value="admin">admin</option>
+        </select>
+      </td>
+      <td>
+        {user.disabled_at ? (
+          <span className="pill status-bad">Disabled</span>
+        ) : (
+          <span className="pill status-ok">Active</span>
+        )}
+      </td>
+      <td>{user.last_login_at ? formatTs(user.last_login_at) : <Dash />}</td>
+      <td>{formatTs(user.created_at)}</td>
+      <td style={{ textAlign: 'right' }}>
+        <button onClick={resetPassword} disabled={busy}>
+          Reset pw
+        </button>{' '}
+        <button onClick={toggleDisable} disabled={busy}>
+          {user.disabled_at ? 'Enable' : 'Disable'}
+        </button>{' '}
+        <button onClick={deleteUser} disabled={busy} className="danger">
+          Delete
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+function formatTs(ts: string): string {
+  try {
+    return new Date(ts).toLocaleString();
+  } catch {
+    return ts;
+  }
+}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -339,6 +339,176 @@ dl.kv-list {
   color: var(--accent);
 }
 
+/* -- admin ------------------------------------------------------ */
+
+.admin-subnav {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--border);
+  margin: 0 0 1.25rem;
+}
+.admin-tab {
+  padding: 0.5rem 0.9rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+.admin-tab:hover {
+  color: #e6e6e6;
+  text-decoration: none;
+}
+.admin-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.admin-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin: 0 0 0.75rem;
+}
+
+.admin-form {
+  background: #181b1f;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+  margin: 0 0 1.25rem;
+}
+.admin-form h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+}
+.admin-form label {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin-bottom: 0.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.admin-form input[type='text'],
+.admin-form input[type='password'],
+.admin-form input[type='datetime-local'],
+.admin-form input:not([type]),
+.admin-form select {
+  width: 100%;
+  padding: 0.5rem 0.65rem;
+  background: #0e1012;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: #e6e6e6;
+  font-family: inherit;
+  font-size: 0.9rem;
+}
+.admin-form input:focus,
+.admin-form select:focus {
+  outline: none;
+  border-color: var(--accent-dim);
+}
+.admin-form-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+}
+.admin-form-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+.scope-checkboxes {
+  display: flex;
+  gap: 0.75rem;
+  margin: 0.25rem 0;
+}
+.scope-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  text-transform: none;
+  letter-spacing: normal;
+  color: #dfe4ea;
+  font-size: 0.9rem;
+}
+.scope-checkbox code {
+  font-size: 0.85rem;
+}
+
+button.primary {
+  background: var(--accent-dim);
+  color: #fff;
+  border: none;
+  padding: 0.45rem 0.9rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+button.primary:hover {
+  background: var(--accent);
+  color: #0e1012;
+}
+button.danger {
+  color: var(--danger);
+  border: 1px solid var(--border);
+  background: transparent;
+  padding: 0.3rem 0.7rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+button.danger:hover {
+  border-color: var(--danger);
+}
+
+table.entities button {
+  padding: 0.25rem 0.55rem;
+  font-size: 0.8rem;
+}
+table.entities select {
+  background: transparent;
+  color: inherit;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.2rem 0.35rem;
+  font-size: 0.85rem;
+}
+
+.reveal-callout {
+  background: #1a2e1e;
+  border: 1px solid #2e5734;
+  border-left: 3px solid #7bd88f;
+  padding: 0.9rem 1.1rem;
+  border-radius: 4px;
+  margin: 0 0 1.25rem;
+}
+.reveal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+.reveal-header strong {
+  color: #c5f0cc;
+}
+.reveal-value {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin: 0.5rem 0;
+}
+.reveal-value code {
+  flex: 1;
+  background: #0e1012;
+  padding: 0.55rem 0.7rem;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  font-size: 0.8rem;
+  word-break: break-all;
+}
+
 /* Two-column layout for detail pages: main info left, related right. */
 .detail-grid {
   display: grid;


### PR DESCRIPTION
Second of three PRs for ADR-0007. The backend APIs landed in PR 1; this PR wraps them in a role-gated UI so admins don't have to curl the endpoints.

Schema fix (migration 00015): sessions gain a public_id UUID. The primary key stays the cookie value (used by the middleware for lookup) but admin-facing list / revoke never leaks it — public_id is the handle exposed to admins. Fixes a real issue in PR 1's ListSessions, which masked the id to "<first8>…" and therefore wasn't round-trippable through DELETE.

UI:
- ui/src/pages/admin/AdminLayout.tsx — tab sub-nav
- UsersPage — list + collapsible create form, inline role dropdown, reset-password prompt, disable/enable toggle (with session-revocation notice), delete with confirm. `must change pw` chip on rows where the flag is set.
- TokensPage — list + mint form (name, scope checkboxes, optional expiry). On mint the plaintext renders in a prominent green callout with a copy-to-clipboard button; it disappears on dismiss and never comes back — mirrors the GitHub-PAT UX. Status pill per row (Active / Expired / Revoked), revoke only visible for active tokens.
- SessionsPage — read-only list + revoke action. UA and source IP surfaced for attribution; session id shown is the public_id UUID, never a cookie value.

App.tsx:
- Role-gated `Admin` entry in the top nav (admins only).
- RequireAdmin wrapper redirects non-admins to /clusters rather than letting them render pages that 403 every request; the backend enforcement is the actual guard.
- /admin redirects to /admin/users; three children rendered through <Outlet /> via the layout.

api.ts: User / UserCreate / UserUpdate, ApiToken / ApiTokenMint / ApiTokenCreate, Session types. CRUD helpers for each. The TokenScope enum excludes `admin` and `audit` so the UI can't accidentally offer a token scope the backend would reject.

styles.css: admin sub-nav tabs, admin-form shell + grid, primary/danger button variants, green plaintext-reveal callout.

Smoke-tested end-to-end: bootstrap admin → rotate → create editor user (bob) → mint a token → confirm it works via bearer → revoke session via admin UI → cookie stops working. All backend tests green.