### PR TITLE
docs: add CHANGELOG.md with v0.1.0 "Canopus" release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,170 @@
+# Changelog
+
+All notable changes to Argos are recorded here. Format loosely follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning
+follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+— the REST and database contracts may still change incompatibly before
+`v1.0.0`.
+
+## [0.1.0] — 2026-04-19 — "Canopus"
+
+First tagged release. Argos is a Kubernetes-aware CMDB aligned with the
+ANSSI **SecNumCloud (SNC)** qualification framework, replacing the
+Kubernetes-scoped portion of Mercator. Named after the principal star
+of the old *Argo Navis* constellation — a classical navigation marker.
+
+### Highlights
+
+- Multi-cluster polling collector mirrors a full Kubernetes inventory
+  (nodes, namespaces, pods, workloads, services, ingresses, PVs, PVCs)
+  into PostgreSQL and reconciles rows that disappear from the live
+  listing.
+- REST API is OpenAPI 3.1 contract-first with RFC 7807 errors, cursor
+  pagination, and merge-patch updates.
+- Dual-path authentication: humans log in with local password **or**
+  OIDC (authorization-code flow with PKCE + nonce + state); machines
+  carry admin-minted bearer tokens (argon2id-hashed, prefix-indexed).
+- Four fixed roles — `admin` / `editor` / `auditor` / `viewer` — wired
+  through the existing scope checks.
+- React/TypeScript SPA embedded in the binary; admin panel, audit log
+  viewer, component search, and inline cluster-metadata editor.
+- Append-only audit log captures every write + every admin-panel read.
+- Prometheus `/metrics` exposes per-cluster collector + HTTP counters.
+
+### Architecture — ADRs
+
+- **ADR-0001** — CMDB for SNC using the Kubernetes API as source of truth.
+- **ADR-0002** — Mapping Kubernetes kinds onto the ANSSI cartography layers.
+- **ADR-0003** — Workload polymorphism (Deployment / StatefulSet / DaemonSet
+  on one table, discriminated by `kind`).
+- **ADR-0004** — Ingress layer classification.
+- **ADR-0005** — Multi-cluster collector topology
+  (`ARGOS_COLLECTOR_CLUSTERS`).
+- **ADR-0006** — Web UI bundled into argosd; curated-metadata columns.
+- **ADR-0007** — Auth & RBAC (sessions + OIDC + bearer tokens).
+
+### API & data model
+
+- Nine resource kinds: **Cluster**, **Namespace**, **Node**, **Pod**,
+  **Workload** (poly over Deployment / StatefulSet / DaemonSet),
+  **Service**, **Ingress**, **PersistentVolume**,
+  **PersistentVolumeClaim**. All carry a `layer` field derived from
+  ADR-0002.
+- FK chain `clusters → namespaces/nodes/persistent_volumes → pods /
+  workloads / services / ingresses / persistent_volume_claims`, all
+  `ON DELETE CASCADE`. Pods also carry a nullable `workload_id` FK to
+  their top-level controller (`ON DELETE SET NULL`); PVCs carry a
+  nullable `bound_volume_id` FK (same semantics).
+- Pods and Workloads include a `containers` JSONB column for SBOM /
+  CVE workflows. Nodes carry a Mercator-aligned field set (role, cloud
+  identity, OS stack, capacity + allocatable, conditions, taints).
+  Services and Ingresses carry a `load_balancer` JSONB column so
+  on-prem VIPs (MetalLB, Kube-VIP, hardware LBs) surface alongside
+  cloud-provisioned ones.
+- Filter endpoints for incident response:
+  - `GET /v1/workloads?image=…` and `GET /v1/pods?image=…` —
+    case-insensitive substring match over every container image.
+  - `GET /v1/pods?node_name=…` — powers the "if this node dies, which
+    pods are lost?" view.
+- Merge-patch `PATCH /v1/clusters/{id}` supports **display_name,
+  environment, provider, region, api_endpoint, labels, owner,
+  criticality, notes, runbook_url, annotations**. Collector writes
+  only `kubernetes_version`, so operator annotations are preserved
+  across polls.
+
+### Collector
+
+- Polling-based; each tick refreshes the API-server version and lists
+  every catalogued kind cluster-wide. Default 5 minute interval,
+  configurable.
+- Reconciliation (`ARGOS_COLLECTOR_RECONCILE=true`, default on) deletes
+  rows that disappear from the live listing so the CMDB mirrors
+  ground truth — required for ANSSI cartography fidelity. Runs only
+  after a successful list so a transient Kubernetes error never wipes
+  the store.
+- Multi-cluster via `ARGOS_COLLECTOR_CLUSTERS` (JSON array of
+  `{name, kubeconfig}` tuples); legacy single-cluster env vars still
+  work. Empty kubeconfig falls back to in-cluster config.
+- Exposes Prometheus counters and last-poll gauges per
+  `(cluster, resource)`.
+
+### Auth (ADR-0007)
+
+- **Local login**: `POST /v1/auth/login` → server-side session cookie
+  (HttpOnly, SameSite=Strict, 8h sliding).
+- **OIDC**: `GET /v1/auth/oidc/authorize` → IdP →
+  `GET /v1/auth/oidc/callback`; authorization-code flow with PKCE
+  (S256) + nonce + state. Shadow users keyed on `(issuer, sub)`;
+  first-login role is `viewer` — admins promote manually (authorization
+  is never claim-driven).
+- **Machine tokens**: `Authorization: Bearer argos_pat_<prefix>_<suffix>`;
+  argon2id-hashed at rest, 8-char prefix for O(1) lookup, plaintext
+  shown once at creation (GitHub-PAT pattern). Minted in the admin UI.
+- **First-run bootstrap**: creates a single `admin` user when none
+  exists; password comes from `ARGOS_BOOTSTRAP_ADMIN_PASSWORD` or a
+  random 16-char string printed once to the startup log. Forced
+  rotation on first login.
+- Role → scope mapping: `admin` carries everything, `editor` =
+  `read + write`, `auditor` = `read + audit`, `viewer` = `read`.
+
+### Audit log
+
+- `audit_events` table is append-only; the audit middleware observes
+  every state-changing call plus every `/v1/admin/*` read and records
+  actor + verb + target + status + source IP.
+- Password / token / OIDC client-secret fields are scrubbed before
+  the row is written.
+- `GET /v1/admin/audit` with filters for actor, resource, action, and
+  time window. `audit` scope (admin or auditor).
+
+### Web UI (ADR-0006)
+
+- Embedded React/TypeScript SPA at `/ui/` (build-tag `noui` disables
+  the embed for backend-only builds).
+- List and detail pages for every resource kind; **Cluster →
+  Namespace → Workload → Pod** and **Cluster → Node** drill-downs.
+- Node detail renders the full Mercator picture: identity, OS &
+  runtime, networking, resources (capacity vs allocatable), conditions
+  with per-row health colouring, taints, labels — plus an
+  impact-analysis callout of affected pods grouped by workload.
+- Ingress detail surfaces the load-balancer block first, then rules
+  and TLS.
+- Component search at `/ui/search/image` with URL-persisted query.
+- Admin panel at `/ui/admin/`: Users / Machine tokens / Active
+  sessions / Audit. Auditors see only the Audit tab; admins see all.
+- Inline "Ownership & context" editor on `/ui/clusters/:id` for
+  editors and admins — edits environment, provider, region, labels,
+  owner, criticality, runbook URL, notes, and annotations without the
+  collector clobbering them.
+
+### Operations
+
+- Dockerfile: three-stage build (Node UI builder → Go builder →
+  distroless runtime), static binary, runs as UID 65532.
+- `deploy/` ships reference Kustomize manifests for running argosd in
+  a Kubernetes cluster cataloguing itself via in-cluster
+  ServiceAccount (`list` on every catalogued kind). Multi-cluster
+  variant documented in `deploy/README.md`.
+- `/metrics` mounted unauthenticated on the main mux (Prometheus
+  scrape convention): HTTP request / duration counters, collector
+  upsert / reconcile / error counters, per-`(cluster, resource)`
+  last-poll gauges, `argos_build_info`.
+- CI (GitHub Actions): conventional-commit title check, `go vet` /
+  `go build` / `go test -race` against a Postgres service container,
+  `golangci-lint`, UI `npm run build` + typecheck, Docker image
+  build verification.
+
+### Known limitations
+
+- REST + DB contracts may change incompatibly before `v1.0.0`. Pin to
+  this tag for stability.
+- Only the **Cluster** kind carries curated-metadata columns in
+  `v0.1.0`; the same pattern will land on namespaces / nodes /
+  workloads in a follow-up.
+- No snapshots / time-travel yet (longer-horizon roadmap item from
+  ADR-0001).
+- No built-in MFA on the local password path; customers who need it
+  should federate through their OIDC provider (which already gives
+  every argosd instance MFA as a side-effect).
+
+[0.1.0]: https://github.com/sthalbert/Argos/releases/tag/v0.1.0


### PR DESCRIPTION
Keep a Changelog format; semver caveat spelled out (pre-1.0, REST + DB contracts may still move). Groups the first release's scope by user-visible theme (auth, collector, UI, audit, ops) with pointers to every ADR that shaped it.