### PR TITLE
feat(node): curated-metadata columns + hardware_model editable in the UI

### DIFF
--- a/api/openapi/openapi.yaml
+++ b/api/openapi/openapi.yaml
@@ -2286,9 +2286,10 @@ components:
         Fields on a Node that clients may set and later update. Modelled on
         Mercator's logical-server entity, with Kubernetes-specific
         additions (role, taints, conditions, the full OS stack). Curated
-        fields (description, attributes, patching_frequency) are
-        deliberately absent — they land with the curated-metadata work
-        per ADR-0006.
+        operator-owned fields (`owner`, `criticality`, `notes`,
+        `runbook_url`, `annotations`, `hardware_model`) are populated by
+        editors / admins through the detail page; the collector never
+        writes them.
       type: object
       properties:
         display_name:
@@ -2420,6 +2421,44 @@ components:
             type: string
             maxLength: 256
           maxProperties: 64
+        owner:
+          type: string
+          maxLength: 256
+          description: |
+            Free-form handle for the team / on-call that owns this
+            node. Surfaced on the detail page so incident responders
+            know who to wake up.
+        criticality:
+          type: string
+          maxLength: 32
+          description: |
+            Free-form operational tier label (`critical`, `high`,
+            `medium`, `low`).
+        notes:
+          type: string
+          maxLength: 8192
+          description: Long-form prose.
+        runbook_url:
+          type: string
+          format: uri
+          maxLength: 1024
+          description: Link to the owning team's runbook for this node.
+        annotations:
+          type: object
+          description: |
+            Free-form k/v for metadata not worth its own column. The
+            collector never writes this field.
+          additionalProperties:
+            type: string
+            maxLength: 1024
+          maxProperties: 64
+        hardware_model:
+          type: string
+          maxLength: 256
+          description: |
+            Free-form bare-metal server model (e.g. "Dell PowerEdge
+            R640"). Complements the cloud-shaped `instance_type` set
+            by the collector; operator-owned.
 
     NodeCreate:
       description: Payload to register a new node under a cluster.

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -786,6 +786,10 @@ type Node struct {
 	AllocatableMemory           *string `json:"allocatable_memory,omitempty"`
 	AllocatablePods             *string `json:"allocatable_pods,omitempty"`
 
+	// Annotations Free-form k/v for metadata not worth its own column. The
+	// collector never writes this field.
+	Annotations *map[string]string `json:"annotations,omitempty"`
+
 	// Architecture CPU architecture. Open-ended; common values: amd64, arm64, ppc64le, s390x.
 	Architecture *string `json:"architecture,omitempty"`
 
@@ -806,12 +810,21 @@ type Node struct {
 	ContainerRuntimeVersion *string    `json:"container_runtime_version,omitempty"`
 	CreatedAt               *time.Time `json:"created_at,omitempty"`
 
+	// Criticality Free-form operational tier label (`critical`, `high`,
+	// `medium`, `low`).
+	Criticality *string `json:"criticality,omitempty"`
+
 	// DisplayName Human-friendly label, free-form.
 	DisplayName *string `json:"display_name,omitempty"`
 
 	// ExternalIp First ExternalIP from status.addresses, if any.
-	ExternalIp *string             `json:"external_ip,omitempty"`
-	Id         *openapi_types.UUID `json:"id,omitempty"`
+	ExternalIp *string `json:"external_ip,omitempty"`
+
+	// HardwareModel Free-form bare-metal server model (e.g. "Dell PowerEdge
+	// R640"). Complements the cloud-shaped `instance_type` set
+	// by the collector; operator-owned.
+	HardwareModel *string             `json:"hardware_model,omitempty"`
+	Id            *openapi_types.UUID `json:"id,omitempty"`
 
 	// InstanceType Value of the `node.kubernetes.io/instance-type` label
 	// (e.g. `m6i.xlarge`, `Standard_D4s_v5`).
@@ -832,11 +845,19 @@ type Node struct {
 	Layer *Layer `json:"layer,omitempty"`
 	Name  string `json:"name"`
 
+	// Notes Long-form prose.
+	Notes *string `json:"notes,omitempty"`
+
 	// OperatingSystem OS family as reported by Kubernetes (`linux`, `windows`).
 	OperatingSystem *string `json:"operating_system,omitempty"`
 
 	// OsImage Node OS image string (e.g. "Ubuntu 22.04.3 LTS").
 	OsImage *string `json:"os_image,omitempty"`
+
+	// Owner Free-form handle for the team / on-call that owns this
+	// node. Surfaced on the detail page so incident responders
+	// know who to wake up.
+	Owner   *string `json:"owner,omitempty"`
 	PodCidr *string `json:"pod_cidr,omitempty"`
 
 	// ProviderId Cloud provider identifier from spec.providerID
@@ -851,6 +872,9 @@ type Node struct {
 	// Role Node role derived from `node-role.kubernetes.io/*` labels.
 	// Common values: `control-plane`, `worker`, `etcd`.
 	Role *string `json:"role,omitempty"`
+
+	// RunbookUrl Link to the owning team's runbook for this node.
+	RunbookUrl *string `json:"runbook_url,omitempty"`
 
 	// Taints Scheduling taints from spec.taints. Each entry has
 	// `{key, value, effect}` — a pod lands here only if it
@@ -874,6 +898,10 @@ type NodeCreate struct {
 	AllocatableMemory           *string `json:"allocatable_memory,omitempty"`
 	AllocatablePods             *string `json:"allocatable_pods,omitempty"`
 
+	// Annotations Free-form k/v for metadata not worth its own column. The
+	// collector never writes this field.
+	Annotations *map[string]string `json:"annotations,omitempty"`
+
 	// Architecture CPU architecture. Open-ended; common values: amd64, arm64, ppc64le, s390x.
 	Architecture *string `json:"architecture,omitempty"`
 
@@ -896,11 +924,20 @@ type NodeCreate struct {
 	// ContainerRuntimeVersion e.g. `containerd://1.7.13`.
 	ContainerRuntimeVersion *string `json:"container_runtime_version,omitempty"`
 
+	// Criticality Free-form operational tier label (`critical`, `high`,
+	// `medium`, `low`).
+	Criticality *string `json:"criticality,omitempty"`
+
 	// DisplayName Human-friendly label, free-form.
 	DisplayName *string `json:"display_name,omitempty"`
 
 	// ExternalIp First ExternalIP from status.addresses, if any.
 	ExternalIp *string `json:"external_ip,omitempty"`
+
+	// HardwareModel Free-form bare-metal server model (e.g. "Dell PowerEdge
+	// R640"). Complements the cloud-shaped `instance_type` set
+	// by the collector; operator-owned.
+	HardwareModel *string `json:"hardware_model,omitempty"`
 
 	// InstanceType Value of the `node.kubernetes.io/instance-type` label
 	// (e.g. `m6i.xlarge`, `Standard_D4s_v5`).
@@ -921,11 +958,19 @@ type NodeCreate struct {
 	// Immutable after creation.
 	Name string `json:"name"`
 
+	// Notes Long-form prose.
+	Notes *string `json:"notes,omitempty"`
+
 	// OperatingSystem OS family as reported by Kubernetes (`linux`, `windows`).
 	OperatingSystem *string `json:"operating_system,omitempty"`
 
 	// OsImage Node OS image string (e.g. "Ubuntu 22.04.3 LTS").
 	OsImage *string `json:"os_image,omitempty"`
+
+	// Owner Free-form handle for the team / on-call that owns this
+	// node. Surfaced on the detail page so incident responders
+	// know who to wake up.
+	Owner   *string `json:"owner,omitempty"`
 	PodCidr *string `json:"pod_cidr,omitempty"`
 
 	// ProviderId Cloud provider identifier from spec.providerID
@@ -940,6 +985,9 @@ type NodeCreate struct {
 	// Role Node role derived from `node-role.kubernetes.io/*` labels.
 	// Common values: `control-plane`, `worker`, `etcd`.
 	Role *string `json:"role,omitempty"`
+
+	// RunbookUrl Link to the owning team's runbook for this node.
+	RunbookUrl *string `json:"runbook_url,omitempty"`
 
 	// Taints Scheduling taints from spec.taints. Each entry has
 	// `{key, value, effect}` — a pod lands here only if it
@@ -966,15 +1014,20 @@ type NodeList struct {
 // NodeMutable Fields on a Node that clients may set and later update. Modelled on
 // Mercator's logical-server entity, with Kubernetes-specific
 // additions (role, taints, conditions, the full OS stack). Curated
-// fields (description, attributes, patching_frequency) are
-// deliberately absent — they land with the curated-metadata work
-// per ADR-0006.
+// operator-owned fields (`owner`, `criticality`, `notes`,
+// `runbook_url`, `annotations`, `hardware_model`) are populated by
+// editors / admins through the detail page; the collector never
+// writes them.
 type NodeMutable struct {
 	// AllocatableCpu CPU schedulable by Kubernetes after system reservations.
 	AllocatableCpu              *string `json:"allocatable_cpu,omitempty"`
 	AllocatableEphemeralStorage *string `json:"allocatable_ephemeral_storage,omitempty"`
 	AllocatableMemory           *string `json:"allocatable_memory,omitempty"`
 	AllocatablePods             *string `json:"allocatable_pods,omitempty"`
+
+	// Annotations Free-form k/v for metadata not worth its own column. The
+	// collector never writes this field.
+	Annotations *map[string]string `json:"annotations,omitempty"`
 
 	// Architecture CPU architecture. Open-ended; common values: amd64, arm64, ppc64le, s390x.
 	Architecture *string `json:"architecture,omitempty"`
@@ -994,11 +1047,20 @@ type NodeMutable struct {
 	// ContainerRuntimeVersion e.g. `containerd://1.7.13`.
 	ContainerRuntimeVersion *string `json:"container_runtime_version,omitempty"`
 
+	// Criticality Free-form operational tier label (`critical`, `high`,
+	// `medium`, `low`).
+	Criticality *string `json:"criticality,omitempty"`
+
 	// DisplayName Human-friendly label, free-form.
 	DisplayName *string `json:"display_name,omitempty"`
 
 	// ExternalIp First ExternalIP from status.addresses, if any.
 	ExternalIp *string `json:"external_ip,omitempty"`
+
+	// HardwareModel Free-form bare-metal server model (e.g. "Dell PowerEdge
+	// R640"). Complements the cloud-shaped `instance_type` set
+	// by the collector; operator-owned.
+	HardwareModel *string `json:"hardware_model,omitempty"`
 
 	// InstanceType Value of the `node.kubernetes.io/instance-type` label
 	// (e.g. `m6i.xlarge`, `Standard_D4s_v5`).
@@ -1015,11 +1077,19 @@ type NodeMutable struct {
 	// Labels Arbitrary user-supplied string key/value labels.
 	Labels *map[string]string `json:"labels,omitempty"`
 
+	// Notes Long-form prose.
+	Notes *string `json:"notes,omitempty"`
+
 	// OperatingSystem OS family as reported by Kubernetes (`linux`, `windows`).
 	OperatingSystem *string `json:"operating_system,omitempty"`
 
 	// OsImage Node OS image string (e.g. "Ubuntu 22.04.3 LTS").
 	OsImage *string `json:"os_image,omitempty"`
+
+	// Owner Free-form handle for the team / on-call that owns this
+	// node. Surfaced on the detail page so incident responders
+	// know who to wake up.
+	Owner   *string `json:"owner,omitempty"`
 	PodCidr *string `json:"pod_cidr,omitempty"`
 
 	// ProviderId Cloud provider identifier from spec.providerID
@@ -1034,6 +1104,9 @@ type NodeMutable struct {
 	// Role Node role derived from `node-role.kubernetes.io/*` labels.
 	// Common values: `control-plane`, `worker`, `etcd`.
 	Role *string `json:"role,omitempty"`
+
+	// RunbookUrl Link to the owning team's runbook for this node.
+	RunbookUrl *string `json:"runbook_url,omitempty"`
 
 	// Taints Scheduling taints from spec.taints. Each entry has
 	// `{key, value, effect}` — a pod lands here only if it
@@ -1051,9 +1124,10 @@ type NodeMutable struct {
 // NodeUpdate Fields on a Node that clients may set and later update. Modelled on
 // Mercator's logical-server entity, with Kubernetes-specific
 // additions (role, taints, conditions, the full OS stack). Curated
-// fields (description, attributes, patching_frequency) are
-// deliberately absent — they land with the curated-metadata work
-// per ADR-0006.
+// operator-owned fields (`owner`, `criticality`, `notes`,
+// `runbook_url`, `annotations`, `hardware_model`) are populated by
+// editors / admins through the detail page; the collector never
+// writes them.
 type NodeUpdate = NodeMutable
 
 // PersistentVolume defines model for PersistentVolume.
@@ -4590,248 +4664,250 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+y97XLbONIvfiso/Z+q2DuUbCeZ7IxTW1OOk9nxTl5cdjJb9R/mWBDRkrAmAQ4AStZO",
-	"per5dC7g1HMN58L2Sk6hAZCUREmU3/L6ZSYWQQJoNLp//YLGn51EZrkUIIzuHP7ZyamiGRhQ+NdxWmgD",
-	"6oTZPxjoRPHccCk6h51zUBNQXao1HwlgJHFNCWcgDB9yUL1O1OG2aU7NuBN1BM2gc9jhrBN1FPxRcAWs",
-	"c2hUAVFHJ2PIqO1lKFVGTeewUxTY0sxy+5Y2iotR58OHqHNcKC3V8oje5PSPAkiCj4kCUyg7sKGSGaEk",
-	"VzDhstAk5doQBTqXQkM5xj8KULNqkO4jnfrAMnr1EsTIjDuH3x88bBrYiRgp0LoNtbhreg/U8oN6TTPQ",
-	"OU3ghP3MUwMN9DtDihEp0lkYH2gygFSKERcjYiQxY66JCJ9aRbyywQWOaZvRvuQZN8tDe0WveFZkRBTZ",
-	"ABSRQ8INZNoOya1zjzgKkySlWY4Pfj+IyMP9/ferRpliV/XhMRjSIjWdw+/3I7vctsvO4cN9+xcX7q+D",
-	"ctRcGBiBwmGX1C03TBsil3RqorLfTysZ1D3ensI1RtjMpuUI74FRX0u2Jfkku1/KSdaOaJLdB71OQWmu",
-	"DQjzm0yLDI5TyrM248vLF8kE37Sbhmcfa8hbSqYVo79vQbU8lS04d2kO98nGiyO/HsvcA7NI1mpokt3T",
-	"YDI6glWre0w1dLnQIDQ3fAJEFwP3OsmoScaEjigX2hAqZiSRwlAuQD3QpM/tZ/uxGHJILS4gZgx2Ug90",
-	"1U6Tf5y/eU12uOCm/isXSVowYLu9WPxCBZuRoVSECj0F7DruTMc8GdvPaaIKQfqpHD3+1+HD3sH3vf3+",
-	"T3GH/Oe//8eCI6oMp2ksUn4J9VZ9MuVp6ucw/3Y09/dBPyJgkl4sVvArznMVoHr4/aMVVN9WOtiZ3rMk",
-	"kMxqBjvQVSN8cUUTs8AI1TL3rcK4sCPo98hLMBqf2W8SBobyNBYTDlO/rvOLShWQsdQGGJHCz1UysCs7",
-	"5WYsCxOLnI64oMbSAyagZm7LOEYLQmblspVj23Lp7Dbl7UCGdk3vYRf7QW3JU358981X56A1l6KZgvio",
-	"RjGyg6sp5SUHMqFpAbvXI2JtZZ88bhrWW3kJos2yHp2eEGMb38PCvtPtjNRC34uF+k+pLlNJW+mvqW97",
-	"n8O6R00WpretOnvFlZLKicJ55Uu0JANpxuSSCysBnVS07TTNIBZBPlKtrSy1as/hqeDnIBOLZqSwQvKP",
-	"ArSd+O3qrUDoX7loJWECkbS1bHGwdm6rZIp9Njeg/1Iw7Bx2/r+9ypWz557qvfpQ5sa2pRCshnifUvCD",
-	"ZXjnqUF/1DPKzgDXzP5lWQcE/pPmecoTage+lys5SCH77l/azuLPloQ6dW+5The9D6kdKDCiXOe9zoeo",
-	"cyzFMOXJvY4k9InKnSSFUpaftaEGyA70Rr2IsML1D7gsuzjUn6UacMZA3OdY3zrZr6064owMCkNSmly6",
-	"La0TmQMJwowMZvirzEHhaHDUr6X5WRaC3eegz0DLQiVAhDRkaHvHobwTtDBjqfi/4V6H84prbXeaVIQL",
-	"T0egyso7S90e7mj/HdvNUc6R7A0eNDCUUUOdhUAymoy5AP8Z8taC0ZRyYeDK2DUTFik6Gc51LMImRHOB",
-	"mwfaCYXSxypFAnYR+4kCaiAMo+/Eaq7swhru9rBrwi6omZMAjBroGo5AUwFlb0Q6C0puQSxE5TcGswur",
-	"0q1YaZAmGz8DVzlXoNcNRRRpSgcprPzGNbtOqTZ27Gybzjd+1cnbxbX/pcio6CZjqUGQlA4gDcKiH3cS",
-	"3lWQgtX6Oc8h5QLiTh/R45yie9LQXa5gyK+WO/yZK23IDyQZU0UTY3U7KrY6k3nOe851ntIZMEKtWtGc",
-	"QSxsSwcd7YSswneSwQKChJaAckacpjdB0nBhEV4svOlDFEyApqiqxkCGRZo6bOzYciM1FUzk5S2vEAo+",
-	"3Afowbb/WGrjf6BK0VnH6cAA+n53KNAbZJ7+5VcbN0ZU33Hvy6/Lwb8gMba7sFuPsdnyap7SGQJUI0nG",
-	"hSGUCJguSJClXT6/tRYDNfYfNCXYaNYjJ0NCBxqEiUi19KXmKIThKfGLYXu63kYNe2MjV1dLtIDc8XdL",
-	"hpGiwvTIEcu48KosocKqjAG4h4DkwoloKzRjQW3jLopNECyXXBhnvmtnzLlHKJ2TRBbC0AFPuZl5ZBqY",
-	"BUSRWTawjNaJOlPFjZ09gxQM1Ja3mk7GxYl7+2ADa5VmPs5/Hau85No0McoImIuv2e2Ok1/mjHIq5T/W",
-	"KcdSoy3ti6gj4MpcJGU0cAMHLO4j7H3dJF9xr+HT9M2wc/h764H+uTBj06yST+dlYUQcX5M+VSOpL3Jq",
-	"LuJif/9R8oOVoxr/Df4nRQWTmfvJatlTBXb/ACNwRROTzlAl98i5kQqsXKREQ6KsQZRRQUegnhImY+TZ",
-	"RGYZt4MgHvtYdKNk6jhvPRXd1Jap+L4BWDkEUWKGJriAQKSPH+0TZ0cmVCkO2ikFFOGVDrFoJJH5jHBD",
-	"hJxG9v9TKR4YQvMcqLI26nQMCgikGqW+Xd6CcfNi4uHbgmQSdoCJVMw7MGiCcJT8U3FjQASgSu03SMYZ",
-	"S2FqNzEdGlBujFNlO2dkTAVLQaHdaTenfupRVZFbuYUWcp5aq6kBJLl+lwf4XJquhpwq/MIE1IDoAo1d",
-	"0rcCv+co2o9IP7j2XHf9KBZ9C2J7qRxx0dNFkoDWtmHt1yHlaaGg37j0kR2VDGBrflyv7cJY4VUgUrbq",
-	"OcEheotJO8RBbAdWRtje9O6cMPfIaaMcd4NAI7gmD+3k7ZCRH6MOFVLMMllYnahn2kDWKBvdt5RMoYUA",
-	"Cc1tV0GZbHzFeXDdmjLGneI7ra21e2+emke4+l2dQ8KHPCG508A9cpRO6UwTKojbaGQ6BkFyt/l7q6lX",
-	"CbexMflFBmYsWSP2wOfod1r51JqbRR25lJHwVWh46TsyQdt1LbRqgGNOPjUy4Dk240NuNxYLcNNQNQIn",
-	"JzI6I15DU/Lu3clzp2vT1PmRem1YrxyBe7I4hl+5WOzZbgQz88wftqTddJaJcPPl/MLJu91WQwgkyFtx",
-	"H2JAOvKybksFaVeuvlBzWy8KImqepeoMNM8ujZq2FMVtAIUTumCb68hiUNCGDK2pcWOQUamEe4QZhRkf",
-	"SzHko4aJK+iijCRWmlqFPOSjwvlGiABglc/k3UmPnKA3AkVLOrPWOmV2hCEE5D6iJbZ3n83pCDErUSCY",
-	"d5++OXl+HItBYYwUZABDixzs7+g0H1ONGAKxapPGkpwlmEA2bwYIO5C6qBlImQIVzgYeQLo8+WduBM5Q",
-	"lWJh1BHBvRR3zvlIWB1qJxmLN5eGxp0eOXbYJfUA4+js72/OL+zMLl4ePXvxst8G1IRBL6/aQkOcc9Pa",
-	"Ho+pGMEp1XoqVd1lueDO8w683Dck36FpFf5cZmvv8bsILRbsmYP9h4+bLB+Yzr2x6GPC1CZy8LBur+eg",
-	"yOuT87fkh/397pNHz8io4IwipnwtiTRjC3dwK2lUakQVKWgfTraWPM4iHyuqwZpyNEkgN8iVVLBYWNMV",
-	"rGQh0mIiPZbKeKh0RdzQtVurpfllXJQ/PNy0lksUWyBH4+o5Md0e+/sXXhU4wQYL4DZ8Xtd2NM22mcpL",
-	"bL6M3z3y6HMxVFQbVSSmUHBh92VC0z4qU0+GHjkHE8STxnBXb2mkzQb5k/nlfRh1cmoMKDuC//U77f57",
-	"v/vje///7vs/96MnDz+En/+rCTN4rH0Dwq9xvzjSzvlX5npsYRYdkV+LAShh7YMyhVbBiNt/QBlFO371",
-	"/FmvxpqVq+aWGLTZcXjuNqxOi1EXM0OqGGVECsH/KIDQREmtq1HG4iTLCr/TrVVEkDyl1ri71W7yZrRY",
-	"gpp7KxDeu7jKDKyK8G1win/txq6PIIY2Q5J1edBGoiRGC/En99vf+vbXIZhkjOtmv4a6tReLI/TDEamI",
-	"xTnOvhCSZBYM2CaaKMgo94t5W1hogT8bHMqQMm3BAA1ShpgxNSRJuaUZonsNxuoWklJTWtnLa4B+OuTH",
-	"NUZZG626MEIF0LXyhVzuTVAaZiHiYq2OqVRmTLjRRE4FSWRaZKJHfqNpAToW6Ab0Oo8cW/RigTZB516I",
-	"xRhZ4HJx7Rwj5W6qj7uWslER15oYweXYYLRU8ufo9MTLa/Lu7CXZ4cIJTCTPgrGueKcxLsOt4Z9yM2tY",
-	"xJJEhoNy+M5ON8ukcH55fUj64RPWOBrz0RgdFxkwXmQu5WzatxDEmlZF1gU7xATYcoxAp9IQLtAnwxWS",
-	"3dArKWQ2Izun+3unB3v/+e//u7sklB49bFprF6W4WBdfGSoOgqUzN7GIDMN0W4VSQEy4kiJrdEtVlKs1",
-	"I4aOyqAvTCKiDR1xMYpIriRbDOA8aWLhy3LtL3xORANG9dutxhy+LVGQS2Uc0q6x0Y4H6Ae9hz/2vo87",
-	"i0NppDASre2ObCbhgmZVA24UVTO0X7q6yPOUW0ZxuSyXMNtDnnPLpXstN5OQpik28FKKkVuhXEkNPXIk",
-	"ZiSj6pJZxuPa21l4TsZKrK7mDBbo8sPBj02UkVPRlJxR8YRzNKLMQc8D0IzsESm6CU1TJyblVGgfyk1K",
-	"kFaoIU1C4mDINXSWoZaEiwS1vT8qw0DpWFwKOSXTsbT6Y0ovgRT50gZaFSqUE86aJvLOfjud2UWpMRHj",
-	"9t1BgbaFVJjkaJuE7/Ri8SYH0bVkZU/Rh12TIqNLayde6ohQ+x+Zg9BjPjQRUfaJ5XvKsohIa4fY/1t7",
-	"phGfNPiARn6fbGxZiIGUlxeFajByX3Jx6RJowK4OxiiBZg8wYcm+5tdzPhF8Qf5uUlIfVqvad6ger48g",
-	"l2DUK1Aj6OaYIjaQbNYjFlSTAAVRZ+mnpI95rhisDTDRLmXGjRUkrhWGxVIYGlKIBC1p5n33xyFZrBmH",
-	"HVe5ZFRrmXB0QWOujKVzcN/1yM9SkVPJ3J4gCoZW4yKIjUXKJ2AXwZoHZMcONyKYBOb/d8H9mbIyc+0c",
-	"PVygI8IFN7EYpnS0+xQX8J9l2hRmTfikX2Igyy1MeaAJgySlKBjKwcdioVvBzW6PeFzHBZkcHBKgyZiA",
-	"MGr2QBM9prkzs1F4TiCKhZYOxAY40YUrg9Z9SWaGoRKP0AglOoeEDIosX4g5rnNcL/HXIlT9BWjqvMnz",
-	"OKzyIgcXvrxs9NGv1EzPCp6yUhl5v6sqBG4mjKGhB2U9Jl3jnfQn59rvEf/C1+AGKLOeJuBsfz93a/sD",
-	"OXp+1t3f33/c2ux/NO/VaTQEd37v+n/9Jfy0+1Oj0T+XbtgmHHF3XoJa1uMdOQ084dc5DXyTbZ0GG9m5",
-	"GQ3XxhZOuWIWz87z1+dd59TVZpbCbo+8cy6EHFQth3QbB8Ld8s2ikY++2vqRyB5ZNdSnzrAObWORFdoQ",
-	"mlo2mhG4QleBw2uOEXxcXJPH+4/dPDfncy96OxaZ7UbOj7B2BcYHaD3Jt2KpNu6Q8ijxTf0hQR5/Bf6Q",
-	"ha23zh8iSglwTYeIX5+LJKVar7BwgwSxTdxudsdNfKxFkQHm4hsZDNK4I0ZcXMUd+0+jKAz55bIl2JQ+",
-	"//mYgnbjXAxoSkXSfOjLSiKaEtuuG9pZhOa2Q0QyPOPAxSgWfYdDerbtM9+051fm9/f9HnlRwj1irbj+",
-	"nzz/KUKryC7HTxGxprj+6UO/R05lXqTU2+XTMTXoPxoW6ZCnKTCXpRKYxgVsklQWrL6eUvg8obKwgzWj",
-	"VCxegaHpy2dkD3VQ97eTU7JHKBlTxTARBqVJOVkputbA6pGjWGguRimUcyBmlvOEpk9JVqSGd93vGkyR",
-	"65C+40J7rKBpVxuaXJKdyePvJk92CdZ3YIVgVBjy28mpvglizeiVT5CreSZK0YJxrZU7gihZoF2KzVZj",
-	"9JDGVK0H2holOCeYnYvCyR21JTt2bSOSUzN2/8Wkg4gMaHIJojw1Fwvcjnu4/ru3CdxN2jDtty/PF6LR",
-	"dnq81dTthHQsrERy1tgQFIgEGDnH1DQULLc3gw+r5eq2xu8iErqR8Ru0dB9ls7eHqYJYVBYxaWsQvwyw",
-	"fkHivT4/P7GEN3KkaD6eEYSdLndNW73gTvFYkT0H2R8GN1IsLrlgXSO77s2M5jnaVWH1vFsYyADG3P+o",
-	"+VVoLhn4BMJg3kEifSZW1BkUmgury6NOzZKwf7GMC66N+zweJ2qKNy4/yMczjU+aTMiXcsTFyij8O5/P",
-	"Rb4rI++RO2EWlPWy0twuAF/PGNuguxYgQvlm1Fkbsn4FTSf5UJS7mJ2ZRUTJFCJcQRgOIXGn+zDZtwEV",
-	"sGZCEc4cCLLs8Tc7vKg85Vl7UGaFb7S9QiLffFcuP8p9cD6hcMLLNBR/3jUqM0Zt81jYFv0jf14H+eiQ",
-	"PMNTM/0eeXcSfLGYZ62Y1UqzeU6dyyVsTKkutLlwG3FNYoXPyV0gV4+8VYXz1g6kNJbVc4Jsr3FpbBsd",
-	"iynqgzIxZErtsLWLq1PhXkDl7XKAyCCVyaV2B7xjYbUSELhKIDekv+eG2g1f6/uUenR+oYPRUofNpcbU",
-	"0nRCemQ7WXkmGyXkCmKsy7d/scCk3sSyw/nP//4/Lu0+iCXpT0R5d5o/RBa1PmThV3sF/F0efMnfa/d6",
-	"OxJskgHlec+VafnlWc72y1S+ssZbVVUYaeNE+TpyXEq63STL5XbdFnfjvZqrL3NHvqvKl7LGe1XV1trS",
-	"f7U1izf6e6q6dpu8PaGl1Q6xuE1fT7TZ1VaRsoWzrar68XFcbYs5ekusdiPPVUWK4LuqJ/KUXNHGd1VV",
-	"aLup86oS0V+B+2pp561N6ClbfwkpPW/nzXqXu+MTea6TvNMyo6Y8OU/TWnYN2WmTTrOLp3ANF4lxgc3n",
-	"J8dviZ1nF32CfOjPt0cWlvJkTFI+AVy8+dnrTyWZ5gtLJvkYaSKihnPaJYqEKgEMlCY3SBQZU91W1WFb",
-	"KwpTauX1AGEYKxOQjtB6cD7ot6AyXwUr7uzOZY/YMVpbMMuklS9Y2KbiG9eJJnNhLaMkK6xWaMXwt5UI",
-	"Mldn5RZSQUrBu60/bBlZXdsjVun+W/GHvZZsm3lI9s3+2Wj/BNeaN4Aku4ntgyGfjUnfJZDsfcnWj2Tr",
-	"DR/Jtrd5tuDoz9rcsbSrLB1dDJi0OPaWrJ1b5tI7tncsLRpNHcnaWTmS3YKBYyXv12Db1HbYerPGLks7",
-	"i4a8kgzwzKIUsXgFKqFGqgeaeNdT1ydeB0c+ZjRWu6E8KB6LgFs02XHefkM5HpdNpPBPoqoYzptzgnHV",
-	"3R45LrCkgK/ep8lObWIRocYl44LGWGQy5mJ0McSz/SKZ7Tp1zSDlA2uGQDrz9VyCh9rieFHLxExcb93S",
-	"oJpKdRkLu1t9IOpJY1WENJUJRdpfJHnREPI4fUcsQ7IC13ohMd1teheEQm+6mjirsU2Cer1vyMeQgaLp",
-	"hTZS0dGiktv4gQwyqWbbvpVLplu9o5IxN4Dau5lG9RY9siaRmmbsyeOIUJXZ/+V58uSx5Sr96Mf9q3bg",
-	"N6E5TbiZNS/YW2loSuyQcHc7jYipDC7Q47Iiwjd6SV6QnT8Kivug1bmCsvtrrVn5dvsFK19pu1rVzmw8",
-	"gGcKXdu8zkAv6wPvnFmlG5FXOLxTBVoXCqJYPOf6svyTnJ48r/54DcbutneCTijHbbJbTy/Bo7kob1y6",
-	"cm3/uCxjbRUQRSsvoYIMXVHOwSwWfTu3/p7PZemTqgxXTpWGu8vRKFOnL3ze9urjLL4QQ3iBHe7tHfT+",
-	"2jt41G9zYOYezgH5rCFf4aGprlpILDo5ddzgN0ktsYgPrRG70N/j75sMDqENFSsrWuABtZBajXWqe9WZ",
-	"oR6Xe+H9Li69m3IsfLmL7AnvXaVUjbAezbmhglHFLp4/1heT7/vLR68OHv7QOMQ1FDlVPKNqhhUQPE08",
-	"HZpp04Yml3Z+aZ2FNo7REuUiV/JqtuK1xp1v30rBrGbWX10DMuJl0VqCgeC1564mX+TBK+/hFKMLn0Wy",
-	"DCbPyZBm3IKP1TTqp1wUV5Yfp1wwOdX9VlSS+sIVAl6ufGTl8Jtzd1YjTDIsxbtBIUxBHj7s7T/uPSIv",
-	"3543JUE2usEku0g4U20OGoUzUY123TGm9oUm9ZLhboPkkPTC05Pn5d6lU324t7cHRXcK2nQP6B7v7tNB",
-	"cvDw0ePvn/z1hx/3GQwb9nDzbNA2bDyvMwHBAauHuoQDwkDxSbi2CcUO6ri+38qVLuzF4m0AsuWPZAcx",
-	"pgKqpdhLqTZvFRWuRMVbnsGuLxOJGU79Sq/2CSqTTSkQDUtvH80PGuVk1/6+ICz/0g88H4ulY68u97Kb",
-	"p1SguLQ62pUIApOwfjuw5dB+U+lCxMToXMQmtcV3P8xlmI4ppphewixyI4x8xtCHfrgwQjKE9JpgeTV3",
-	"Z9SQcBMLI1M0AnwyiuuQuHwW9xW7Bq+lHxPsvZYvriApzC0BhNoWKQFCIWpWwTJ5kA5zbcrUGruCiUnt",
-	"AikmRZ8MUzrqNTLJv6XYqEKNzGUqR7MFzrCvLmrPaus1bLMnLT28km3v3K27kD4Vv+7ipTXtp7P45jd/",
-	"73b+3kX63aLv9+Dr9f0uUnWdH7jx1qzrbwB8/as8o9hIiU+Jn7+qg4uNq7H1Ptg2QLLlbtgYiDj97bhl",
-	"HGIupn7tSMSt89hXfcjRrl7zAcdGPmkTTFl1P+FN4yvNWuArCLis3bFrIzB2da+bUobVkS8yyRbWapMF",
-	"VtkhPywvzUAWgl04tmjcfj//GlJBlgACZoDYGXFN8Dt4dCfUXY7FKQhm7bvT34413hfiLI7T34iSUyzf",
-	"OQDMj08B4zw7b16T5y9evnj7gpy/eEtev3v5crd5T26sMvu5uJA2pxZZ+jYnFR0ST+CIPLPUj8hLqU3L",
-	"/B938ghYPfSwWB7dNyGa/xvIDlqkoV6J7oUq2j3/gd0Ia39Tw7PSXow73/+d49UdrQblv7Rw7Hfj4VzP",
-	"vM168YxOSR+H7pq9RpsvmNKnv4Wjw3jmBK+crfFyLI79QUFEYm6pYQLCCRp34Fj5HDPH6YG1xQMTC2Rv",
-	"LkaOjDMwzbq0hdXcKHG2NaPXA41bP0HoisjdgmV9U0D1NWSfeE7uhVqEXTybwyKiZSiLeUuJJwefcuLJ",
-	"MtRpykJZZJBrgahbh09fI3JqB5qWgcetIKiVm8k1xBPDOugJuMqlDuWkxYzIYSwwDvBPxQ28EQm6yM+8",
-	"afuKiln4Gxu4HxZfOZXBjX47aC5E+htu6ShrevkmG6N2/bhzsF+qb7y1hZUq/ilJpAjxPyPJYIZZyJpQ",
-	"H4m3zxNQomVGhtVEFwqGK7S41drBYe20s4VFDpLgu2cw7PnLBVuU85jvrjymuNynMzjbdIwtW/au+QVT",
-	"fNJ41en5CXHPHDApccbpb5a6x+cnXay2wMIYNO+59naRyitPuOgaBUD2SAojmsyCMAzgrQ0M+bJA9GYM",
-	"fRRyTwKcjsWZu4WOReRnvCSmLbZ2/JXLlCezxjtMKRdkjzxHw4fskTNIZkm6eKri4MmtY2R34KIx6pko",
-	"OxbLXHYpfDfhhEbFbO5Dv+DPuwFHx6Li2wd6LqDrgU9RVdRkXF+SPaLHVMESQb9vLp+/UY/cFAp/etEl",
-	"dxlOy9lI9nV6zyX75iv/SL7yXLK1nnHJtjbb1nHxRgPIjqdl9v21Cvt983rfpdfbrt4Kr7dkrcwzyW5u",
-	"kEn2Vdhg1T5bb3ZJdl1LqyocvPFGibnyyZ/VQVkGLawV4Y5cuBrLXIejAHiuopW1sBnc2i9vRLdnrghx",
-	"RM6LJMHbuqJYOFQbWQZ8h4XURT3zvtUh1HaQOJesOVdWMlLLj905OZ08tqM5OZ082e2Rk/ptD0/xiDve",
-	"v4tVl6gmVMTi5JSk3ICi6dJQGlNpp778daPUfSvzbgoTSMsq2X4HuFQ4f17eEnznOeSpnOGtB3vWPKYG",
-	"hkVqwcgeeU4hk+IczK67PrQ6fD+lqb9u/tcfdCzwhPRZqDpHkjH1JZQsuql66Np2DGVcKA+uZToBHQtL",
-	"wa67dJWcAeIjO4bwU/WNKjDjvoNJiULGol5i0dU3xMsc7ciwJJCvW02YBC0eGFdHjczAeDd/RP4hBxE5",
-	"VlL8Qw6uF7D50Cymtkb1NQTx6RTEC5fpLxuCPx+Tv/6w/1fiL+n3x9gb9Jh70Fg0CpSSSq+Q5J6Z/abB",
-	"2ojYPPJlzBygHjjTs9SR833j9Bq7zkBrHzpar4vcJ6oX3reo9RjS+OeBdPMdL1Xh9oxe8azIOoff//gj",
-	"wjX318H+ftRwNajhJoU1pbgsTYe0SG3XdCALczhIqbjceOvM4o3E9mnoLVpX3/1MNivlK2Auq9eq39qR",
-	"tL/6HFl8ltEc691SMsQXXDky7S4bdSVW/cXgY0guA2K38v7o9IT0NSSF4mbWD4XbuK5YOXJmfqhyV7tm",
-	"+F8INY2hyTjEyVxptLkEZEw9nqtoh+Xi7N+MG2kNE7xLE/814TAF1Vjm7tyVGG0vEvwLX6V57Of+6ZQF",
-	"+6oMZE/9dUayb7KtobyRpzcay75S77cq+J+hqRzWrtlc9rzRxmT2H7qx2Rxk8ldgOi/svLXmc9j/1zWh",
-	"gz+5wWw60pqPrEXgg/0np2QHstzMUOz/ApSl1pzaK89lokUa1nu3zYnDbxXvGyreo8Hg11WjhT/LIRb9",
-	"l7UX+qGKfOrKjM9COfKn7kovfEeTFOgEHCjD3UJw/WwXWJ6e5PWK+U0V7mNRFrh/+ezpUmn8oO8Xy+jf",
-	"3YlnPCLfcM7LbwN8fKvV6N2FVPa7kb/b/sL9kStpZCLTCL0vF7dehl6DG9Mt7o5TPLyGKth/vOduA8t8",
-	"aQt/cq3aJnhBJ7Z1xcDbbJZg1bSQ5m9t00a7vN5gHcYo5d8shx45ptrOAqfj7QRrCczVMDMa0mEsIOOO",
-	"U0pHFDXesLBDDHXj551Tw8IUCkr/lH5q94dgKag569fdzen6nxwQXQx0yMoLhkkpUzvusNqpVBYJ1vd4",
-	"J+rUJes6S2VbF8Yitvt03BjnzvZr0EaCUFcUe1xkVJQ38i+rtM2mVkPxgZwr0Fu90wQS/ehrsWlPOPTN",
-	"KhjyK3TPjvFWVunLnz91EhoP9HL037rqmSnQS4fnqYNTLgc0FJRo0KbaXBR6y7m7bA2PADamPFu1ekFH",
-	"/rbWds3bmmErC4g/B2FfTrm2HCSVrwKfVKeoNxcTxz7DcBbsrznCzXFDMzzDRW4Dfj3Hel69BQzsNsdm",
-	"DHxbUPSdbrxlw+9BS84Fy7O6fvD2HSCMazuntR9ZnPjdeVW0wQLp4lZHs+qChdUn8zdfSXAbDo6bXOVR",
-	"7jzvAsGRb+MBcWxY+S9W2rDelnYWbMWiy9zY7h6L584tSyxFymR+7au5kNg5F12FCe0KjLkNIQ1WAZAi",
-	"FkMsXIN8EnfIMJVT5ycb0lS7krQaw2Tu9gvcQIWRWc3fsbzya69gqftDGtPGtmGbNUu+1u9y1P3/97s/",
-	"9i6677/bnJvddNOLH+cqVmgjepGgNxW4KP7uV9pWUG4TIjsHgzdw9avrTRSMqbbI1yIxB0Jj0W/i9r/Z",
-	"kfZrHwnC1T0gCiby0r7tLIJ5RVYl3Olg6y1EkvzHmkVXeyF3T6zeZICE0Gx7UB3e+CSjAOG2oTYT+NW2",
-	"vYfIQejvW3bdpuCBvwnnjmIIIVmhfg/imnhCWLZtAwqb90dg0u2+59h1aYplbgWmFzBun2EldKnWH0Nv",
-	"cxCqJFnbI/A75YpGOKDdb0fhbyXSUd8ZNwp4lCvaHPGYY7ZWnFHbTHaQjc6pvn3Sd06RWCx5qYh3Uh1V",
-	"+VCXeN/sTj0ZJqql5OBxAi9mpTguh7CLMYEBVCX8MbXJThwdZK4cV1m4ksbCu8EyPvL3Xe7o6rbER7vz",
-	"3qwqAagTdWpZSp2oU2YpNfqvAlnbILpA2RujulK1fwWxpEWhuzaYtJCO9i0hc5meKNculNtjDYGIN+Eu",
-	"DicAfUOSyCIkx6EQdfcQOuvQ1/eriFomFDWmE63u+zloyxCrOn1aZQxiWQQhiU5oShVh/kX3wsYR6ByS",
-	"TeGNBfnIBSuLdQcfsJnLWUzGEk8+1mMveEIQ70SF0SwW8+mKUQg1Yn6sS0WpJM/ufHVnjQcLY0E1+cf5",
-	"m9fP5mzrsLrrzIBtPexLYOd2XOyRVxl4m2ksKmf79ifgMcTkkrHO7aDdLnP3hR4Vdpv92RngXz8HBe0u",
-	"Bl3aaacn4SZUrQtgRBamK4fdARUI7QWqmuaLSQlmkCb4uksm7fdiEYtzl901UlQYnyPs+jiMBSFd0rfb",
-	"q08IumVQQVjpNAJTXQilfUu8g6rvWgYHkWB+u5Ednlm5oMMXfRAowStkH2iHG8F+b9d/zxUScdUdFGRy",
-	"AqSsV+GboGPId0nTNGRp04GcwFNfgN17ssuIUsZFF6tJgmC55MJoS4e3ds7ahXixiKUFDf7zLs0Ox59w",
-	"k86Ipobr4QxTqN3DoCNi4W5PLYmDRD6tpfhFJKPJmAtwZHZc4w2MuatXvTXw7iQWiAj6p2/O35K9ycEe",
-	"Pt9zr/d3iaIuED2m9qV/YQiRmLGSxWhMQEzIhCqf2I2bBk1/ZIpqZ46NyWsu92O89nZF/emFy3GJvzO2",
-	"Nr7CjPfQFdfvkV+Mye1+i2JxTjM45wb+dm4UT0xEfuiOZaGITjmW28BwwKxH6uRC+r1A10hJUzzQnRtN",
-	"gOPM+9Ve6lu135+bRd/lS7p18hFDzPO2fFgrd15yImZf7jiXoQsn7OLF9G7r+XRIfO6ouItVGfDGq6nE",
-	"i9S1Ow7pzGyaQSyYnAptFNAMLxuWims3FUze9NFsS2FH0wC0LV4aSX3hB1KtF835rzDrfPiAqbVD2ZCN",
-	"/OL8LbESww70L385st/5y18iQtG+xF9rMBjEhCspMsQhNHXpKOEyhVi4277PIXldZK7c78756+Nd8kdB",
-	"0/LyNjJUNAMLHnHR3o65LmtK7+z3Dnr7u+5I+ZSm7lTqpd3hyEgTsGDBy5yXfAICtHOu2VXCm7wxrbrc",
-	"+T6s2y9FAjk+e/ccJVox0HhtRFnR2sLtNCWUMaxpH1X3AUYlEovIqWTu6mrM65gzEtytGN4kyGie43kP",
-	"X0dpxU3o2nEu5meToUxTOSVlhvhO5aORYs/ni3/3Ly1FKK6jiyyjajZn8nQTzD1J3AourhJZXqRqQcp8",
-	"ZYvXRlK7TxydnnSiTlkcvIOL5EthC5rzzmHnEf6EdvAY9dbeGGhqxv+2/x4B2hLlxjxhncPO38H84ptY",
-	"DOUCqfjqw/39AF59WLNOBTt7+5tT7JtwrevCbYDmDBWOjDyxVmVNA3cOf39fp27Ja8hdlkx0pC3Sd9Ps",
-	"vLcv7yHGrE95oQIvKD60uq22zRnkFhKJxP6+w6ihA6oBLzKxPJ2MQ57+EvXOXGcfm3gOVxvpHIXEKDoc",
-	"8gRt9O/3H60ZS52d248pHKtYPyghndyerV/Vs3mhsWpZS12Kyeorlxet48ja8KBN10eavK2sIJGKAUNR",
-	"SxN32Qs5c3BA+yrg+HmPI6I61hpIMy5hBiZ1+LT5Pmoh7VSX/00j7LKzd/hlwjUf8NRKpuBOcODH/Wak",
-	"zyKLhYt5hRvMnWT6GW/VcPDj6PXzbiKzARfAeqSvuUigT/ZIH62nfqighXORSVIohf7PPlEW5ZKdMU2H",
-	"XSszDkn/d3w7cobXbhBn80xubdEjO6kXE8sDKF6sqDJo0K4A/FWTvZc84wbdmhsaHjv/gm25aIzjnSJG",
-	"Yv0vCyU8lEfnONdlOBOV8h8FqFlNJ1s7ynnFKt7e6FzbOATqbqMXI0JJacKV6g2dq76Ui88KtEaKHae7",
-	"YKBppOHtC39mpRrubQ+Ps41jWCDYFiOodei2GBauCdTApXIIejUl3HubBtD0JvJz81KvSfdZ9TXcFtt/",
-	"7f0daoNqJzof0bIAXsi1se09V6A6eLx/sKqPctB774QHvv8G5l56tPmln6UacMZALEr7efv5d3faqPPe",
-	"Un3BhKmeLeh9a8rWZlLTEe4s04KKCLbAStxjv3geGt25RLtLhqjnXW3khirl6hPhBL94jZzgnzVwQkPG",
-	"Y2uW2PuTsw8ONqRgGtPqUjA+EqHk9GnlsvZlN9GSdG4HPJ6MdvUIjCaP9w9iQZ32Je9OiALGFSQG/Xdo",
-	"Yzcp2DNMKjgvrcYFVnncVMXIvsHubxXtG483v/Famp8t+rj1ZXcTRnfLXMpFw6Jvu5n9AE5Y58P7OYZx",
-	"8GutBDnKuXNFfd4iJEyjnQzxsPSzliALXr2d8uJJxOr/+e//IXlKuTB215dZxxPQZYB3t5nzZFO87syH",
-	"dsts5urbzksFVzQx6YxIkUDwJNaSmn0NAO//1/52HQvy1EiKh5yRMdVjn4rHtYtakoQKa38NIBYKjOIw",
-	"AR+o6pGTIUmlNpHPZ0JjJuPC+KCvFNAkp1xmQ2CWTlnI+Jl0lzndKi/6NIoP8zE9n/KysBMObr33V1w0",
-	"7gR8iKQC9rS2ji51vb5+GLtw7L6/md2fUeZLPn+u2+pVxT5zm2uTWnY7cKNSPrfqte/YFa3Zp+78iHMd",
-	"hnrYNc3su7cmP/AJxOLx/gHhWQaM4420PeLWUsmpM6svITcuix5xpmUnLgprm9uNVWh/YAylYAhGuISJ",
-	"CYcpySmeRJjIxN8hu1LRz22gb5p+habfyEXbalyk+bKWR2/LWiX/Dlt81gq+zA7eqNx9fvDnrNurDHe9",
-	"Vkk3KTfMbL4bxVZL1r9npebStZdX3v4egpmftKqyb/y4+Y1jKYYp9ykLt8lWx+EARcVam9Qast9GrXZM",
-	"dUKZS+8IieMPdGnSIi57c/L82J+cMxx0j5SJBdppJDxd4SCJj1dgDhEjtSs9zl6cvz07OX676+PzKGPN",
-	"GLJYwFUZKUdnOVYkQ7SLDYLBFXLb0RDGOTZpOGc7l7tok3ZzzT9l7faxWc+XKaarmC5aGdZrXoT9e5Eq",
-	"Xw9c+TuYdYuzHWawpDtxSduYALX+uIuGjArDE31XZ14waxNPebU59kJN7dzLPDe6LLGtdGtWTfS77fnS",
-	"p6W10rP3sCPcGQQfpfrE9ezH3EyOUH4/+dyeiAQ+RcUUeBPTQ2GNFi7MeM8xerd+XKrZQ1OmBGBqUaEw",
-	"07/q1+8kp/7QPUJ2gu9lN4pFkgJVmjTuLpeTSLgIxTPDPcg+cWXFETJNM3+OzKcEdp056/KeXHD58f4j",
-	"X10upMOhx8cNoKJiGEmjSwfbntYOGN4B8p3vpGTqNpvzcVN8332HhKzNz8nJsrgPFoGmW7o6Fy4sYp3j",
-	"i7nUCGR4KYZ8tDI1IjgiL4UcOHbGmATm2RMBwLRzaOBRD3QnSkZnWGUwFtMxYP6ew6N48fqQjwplUadg",
-	"EeFDomXkfF+FMVK4FPJeLE6QhzAjOp2RvBikPMGCslhbxR18AeZuDucW/eIF7ZNGH+TfwVjxcuwmeqdx",
-	"1rKXBpFun5YUcKmja1NcTnHSmE04/1qIFDnq5wq6uCTrl9k1WSnNXly5raG9DMBE8O9KFnJOroW80B45",
-	"Kw8gHcSirETrjnaEGqkDyWZ4JkLMyJDytFBAdoS0Utlw4YL9AzBTABGLwlU1dvaJlYEDyspB7CLe0KQ/",
-	"lzLZJ1SXOajku6UkVBeLGyg5RdPVVy3ixo6p5g60wrMrFR9xEYvSNxiOkGN5qMZEF0/5u5CB+O2bir5Q",
-	"R6W02aPOGC/8wVfOwXRXpQKfzy/22syKD/cmT9dsmHNDlSkt7oZoX+OukIVZvS3qcV13nLarOatUr5JT",
-	"ZFOvzd05DCRXLHzhbk00T0GgrSxVqYxt91bCWc4QIzLh1CcbOzs9FjtB2Dl/sbyEXaIxIiwLY2UeZ5Dl",
-	"0rLZCsa0M9uKRewkUDmuxWiN4GxBKb3w8eygkbZYEndcdK0umkvm9m6OWeShH7gspkmoa+uwlEttawRb",
-	"ZJjSkav7jeF3Gop2l3otFvbTXYrF2wSd8JHPUsfsZReuD+4YNJtY1wMqf2CtSSW9grtURa+gSQUdI9FK",
-	"kvVuZQ9egz3+OZaEZuTErc0UUyKoICeEyfXMITlL9sqhrGSUVxzz2chQgR472B+R01+PX5BEMriYOOiu",
-	"LNhPU3ALxZU/CSSkSOBpFTrF0mP+DfIdESFi17eDubCDucAedP9pLB7tPyw9czW0c8JOH2hSDrwMBtVV",
-	"6GPES6IES4jLy080cdEbzpKjkhgL3PRo/2HTDprn1hN2uqARXvpg1DyrbSif/aEyAxfO8DXOhSCG4bos",
-	"cbRZqmPla/sxWj/71LXLibVgWrCNlRgDmlyu5JpjKXSRlZfHUrzqC7mmXP49v/zaWPMOC92VixoLwzMr",
-	"gEoo5ZiAQZXBf8JOo/A19/zkeSnw8cyX5cKCYSWuiGg+EtQUCiLX725EhnhEQQYnvE9A1mPK5NTBpkuY",
-	"ORL3yy/qYrDbj9DhqysYFxHPrbHo7xV8r9/Da9MKBZqkeE5CEHyA2PEnZHcsR/83d9RMAdWydtaskT+P",
-	"A9WXHFtNyZOWWp1FnHOdlE5v6bf/0PvrbJ93J612z/J2WcPvxzLL0X97bZYPJUXXRiiPQ6PPOkjpZ9Eu",
-	"Thno8hmnWFh00hjATKrlDExR/rQpgOmJeFeeHPf1jxPGDFNrwkL+9udmw6i+kRc8s2cn5V1BME1n5dHO",
-	"8sLiaFvF+VVEUPHw8HLmRlk5JCm5sIGBFyRbQ5C0KaZYZ+xNRlBgB/bJhxfXk9lTZFVIcC2VVwcGV1Jy",
-	"/z63anndzme6Nk3S2wUDNyzLdho6FETePip4GAodyFD3IJydRi+eNX/rlQ98zQSuq5IJjQWYmiJ72yqd",
-	"6wf3fE8fJ763hqtDiK9+0f1XEuVr1AU+kjdftQOPI7XSDb7uP6yHvSdlq/s4krihpR9MeVj9hLkTcXeL",
-	"mX2v7TBzSdUvETTzGjMExqp+2wSbPR3vCDb7r38c2Bym1sAe/tHtwWZP8C8KNn/MdLENOFsEgq/g+UVp",
-	"2hJq1zfDJqgdWOjLhtqbCL0abK+k5f59bvAvFmxvXpjtgIEn2D3B7VVXhFwDgm+rwK4PwX1PHweCr+H1",
-	"AMFLHfQNgq+A4C3VRsmh61H466rZJwDDy9GUhvN9wPCy13ZAvKLsl4jERZ0hAn/VftyExUti3hEar1jk",
-	"o+DxanoNfFI+vD1MXivY/A2V34v3W9QYuJH/lwRsS2A+vzM2QfOKl75wP/hGeq+G52soun/fO/7L9Yi3",
-	"WKDtgEPNy3bnQL28C/Y2YPr2uu36QL3s6+NA9bVcH8D6/G0C3+B6o8e8tT6RbBNWxxafAkyX7J4RumRt",
-	"wbml0ReJy/3ilyyEf29E41UW160DccsEHweD20k1KWPJbhN5S/YNdN8b6HZ8usjcddHYFmUHjt8IsC23",
-	"fOnYupmsaxB1I/X272frfsEQetU6bAmcJfv8MPM2GugGcFmyj4WUV7B0CZJRj3zDxyvx8VrR789+gDAT",
-	"mRYZJCnl2XqYfFq+8hu+cuxe+QRwc+PI7jnnpHEM7bB1tRbELQZxq/Elwu1Vc61x6grW3ATJGxfgjjB6",
-	"Y18fB7Q3T7uJ55oa3h6sX7Gw35D+PSH9FfRvs6/WqoSW5sHq3bexckUjX37hBsQNVmu1kdFyDfY/Fdnz",
-	"5dolN1re7eBUI2k/v0ydm2nv69s3jf1+HIOn9W4KFtBKlfvNKFplFN2+ltzOZvpEzaV7DDksdn5NE+nr",
-	"MI7WmUXbW0T3ZQx9EnZQGxhyh9bPN7vnY9k9G7bMKjF+TTvnWibOV2fdbBRjbU2a+7RmWkmQr8iG2ayL",
-	"bmS4fG4BmGtr19szVj4NO2UrE+WbcbKFcdJSlUm2wQixDT4Fu0OyhqBMq/dOMjqCrd54LRnmFd6LTSNZ",
-	"SzNGsi/TcHEcVjKr/XOjdSLvqrLyqWQfyQaRrJEHJLtFS0Oyb7bFfdkWki1zdU3qtrUZPKdvNBMk++It",
-	"gyaKroH/TZTbv4/9+gXj+uYl2BK8S/YZxhi20Dg3AOmSfSRc3szNJRSX7Bv4XgO+18h6DWrCN534PQ+N",
-	"PgGk7cdyzylQvte2d247cn2JcFhXrBAYqvxpEyz2RLwjaOy//nHgcZhaA2/4R7cHkz29v0Hle4LKumTb",
-	"Bo5fEKMtYXN9J2wu8O/45wuHz2upvBpGr6Tk/n3u7S8XUm9Ylm1v3sdXPz94va3muj7E9j19HJi9htMD",
-	"1C6Vzze4vQput9EXU6kuU0k3eLf/Wbb6BIB3GMy1/Nzh5V+5uMZbcy7yu4T5ocN2OL9cxC8R6E9rvBf4",
-	"uPptE9QPhLwjrB8+/3HAfjm5Bg4Jz24P7geif8P794T3pxXvNjH+ogRvCfnndsQmzF9y0RcO+jeQejXs",
-	"X03N/fvd5l8u8t+4NtshklKX3zP4j0j/kotwK++NrICtldr1zYDQ1cexA9ZxfjAEKrX0zRJYZQls0iTX",
-	"vYoP77J0u25+cSy8SAmDCaQyzywfRJ1CpZ3DztiY/HBvL7UNxlKbwx/2f9jHnehHtvQpPgEBWvt7Einj",
-	"+Feu5AA02SlE7Q5MYLu96vquMdDUjBHfz3/y12IASuCVnOEGAKK83sU6rrinj189f1b7WnlXwNrv4RFw",
-	"smOpixe92W2gZNrNUyqAZDQZ2+Hv4l1uXFSXEtQ6cqfI1/dS1mBa+6GqUtPar+WSaXfp8hgINTLjCSn3",
-	"7ARK7iGF4EbXOsAIztpPl696OuClpTvPIU/lzLJFRM4NNTAs0nMwEXlOIZPiHMxuLxZHRHMxSoEk9j13",
-	"xW8u01kmVT7mCfFXGDupShi3Q8i4oEaqp0QDkKPnZ939/f1HTpD6MVd8v3bgIdJU0XeummW4IC7Y02u/",
-	"Vd4W0SPHKdWaD3nFZf0apfskpTNQJAcVBv/4aSxss7gzHVPzQBMuDH63C1e51MB+ijt41Z8hKNEskbjd",
-	"K3qKvDzhlAwLUyiIBSRSz7SBrOu6UZCiUNZjnusIb1e0zd3DDLIBKPtojnxVtd7lKfszLl28MZWRpTxe",
-	"BVoWyhLVMpsUgBff2skm40JcWlE1oMklF6NYaCMVDReShzu2qCBjvFGwMD3yEofZ52KoqDaqSOwkL/Lx",
-	"TPOEpn2yo2kGsaCavJYMdg/xU6e/kYzmmkhhJAltLe9ckj1yfH4STizhzX9zE19ODlwmQOmRWEUCdyZz",
-	"ng52WIEp8Vrg8uJovOnXEyIiA6sYiJGELlMWb5N09006siWWz2KRKznhVm6DImOqiaaGa8d9FQXrDLh2",
-	"yv6Y1vK8f8F7eet3EUuBcyvvAN+r7gDHayCj8u7jjAo6ApQFscjnb9jv2ZmGnfDXubHhXYXLIzliGRdd",
-	"KdJZeTmqPnQXWtY6CnK4i3dmEq51QUUCUSwo3vnbLS9mhgmHaY/8HZFGEDjUdtJ3FwOTHSVT+Bv+tDs/",
-	"QvtT58P7D/8vAAD//y8qNaTZZgEA",
+	"H4sIAAAAAAAC/+y9+3IbN/Iv/ioo/r5VljZDSrIdbyLXVkqWnY02vqgkO1v1y/iI4KBJYjUDTAAMKW7K",
+	"Vd+/zgOc+j7DebB9klNoADNDckgOdfP1n8Ti3IBGo/vTF3T/2UlklksBwujO4Z+dnCqagQGFfx2nhTag",
+	"Tpj9g4FOFM8Nl6Jz2DkHNQHVpVrzkQBGEncr4QyE4UMOqteJOtzemlMz7kQdQTPoHHY460QdBX8UXAHr",
+	"HBpVQNTRyRgyar8ylCqjpnPYKQq808xy+5Q2iotR58OHqHNcKC3V8oje5PSPAkiCl4kCUyg7sKGSGaEk",
+	"VzDhstAk5doQBTqXQkM5xj8KULNqkO4lnfrAMnr1EsTIjDuH3x88bBrYiRgp0LoNtbi79R6o5Qf1mmag",
+	"c5rACfuZpwYa6HeGFCNSpLMwPtBkAKkUIy5GxEhixlwTEV61injlDRc4pm1G+5Jn3CwP7RW94lmREVFk",
+	"A1BEDgk3kGk7JLfOPeIoTJKUZjle+P0gIg/399+vGmWKn6oPj8GQFqnpHH6/H9nltp/sHD7ct39x4f46",
+	"KEfNhYERKBx2Sd1yw7QhckmnJir7/bSSQd3l7SlcY4TNbFqO8B4Y9bVkW5JPsvulnGTtiCbZfdDrFJTm",
+	"2oAwv8m0yOA4pTxrM768fJBM8Em7aXj2sYa8pWRaMfr7FlTLU9mCc5fmcJ9svDjy67HMPTCLZK2GJtk9",
+	"DSajI1i1usdUQ5cLDUJzwydAdDFwj5OMmmRM6IhyoQ2hYkYSKQzlAtQDTfrcvrYfiyGH1OICYsZgJ/VA",
+	"V/dp8o/zN6/JDhfc1H/lIkkLBmy3F4tfqGAzMpSKUKGngJ+OO9MxT8b2dZqoQpB+KkeP/3X4sHfwfW+/",
+	"/1PcIf/57/+x4Igqw2kai5RfQv2uPpnyNPVzmH86mvv7oB8RMEkvFiv4Fee5ClA9/P7RCqpvKx3sTO9Z",
+	"EkhmNYMd6KoRvriiiVlghGqZ+1ZhXNgR9HvkJRiN1+w7CQNDeRqLCYepX9f5RaUKyFhqA4xI4ecqGdiV",
+	"nXIzloWJRU5HXFBj6QETUDO3ZRyjBSGzctnKsW25dHab8nYgQ7tb72EX+0FtyVN+fPfNV+egNZeimYJ4",
+	"qUYxsoOrKeUlBzKhaQG71yNibWWfPG4a1lt5CaLNsh6dnhBjb76HhX2n2xmphb4XC/WfUl2mkrbSX1N/",
+	"730O6x41WZjetursFVdKKicK55Uv0ZIMpBmTSy6sBHRS0d6naQaxCPKRam1lqVV7Dk8FPweZWDQjhRWS",
+	"fxSg7cRvV28FQv/KRSsJE4ikrWWLg7VzWyVT7LW5Af2XgmHnsPP/7VWunD13Ve/VhzI3ti2FYDXE+5SC",
+	"HyzDO08N+qOeUXYGuGb2L8s6IPCfNM9TnlA78L1cyUEK2Xf/0nYWf7Yk1Kl7yn100fuQ2oECI8p9vNf5",
+	"EHWOpRimPLnXkYRvonInSaGU5WdtqAGyA71RLyKscN8HXJZdHOrPUg04YyDuc6xvnezXVh1xRgaFISlN",
+	"Lt2W1onMgQRhRgYz/FXmoHA0OOrX0vwsC8Huc9BnoGWhEiBCGjK0X8ehvBO0MGOp+L/hXofzimttd5pU",
+	"hAtPR6DKyjtL3R7uaP8e+5mjnCPZGzxoYCijhjoLgWQ0GXMB/jXkrQWjKeXCwJWxayYsUnQynOtYhE2I",
+	"5gI3D7QTCqWPVYoE7CL2EwXUQBhG34nVXNmFNdztYXcLu6BmTgIwaqBrOAJNBZS9EeksKLkFsRCV7xjM",
+	"LqxKt2KlQZpsfA1c5VyBXjcUUaQpHaSw8h3X/HRKtbFjZ9t8fONbnbxdXPtfioyKbjKWGgRJ6QDSICz6",
+	"cSfhXQUpWK2f8xxSLiDu9BE9zim6Jw2fyxUM+dXyB3/mShvyA0nGVNHEWN2Oiq3OZJ7znnOdp3QGjFCr",
+	"VjRnEAt7p4OOdkJW4TvJYAFBQktAOSNO05sgabiwCC8W3vQhCiZAU1RVYyDDIk0dNnZsuZGaCiby8pZX",
+	"CAUf7gP0YNt/LN3jf6BK0VnH6cAA+n53KNAbZJ7+5VsbN0ZU33Hvy7fLwb8gMfZzYbce423Lq3lKZwhQ",
+	"jSQZF4ZQImC6IEGWdvn81loM1Nh/0JTgTbMeORkSOtAgTESqpS81RyEMT4lfDPul623UsDc2cnW1RAvI",
+	"HX+3ZBgpKkyPHLGMC6/KEiqsyhiAuwhILpyItkIzFtTe3EWxCYLlkgvjzHftjDl3CaVzkshCGDrgKTcz",
+	"j0wDs4AoMssGltE6UWequLGzZ5CCgdryVtPJuDhxTx9sYK3SzMf5r2OVl1ybJkYZAXPxNbvdcfLLnFFO",
+	"pfzHOuVYarSlfRF1BFyZi6SMBm7ggMV9hF9fN8lX3Gv4NH0z7Bz+3nqgfy7M2DSr5NN5WRgRx9ekT9VI",
+	"6oucmou42N9/lPxg5ajGf4P/SVHBZOZ+slr2VIHdP8AIXNHEpDNUyT1ybqQCKxcp0ZAoaxBlVNARqKeE",
+	"yRh5NpFZxu0giMc+Ft0omTrOW09FN7VlKr5vAFYOQZSYoQkuIBDp40v7xNmRCVWKg3ZKAUV4pUMsGklk",
+	"PiPcECGnkf3/VIoHhtA8B6qsjTodgwICqUapb5e3YNy8mHj4tiCZhB1gIhXzDgyaIBwl/1TcGBABqFL7",
+	"DpJxxlKY2k1MhwaUG+NU2Y8zMqaCpaDQ7rSbUz/1qKrIrdxCCzlPrdXUAJLcd5cH+FyaroacKnzDBNSA",
+	"6AKNXdK3Ar/nKNqPSD+49tzn+lEs+hbE9lI54qKniyQBre2NtV+HlKeFgn7j0kd2VDKArflxvbYLY4VX",
+	"gUjZqucEh+gtJu0QB7EfsDLCfk3vzglzj5w2ynE3CDSCa/LQTt4OGfkx6lAhxSyThdWJeqYNZI2y0b1L",
+	"yRRaCJBwu/1UUCYbH3EeXLemjHGn+E5ra+2em6fmEa5+V+eQ8CFPSO40cI8cpVM604QK4jYamY5BkNxt",
+	"/t5q6lXCbWxMfpGBGUvWiD3wOvqdVl615mZRRy5lJHwVGl56j0zQdl0LrRrgmJNPjQx4jrfxIbcbiwW4",
+	"aagagZMTGZ0Rr6Epeffu5LnTtWnq/Ei9NqxXjsBdWRzDr1wsftluBDPzzB+2pN10lolw8+X8wsm73VZD",
+	"CCTIW3EfYkA68rJuSwVpV66+UHNbLwoiap6l6gw0zy6NmrYUxW0AhRO6YG/XkcWgoA0ZWlPjxiCjUgn3",
+	"CDMKMz6WYshHDRNX0EUZSaw0tQp5yEeF840QAcAqn8m7kx45QW8EipZ0Zq11yuwIQwjIvURLvN+9Nqcj",
+	"xKxEgWDeffrm5PlxLAaFMVKQAQwtcrC/o9N8TDViCMSqTRpLcpZgAtm8GSDsQOqiZiBlClQ4G3gA6fLk",
+	"n7kROENVioVRRwT3Utw55yNhdaidZCzeXBoad3rk2GGX1AOMo7O/vzm/sDO7eHn07MXLfhtQEwa9vGoL",
+	"N+Kcm9b2eEzFCE6p1lOp6i7LBXeed+Dl/kbyHZpW4c9ltvYev4twx4I9c7D/8HGT5QPTuScWfUyY2kQO",
+	"Htbt9RwUeX1y/pb8sL/fffLoGRkVnFHElK8lkWZs4Q5uJY1KjagiBe3DydaSx1nkY0U1WFOOJgnkBrmS",
+	"ChYLa7qClSxEWkykx1IZD5WuiBu6dmu1NL+Mi/KHh5vWcoliC+RoXD0npttjf//AqwIn2GAB3IbP69qO",
+	"ptk2U3mJty/jd488+lwMFdVGFYkpFFzYfZnQtI/K1JOhR87BBPGkMdzVWxpps0H+ZH55H0adnBoDyo7g",
+	"f/1Ou//e7/743v+/+/7P/ejJww/h5/9qwgwea9+A8GvcL460c/6VuS+2MIuOyK/FAJSw9kGZQqtgxO0/",
+	"oIyiHb96/qxXY83KVXNLDNrsODx3G1anxaiLmSFVjDIiheB/FEBooqTW1ShjcZJlhd/p1ioiSJ5Sa9zd",
+	"ajd5M1osQc29FQjvXVxlBlZF+DY4xT92Y9dHEEObIcm6PGgjURKjhfiT++1vffvrEEwyxnWzb0Pd2ovF",
+	"EfrhiFTE4hxnXwhJMgsG7C2aKMgo94t5W1hogT8bHMqQMm3BAA1ShpgxNSRJuaUZonsNxuoWklJTWtnL",
+	"a4B+OuTHNUZZG626MEIF0LXyhVzuTVAaZiHiYq2OqVRmTLjRRE4FSWRaZKJHfqNpAToW6Ab0Oo8cW/Ri",
+	"gTZB516IxRhZ4HJx7Rwj5W6qj7uWslER15oYweXYYLRU8ufo9MTLa/Lu7CXZ4cIJTCTPgrGueKcxLsOt",
+	"4Z9yM2tYxJJEhoNy+M5ON8ukcH55fUj64RXWOBrz0RgdFxkwXmQu5WzatxDEmlZF1gU7xATYcoxAp9IQ",
+	"LtAnwxWS3dArKWQ2Izun+3unB3v/+e//u7sklB49bFprF6W4WBdfGSoOgqUzN7GIDMN0W4VSQEy4kiJr",
+	"dEtVlKvdRgwdlUFfmEREGzriYhSRXEm2GMB50sTCl+XaX/iciAaM6rdbjTn8vURBLpVxSLvGRjseoB/0",
+	"Hv7Y+z7uLA6lkcJItLY7spmEC5pVDbhRVM3QfunqIs9TbhnF5bJcwmwPec4tl+613ExCmqbYwEspRm6F",
+	"ciU19MiRmJGMqktmGY9rb2fhORkrsbqaM1igyw8HPzZRRk5FU3JGxRPO0YgyBz0PQDOyR6ToJjRNnZiU",
+	"U6F9KDcpQVqhhjQJiYMh19BZhloSLhLU9v6oDAOlY3Ep5JRMx9Lqjym9BFLkSxtoVahQTjhrmsg7++50",
+	"ZhelxkSM22cHBdoWUmGSo70lvKcXizc5iK4lK3uKPuyaFBldWjvxUkeE2v/IHIQe86GJiLJXLN9TlkVE",
+	"WjvE/t/aM434pMEHNPL7ZOOdhRhIeXlRqAYj9yUXly6BBuzqYIwSaPYAE5bsY3495xPBF+TvJiX1YbWq",
+	"fYfq8foIcglGvQI1gm6OKWIDyWY9YkE1CVAQdZZ+SvqY54rB2gAT7VJm3FhB4u7CsFgKQ0MKkaAlzbzv",
+	"/jgkizXjsOMql4xqLROOLmjMlbF0Du67HvlZKnIqmdsTRMHQalwEsbFI+QTsIljzgOzY4UYEk8D8/y64",
+	"P1NWZq6do4cLdES44CYWw5SOdp/iAv6zTJvCrAmf9EsMZLmFKQ80YZCkFAVDOfhYLHxWcLPbIx7XcUEm",
+	"B4cEaDImIIyaPdBEj2nuzGwUnhOIYqGlA7EBTnThyqB1X5KZYajEIzRCic4hIYMiyxdijusc10v8tQhV",
+	"fwGaOm/yPA6rvMjBhS8vG330KzXTs4KnrFRG3u+qCoGbCWNo6EFZj0nXeCf9ybn2e8Q/8DW4Acqspwk4",
+	"29/P3dr+QI6en3X39/cftzb7H817dRoNwZ3fu/5ffwk/7f7UaPTPpRu2CUfcnZeglvV4R04DT/h1TgN/",
+	"y7ZOg43s3IyGa2MLp1wxi2fn+evzrnPqajNLYbdH3jkXQg6qlkO6jQPhbvlm0chHX239SGSPrBrqU2dY",
+	"h3tjkRXaEJpaNpoRuEJXgcNrjhF8XFyTx/uP3Tw353MvejsWme1Gzo+wdgXGB2g9ybdiqTbukPIo8U39",
+	"IUEefwX+kIWtt84fIkoJcE2HiF+fiySlWq+wcIMEsbe43eyOm/hYiyIDzMU3MhikcUeMuLiKO/afRlEY",
+	"8stlS7Apff7zMQXtxrkY0JSKpPnQl5VENCX2vm64zyI0tx0ikuEZBy5Gseg7HNKz9z7zt/b8yvz+vt8j",
+	"L0q4R6wV1/+T5z9FaBXZ5fgpItYU1z996PfIqcyLlHq7fDqmBv1HwyId8jQF5rJUAtO4gE2SyoLV11MK",
+	"nydUFnawZpSKxSswNH35jOyhDur+dnJK9gglY6oYJsKgNCknK0XXGlg9chQLzcUohXIOxMxyntD0KcmK",
+	"1PCu+12DKXId0ndcaI8VNO1qQ5NLsjN5/N3kyS7B+g6sEIwKQ347OdU3QawZvfIJcjXPRClaMK61ckcQ",
+	"JQu0S/G21Rg9pDFV64G2RgnOCWbnonByR23Jjl3biOTUjN1/MekgIgOaXIIoT83FArfjHq7/7m0Cd5M2",
+	"TPvty/OFaLSdHm81dTshHQsrkZw1NgQFIgFGzjE1DQXL7c3gw2q5uq3xu4iEbmT8Bi3dR9ns7WGqIBaV",
+	"RUzaGsQvA6xfkHivz89PLOGNHCmaj2cEYafLXdNWL7hTPFZkz0H2h8GNFItLLljXyK57MqN5jnZVWD3v",
+	"FgYygDH3P2p+FW6XDHwCYTDvIJE+EyvqDArNhdXlUadmSdi/WMYF18a9Ho8TNcUbly/k45nGK00m5Es5",
+	"4mJlFP6dz+ci35WR98idMAvKellpbheAr2eMbdBdCxChfDLqrA1Zv4Kmk3woyl3MzswiomQKEa4gDIeQ",
+	"uNN9mOzbgApYM6EIZw4EWfb4mx1eVJ7yrF0os8I32l4hkW/+Uy4/yr1wPqFwwss0FH/eNSozRu3tsbB3",
+	"9I/8eR3ko0PyDE/N9Hvk3UnwxWKetWJWK83mOXUul7AxpbrQ5sJtxDWJFT4nd4FcPfJWFc5bO5DSWFbP",
+	"CbK9xqWx9+hYTFEflIkhU2qHrV1cnQr3ACpvlwNEBqlMLrU74B0Lq5WAwFUCuSH9PTfUbnhb36fUo/ML",
+	"HYyWOmwuNaaWphPSI9vJyjPZKCFXEGNdvv2LBSb1JpYdzn/+9/9xafdBLEl/Isq70/whsqj1IQu/2ivg",
+	"7/LgS/5eu9fbkWCTDCjPe65Myy/PcrZfpvKRNd6qqsJIGyfK15HjUtLtJlkut+u2uBvv1Vx9mTvyXVW+",
+	"lDXeq6q21pb+q61ZvNHfU9W12+TtCXda7RCL2/T1RJtdbRUpWzjbqqofH8fVtpijt8RqN/JcVaQIvqt6",
+	"Ik/JFW18V1WFtps6ryoR/RW4r5Z23tqEnvLuLyGl5+28We9yd3wiz3WSd1pm1JQn52lay64hO23SaXbx",
+	"FK7hIjEusPn85PgtsfPsok+QD/359sjCUp6MScongIs3P3v9qSTTfGHJJB8jTUTUcE67RJFQJYCB0uQG",
+	"iSJjqtuqOrzXisKUWnk9QBjGygSkI7QenA/6LajMV8GKO7tz2SN2jNYWzDJp5QsWtqn4xn1Ek7mwllGS",
+	"FVYrtGL420oEmauzcgupIKXg3dYftoysru0Rq3T/rfjDXku2zTwk+2b/bLR/gmvNG0CS3cT2wZDPxqTv",
+	"Ekj2vmTrR7L1ho9k29s8W3D0Z23uWNpVlo4uBkxaHHtL1s4tc+kd2zuWFo2mjmTtrBzJbsHAsZL3a7Bt",
+	"ajtsvVljl6WdRUNeSQZ4ZlGKWLwClVAj1QNNvOup6xOvgyMfMxqr3VAeFI9FwC2a7Dhvv6Ecj8smUvgr",
+	"UVUM5805wbjqbo8cF1hSIBYhi75rAWWpcHf6iC+xrkBlkdg/EcOiVVGDOXiyubLK0PjwEeILDA31d1GH",
+	"57VQdSyAcUzf3wv+cDNWshiNF1Gnlz/zRlYsSisLssaSCmkqE4oLd5HkRUO85PQdsdzMCmSUhax2JzFc",
+	"BAtd8WriJtcmu73+bcjHkIGi6YU2UtHRoobc+IIMMqlm2z6VS6ZbPfMFG9NUJWNuAGFN8/rX7+iRNRnm",
+	"NGNPHkeEqsz+L8+TJ4/tdtOPfty/amcVJDSnCTezZmZ8Kw1NiR0Sij0HFTDHw0XAXLpIeEcvyQuy80dB",
+	"UUC0OnBRfv5a/Fg+3Z4Zy0facmIlshpPJppC16Sa81yUhZN3ziwaicgrHN6pAq0LBVEsnnN9Wf5JTk+e",
+	"V3+8BjOV6vKdoBPKUQTs1vNu8MwyCmKXx12TDS79WlvNTNH8TaggQ1et1Aq2vp1bf88n+fRJVZ8sp0rD",
+	"3SWvlDnlFz6hffU5H1+hIjzADvf2Dnp/7R086rc5SXQvbqpP5aiWT+zyRTiaSt+F3K+TU8eXfrvWcr/4",
+	"kFAxW/je4+8bPjevONdRd0AVdK1YTcNJLXyk9Ic8hzQlp3IK6gUbQSzOnjzejzu7eAYvTyFDkOKgvSxY",
+	"F7maWXNQGyp81ZO+RTCx8LZfKZufknnc0NLZM/fq5anh+ciQ2Y9l0nvVkbUel3vh+a4bGi5nLHy1lewJ",
+	"712lVI2wHNK5oYJRxS6eP9YXk+8b2Ong4Q+NQ1yz2qeKZ1TNsACHX2+/xs3r3ma9L+380vpG3ThGS5SL",
+	"XMmr2YrHGneKfSoFs1ok/OpuICNe1kwmmIew9tjf5Gs+99fOVeukoBhd+ISoZbvonAxpxtPZOnr3Uy6K",
+	"K8vbUy6YnOp+K4pLfeFqWi8X8bKa8825O3YUCBaW9d2gEKYgDx/29h/3HpGXb8+b8nmf3INn2jmg7vf0",
+	"omQXCWeqzbG/cEKx0ctyjIm24ZZ6AX8nL3JIeuHqyfNSlNGpPtzb24OiOwVtugd0j3f36SA5ePjo8fdP",
+	"/vrDj/sMhg0irXk26KlpPD03AcEBa/m69B/CQPFJaKKGUhiBVd9LtgqA9WLxNpiV5Y9kBy1VBVRLsZdS",
+	"bd4qKlzBmLc8g11ftBXzDfsVmOsTRDCbEpIauNdemh80qo2u/X1Bd/ylH0RALJYOobtM6G6eUoHawwJD",
+	"Z/6CSVj/nv3+kl3H5R91nPHfVMkUrVz8Jt5S4z73w1zC+ZhixvklzCJHosgnEH7oh/4xkpGUCqYJVlt0",
+	"LeSGhJtYGJlaaQc+N819kLj0NvcWywSvpR8T7L2WL64gKcwtweLaHi1hcSFqdv4yeZAOc/eUmXaWhRKT",
+	"Wg5RTIo+GaZ01Gvk0n9LsRHSGJnLVI5mC6xpH11EM9Xeb9jnT1oGfCTbPtZT9yh/KmGexR5W7aez+OS3",
+	"8M924Z9F+t1iKOjg6w0FLVJ1XViosYne9TcAPv5VHllupMSnxM9f1TnmxtXYeh9sGy/dcjdsjEue/nbc",
+	"Miw5l2Jz7cDkrfPYV33m2a5e83nnRj5pE1td1a70puHWZi3wFcRf1+7YtQFZu7rXzTDFYunogZ1fok0m",
+	"YGWH/LC8NANZCHbh2KJx+/38a7AQlwACGoZ2RlwTfA+e5Atl2GNxCoJZ++70t2ON7YOcxXH6G1FyitV8",
+	"B4DHZVLAsO/Om9fk+YuXL96+IOcv3pLX716+3G3ekxuLTn8uLr3NmYaWvs05hofEEzgizyz1I/JSatPS",
+	"LeAOIgKrB9wWuyX4W4jm/waygxZpKF+ke6Gofs+/YDfCVgDU8Ky0F+PO93/n2Mmn1aD8mxaqAGw8q++Z",
+	"t1kvntEp6ePQ3W2v0eYLpvTpb6GSAB5Bww7UNV6OxbE/N4xIzC01TEA4QeOiD8q79xynB9YWD0wskL25",
+	"GDkyzsA069IWVnOjxNnWjF4PNG79QLGrKXkLlvVNAdXXkIzmObkXSpN28agei4iWoUruLeWhHXzKeWjL",
+	"UKcpKW2RQa4Fom4dPn2NyKkdaFoGHreCoFZuJncjRq510BNwlUsdqsuLGZHDWGAg4p+KG3gjEvTRn3nT",
+	"9hUVs/A33uB+WHzkVAY//u2guZDf0tC0pyzx52/ZGEXtx52D/VJ9YxMnVqr4pySRIsRjjSSDGR5K0IT6",
+	"/BN7PQElWuYhWU10oWC4QotbrR0c1k47W1jkIAk+ewbDnu812qK6z/znylPLy990BmebD+OdLb+u+QVT",
+	"fNLY+fj8hLhrDpiUOOP0N0vd4/OTLhZfYWEMmvfc/XaRyg5IXHSNAiB7JIURTWZBGAbw1gaGfFkgejOG",
+	"PgoZVwFOx+LMNaVkEfkZe0a1xdaOv3KZ8mTW2NKYckH2yHM0fMgeOYNklqSLkfuDJ7eOkV2UuzHsmig7",
+	"Fstcdin8Z0JYvGI296Jf8OfdgKNjUfHtAz0XUfbAp6gK7DKuL8ke0WOqYImg3zd309ioR24KhT+96JLr",
+	"jdVyNpJ9nd5zyb75yj+SrzyXbK1nXLKtzbZ1XLzRALLjaXkY51p1Pr95ve/S621Xb4XXW7JW5plkNzfI",
+	"JPsqbLBqn603uyS7rqVV1RHf2GBmrpr6Z5WMyaCFtSLcCSxXcp3rcLgHkwZbWQubwa1980Z0e+Zqkkfk",
+	"vEgSbN4XxcKh2sgy4DvMTBT18yatzqS3g8S5ZM25y5KRWr7yzsnp5LEdzcnp5Mluj5zUm788xUM62I4b",
+	"T2tRTaiIxckpSbkBRdOloTSmNk99NfxGqftW5t0UJpCWRfP9DnC5eP7EjyX4znPIUznDJih71jymBoZF",
+	"asHIHnlOIZPiHMyu6yZcHR+a0vTSH934QccC01LPQhFKkoypr6hm0U31BX8OLq91C9AynYCOhaVg1/Vg",
+	"JmeA+MiOIfxUvaMKzLj3YFakkLGoV1x15U6xt6sdGVYI82XsCZOgxQPj8/lnYLybPyL/kIOIHCsp/iEH",
+	"1wvYfGgWU1uj+hqC+HTqY54qOUibMqzPfj4mf/1h/68kd3f4BOIGPeYuNNaQA6Wk0iskuWdmv2mwVCre",
+	"Hvmqhg5QD5zpWerI+W/j9Bo/nYHWPnS0Xhe5V1QPvG9R+jUcq5gH0s0tn6o+Dhm94lmRdQ6///FHhGvu",
+	"r4P9/aihU7DhJoU1lfksTYe0SO2n6UAW5nCQUnG5sQnVYoNyezV8LVrX7uFMNivlK2AurdiqXwthfanU",
+	"v/ocWbyW0RzLX1MyxAdcdULteg+7isvup2QMyWVA7FbeH52ekL6GpFDczPqhjiPXFStHzswPRS9rXcf/",
+	"hVDTGJqMQ5zMVUqcy4DG3Oe5Apd4vNb+jQduO1EHW+vivyYcpqAaq16eu4rD7UWCf+CrNI/93D+dKoFf",
+	"lYHsqb/OSPa3bGsob+TpjcayL9z9rSnGZ2gqh7VrNpc9b7Qxmf2Lbmw2B5n8FZjOCztvrfkc9v91Tejg",
+	"T24wm4605iNrEfhg/8kp2YEsNzMU+78AZak1p/bKM8BokYb13m1zAvRbA4yGBhhoMPh11Wjhz3KIRf9l",
+	"7YF+aCqRuq4Ds9Cd4Knr8IfPaJICnYADZbhbCK6f/QR2q5irSkKaGl7Eoux38fLZ06VOGUHfL3bVuLtz",
+	"/lgYouGcl98GePlWm1O4/nT2vRExVI3AXLg/ciWNTGQaoffl4ta7UmhwY7rF3XGKh9dQBfuX91xzwMza",
+	"qz7tTM1q2wT79eK9rjdAm80SrJoW0vytvbXRLq/fsA5jlPJvlkOPHFNtZ4HT8XaCtQTmShoaDekwFpBx",
+	"xymlI4oab1jYIYY2EvPOqWFhCgWlf0o/tftDsBTUnPXrWvW6708OiC4GOmTlBcOklKkdd1jtVCqLBOt7",
+	"vBN16pJ1naWyrQtjEdt9Om6Mc2f7NWgjQairkT8uMipCZ4QGlbbZ1GoodJFzBXqrZ5pAoh99LTbtCYe+",
+	"WQVDfoXu2TE2aZa++tNTJ6HxRDFH/62r/5MCvXR4njo45XJAQxmVBm2qzUWht5y7y9bwCGBjyrNVqxd0",
+	"5Js3t7u9rRm2sp/AcxD24ZRry0FS+aYQSXWMe3NvAfxmGM6C/TVHuDluaIZnuMhtwK/nWM+rt4CB3ebY",
+	"jIFvC4q+041Nd/wetORcsDyrbqS37wBhXNs5rX3J4sTvzquiDfZLELc6mlX9VlaXBtjcoeQ2HBw36exT",
+	"7jzvAsGRb+MBcWxY+S9W2rDelnYWbMWiy9zYrq3Nc+eWJZYiZTK/9tV1SOyci67EhXb1Bt2GkAarAEgR",
+	"iyEWSUI+iTtkmMqp85MNaapdHRCNYTLXDAc3UGFkVvN3LK/82o5MdX9IY9rYNmyzZsnX+l2Ouv//fvfH",
+	"3kX3/Xebc7ObGj/5ca5ihTaiFwl6U4GL4u9+pW0F5TYhsnMw2JCvX3U7UjCm2iJfi8QcCI1Fv4nb/2ZH",
+	"2q+9JAhXd4EomMhL+7SzCOYVWZVwp4OttxBJ8i9rFl3thdw9sXqTARJCs+1BdXjik4wChOZjbSbwq733",
+	"HiIH4Xvfsus2BQ98Y6w7iiGEZIV6W9Q18YSwbNsGFDbvj8Ck273PsevSFMvcCkwvYNxew8YIUq0/ht7m",
+	"IFRJsrZH4HfKFY1wQLvfjsLfSqSjvjNuFPAoV7Q54jHHbK04o7aZ7CAbnVN9e6XvnCKxWPJSEe+kOqry",
+	"oS6x/fROPRkmqqXk4HECL2alOC6HsIsxgQFUHT0wtclOHB1krh5YWa6VxsK7wTI+8u1vd3TVPPXR7rw3",
+	"q0oA6kSdWpZSJ+qUWUqN/qtA1jaILlD2xqiuVO1fQSxpUeiuDSYtpKN9S8hcpifKtQvl9lhDIOJNaM3j",
+	"BKC/kSSyCMlxKERdW1JnHfoCgxVRy4SixnSi1d9+DtoyxKqPPq0yBrEsgpBEJzSlijD/oHtg4wh0Dsmm",
+	"8MaCfOSClbX7gw94vrR9MpZ48rEee8ETgtgiGUazWMynK0Yh1Ij5sS4VpZI8u/M1zTUeLIwF1eQf529e",
+	"P5uzrcPqrjMDtvWwL4Gd23GxR15lYHPjWFTO9u1PwGOIySVjndtBu13m2gcfFXab/dkZ4F8/BwXt+gQv",
+	"7bTTk9AYWesCGJGF6cphd0AFQnuBqqa5TzHBDNIEH3fJpP1eLGJx7rK7RooK43OE3TcOY0FIl/Tt9uoT",
+	"gm4ZVBBWOo3AVIW3tb8Tq+j33Z3BQSSY325kh2dWLujwRh8ESrCj9APtcCPY9+3697lCIq66g4JMToCU",
+	"9Sr8LegY8p+kaRqytOlATuCpb6ngPdllRCnjoovVJEGwXHJhtKXDWztn7UK8WMTSggb/epdmh+NPuEln",
+	"RFPD9XCGKdTuYtARWMaaioo4SOTTWopfRDKajLkAR2bHNd7AmOvE7K2BdyexQETQP31z/pbsTQ728Pqe",
+	"e7y/SxR1gegxtQ/9C0OIZZ8LEBMyoconduOmQdMfmaLamWNj8prL/Ri7YK+odb7QK5v4FtK18RVmvIeu",
+	"uH6P/GJMbvdbFItzmsE5N/C3c6N4YiLyQ3csC0V0yrHcBoYDZj1SJxfS7wW6Rkqa4oHu3GgCHGfer/ZS",
+	"36r9/tws+i5f0q2Tjxhmro4vZbUi/yUnYvbljnMZunDCLpEqFm7r+XRIvO6ouItVGbDM8NQiFTPW7jik",
+	"M7NpBrFgciq0UUAz7D0uFdduKpi86aPZlsKOpgFoW7w0kvrCD6RaL5rzX2HW+fABU2uHsiEb+cX5W2Il",
+	"hh3oX/5yZN/zl79EhKJ9ib/WYDCICVdSuHrtNHXpKJg8jnF71/z/HJLXRebqDe+cvz7eJX8UNC17OZKh",
+	"ohlY8IiL9nbMdVnje2e/d9Db33VHyqc0dadSL+0OR0aagAULXua85BMQoJ1zza4SNvbHtOpy5/uwbr8U",
+	"CeT47N1zlGjFQMMfBVZ2cF+3cDtNCWUMOzlEVXvQqERiETmVzHWyx7yOOSPBNcnxJkFG8xzPe/g6So42",
+	"CVVGjhTNxzMX0daOczE/mwxlmsopKTPEdyofjRR7Pl/8u39pKUJxHV1kGVWzOZOnm2DuSeJWcHGVyPIi",
+	"VQtS5itbvDaS2r3i6PSkE3XKYu0dXCRfTlzQnHcOO4/wJ7SDx6i39sZAUzP+t/33CNCWKDfmCescdv4O",
+	"5hd/i8VQLpCKjz7c3w/g1Yc161Sws7e/OcW+Cde6T7gN0JyhwpGRJ9aqrGngzuHv7+vULXkNucuSiY60",
+	"Rfpump339uE9xJj1KS9U4AXFh1a31bY5g9xCIpHY33cYNXRANbgeRQpoMg55+kvUO3Mf+9jEc7jaSOco",
+	"JEbR4ZAnaKN/v/9ozVjq7Nx+TOFYxfpBCenk9mz9qp7NC41Vy1rqUkxWX7m8aB1H1oYHbbo+0uRtZQWJ",
+	"VAwYilqauPZN5MzBAe3LkOPrPY6I6lhrIM24hBmY1OHT5vuohbRTXf43jbDLzt7hlwnXfMBTK5mCO8GB",
+	"H/ebkT6LLBYu5oWWtMUMKJl+xl4yDn4cvX7eTWQ24AJYj/Q1Fwn0yR7po/XUDxW0cC4ySQql0P/ZJ8qi",
+	"XLIzpumwa2XGIen/jk9HzvDaDeJsnsmtLXpkJ/ViYnkAxYsVVQYN2hWAv7pl7yXPuEG35oYbj51/wd65",
+	"aIxjJx0jsf6XhRIeyqNznOsynIlK+Y8C1Kymk60d5bxiFW9vdK5tHALF0uVWMVJSmnClekPnqi/l4rMC",
+	"rZFix+maNDSNNDx94c+sVMO97eFxtnEMCwTbYgS1D7othoVrAjVwqRyCXk0J99ymATQ9ifzcvNRr0n1W",
+	"vQ23xfZve3+H2qDaic5HtCyAF3Jt7P2eK1AdPN4/WPWNctB774QHvv8G5h56tPmhn6UacMZALEr7efv5",
+	"d3faqPPeUn3BhKmuLeh9a8rWZlLTEe4s04KKCLbAStxj33gebrpziXaXDFHPu9rIDVXK1SfCCX7xGjnB",
+	"X2vghIaMx9YssfcnZx8cbEjBNKbVpeD7SBIlp08rl7Uvu4mWpHM74PFktKtHYDR5vH8QC+q0L3l3QhQw",
+	"riAx6L9DG7tJwZ5hUsF5aTUusMrjpipG9gl2f6ton3i8+YnX0vxs0cetL7ubMLpb5lIuGhZ9283sB3DC",
+	"Oh/ezzGMg19rJchRzp0r6vMWIWEa7WSIh6WftQRZ8OrtlL1IEav/57//h+Qp5cLYXV9mHU9AlwHe3WbO",
+	"k03xujMf2i2zmat3Oy8VXNHEpDMiRQLBk1hLavY1ALz/X/vuOhbkqZEUDzkjY6rHPhWPaxe1JAk2ciUD",
+	"iIUCozhMwAeqeuRkSFKpTeTzmdCYybgwPugrBTTJKZfZEJilUxYyfiZdN6lb5UWfRvFhPqbnU14WdsLB",
+	"rX/9FReNOwEvIqmAPa2to0tdr68fxi4cu+9vZvdnlPmSz5/rtnpVsc/c5tqklt0O3KiUz6167Tt2RWv2",
+	"qTs/4lyHoR52TTP7z1uTH/gEYvF4/4DwLAPGqYF01iNuLZWcOrP6EnLjsugRZ1p24qKwtrndWIX2B8ZQ",
+	"CoZghEuYmHCYkpziSYSJTHxX6JWKfm4DfdP0KzT9Ri7aVuMizZe1PHpb1ir5d3jHZ63gy+zgjcrd5wd/",
+	"zrq9ynDXa5V0k3LDzOa7UWy1ZP17VmouXXt55e3vIZj5Sasq+8SPm584lmKYcp+ycJtsdRwOUFSstUmt",
+	"Iftt1GrHVCeUufSOkDj+QJcmLeKyNyfPj/3JOcNB90iZWKCdRsLTFQ6S+HgF5hAxUmvpcfbi/O3ZyfHb",
+	"XR+fRxlrxpDFAq7KSDk6y7EiGaJdvCEYXCG3HQ1hnGOThnO2c7mLNmk3d/unrN0+Nuv5MsV0FdNFK8N6",
+	"zYuwfy9S5euBK38Hs25xtsMMlnQnLmkbE6DWH3fRkFFheKLv6swLZm3iKa82x16oqZ17medGlyW2lW7N",
+	"qol+tz1f+rS0Vnr2HnaEO4Pgo1SfuJ79mJvJEcrvJ5/bE5HAp6iYAm9ieiis0cKFGe85Ru/Wj0s1e2jK",
+	"lABMLSoUZvpX3/U7yak/dI+QneB72Y1ikaRAlSaNu8vlJBIuQvHM0AfZJ66sOEKmaebPkfmUwK4zZ13e",
+	"kwsuP95/5KvLhXQ49Pi4AVRUDCNpdOngvae1A4Z3gHznP1IydZvN+bgpvu/eQ0LW5ufkZFncB4tA0y1d",
+	"nQsXFrHO8cVcagQyvBRDPlqZGhEckZdCDhw7Y0zCNc0XAEw7hwYe9UB3omR0hlUGYzEdA+bvOTyKnd+H",
+	"fFQoizoFiwgfEi0j5/sqjJHCpZD3YnGCPIQZ0emM5MUg5QkWlMXaKu7gCzDXOZxb9Isd4ieNPsi/g7Hi",
+	"5dhN9E7jrOVXGkS6vVpSwKWOrk1xOcVJYzbh/GMhUuSonyvo4pKsX2Z3y0pp9uLKbQ3tZQAmgn9XspBz",
+	"ci3khfbIWXkA6SAWZSVad7Qj1EgdSDbDMxFiRoaUp4UCsiOklcqGCxfsH4CZAohYFK6qsbNPrAwcUFYO",
+	"Yhfxhib9uZTJPqG6zEEl3y0lobpY3EDJKZquvmoRN3ZMNXegFZ5dqfiIi1iUvsFwhBzLQzUmunjK34UM",
+	"xHffVPSFOiqlzR51xtjwBx85B9NdlQp8Pr/YazMrPtybPF2zYc4NVaa0uBuifY27QhZm9baox3Xdcdqu",
+	"5qxSvUpOkU29NnfnMJBcsfCFuzXRPAWBtrJUpTK2n7cSznKGGJEJpz7Z2NnpsdgJws75i+Ul7BKNEWFZ",
+	"GCvzOIMsl5bNVjCmndlWLGIngcpxLUZrBGcLSumFj2cHjbTFkrjjomt10Vwyt3dzzCIP/cBlMU1CXVuH",
+	"pVxqWyPYIsOUjlzdbwy/01C0u9RrsbCv7lIs3ibohI98ljpmL7twfXDHoNnEuh5Q+QNrTSrpFdylKnoF",
+	"TSroGIlWkqx3K3vwGuzxz7EkNCMnbm2mmBJBBTkhTK5nDslZslcOZSWjvOKYz0aGCvTYwf6InP56/IIk",
+	"ksHFxEF3ZcF+moJbKK78SSAhRQJPq9Aplh7zT5DviAgRu74dzIUdzAV+QfefxuLR/sPSM1dDOyfs9IEm",
+	"5cDLYFBdhT5GvCRKsIS4vHxFExe94Sw5KomxwE2P9h827aB5bj1hpwsa4aUPRs2z2oby2R8qM3DhDF/j",
+	"XAhiGK7LEkebpTpWvrYvo/WzT127nFgLpgXbWIkxoMnlSq45lkIXWdk8lmKrL+Sacvn3/PJrY807LHRX",
+	"LmosDM+sACqhlGMCBlUG/wk7jcLb3PWT56XAxzNflgsLhpW4IqL5SFBTKIjcd3cjMsQjCjI44X0Csh5T",
+	"JqcONl3CzJG4X75RF4PdfoQOX13BuIh4bo1Ff6/ge/0etk0rFGiS4jkJQfACYsefkN2xHP3f3FEzBVTL",
+	"2lmzRv48DlRfcmw1JU9aanUWcc51Ujq9pd/+Re+vs33enbTaPcvbZQ2/H8ssR//ttVk+lBRdG6E8Djd9",
+	"1kFKP4t2ccpAl884xcKik8YAZlItZ2CK8qdNAUxPxLvy5Li3f5wwZphaExby3Z+bDaP6Rl7wzJ6dlL2C",
+	"YJrOyqOdZcPiaFvF+VVEUPHw8HLmRlk5JCm5sIGBFyRbQ5C0KaZYZ+xNRlBgB/bJhxfXk9lTZFVIcC2V",
+	"VwcGV1Jy/z63atlu5zNdmybp7YKBG5ZlOw0dCiJvHxU8DIUOZKh7EM5OoxfPmr/1yge+ZgLXVcmExgJM",
+	"TZG9bZXO9YN7/ksfJ763hqtDiK/e6P4rifI16gIfyZuv2oHHkVrpBl/3H9bD3pPyrvs4krjhTj+Y8rD6",
+	"CXMn4u4WM/uvtsPMJVW/RNDMa8wQGKv6bRNs9nS8I9js3/5xYHOYWgN7+Eu3B5s9wb8o2Pwx08U24GwR",
+	"CL6C5xelaUuoXd8Mm6B2YKEvG2pvIvRqsL2Slvv3ucG/WLC9eWG2AwaeYPcEt1e1CLkGBN9WgV0fgvsv",
+	"fRwIvobXAwQvddA3CL4CgrdUGyWHrkfhr6vbPgEYXo6mNJzvA4aXX20HxCvKfolIXNQZIvBX7cdNWLwk",
+	"5h2h8YpFPgoer6bXwCflxdvD5LWCzd9Q+b14v0WNgRv5f0nAtgTm8ztjEzSveOkL94NvpPdqeL6Govv3",
+	"veO/XI94iwXaDjjUvGx3DtTLXrC3AdO3123XB+rltz4OVF/L9QGsz3cT+AbXGz3mrfWJZJuwOt7xKcB0",
+	"ye4ZoUvWFpxbGn2RuNwvfslC+PdGNF5lcd06ELdM8HEwuJ1UkzKW7DaRt2TfQPe9gW7Hp4vMXReNbVF2",
+	"4PiNANtyy5eOrZvJugZRN1Jv/3627hcMoVetw5bAWbLPDzNvo4FuAJcl+1hIeQVLlyAZ9cg3fLwSH68V",
+	"/f7sBwgzkWmRQZJSnq2HyaflI7/hI8fukU8ANzeO7J5zThrH0A5bV2tB3GIQtxpfItxeNdcap65gzU2Q",
+	"vHEB7gijN37r44D25mk38VzTjbcH61cs7Dekf09IfwX92+yrtSqhpXmwevdtrFzRyJdfuAFxg9VabWS0",
+	"XIP9T0X2fLl2yY2Wdzs41Ujazy9T52ba+/r2TeN3P47B03o3BQtopcr9ZhStMopuX0tuZzN9oubSPYYc",
+	"Fj9+TRPp6zCO1plF21tE92UMfRJ2UBsYcofWzze752PZPRu2zCoxfk0751omzldn3WwUY21Nmvu0ZlpJ",
+	"kK/Ihtmsi25kuHxuAZhra9fbM1Y+DTtlKxPlm3GyhXHSUpVJtsEIsTd8CnaHZA1BmVbPnWR0BFs98Voy",
+	"zCu8F5tGspZmjGRfpuHiOKxkVvvnRutE3lVl5VPJPpINIlkjD0h2i5aGZN9si/uyLSRb5uqa1G1rM3hO",
+	"32gmSPbFWwZNFF0D/5sot38f+/ULxvXNS7AleJfsM4wxbKFxbgDSJftIuLyZm0soLtk38L0GfK+R9RrU",
+	"hG868XsebvoEkLYfyz2nQPmvtu257cj1JcJhXbFCYKjyp02w2BPxjqCxf/vHgcdhag284S/dHkz29P4G",
+	"le8JKuuSbRs4fkGMtoTN9Z2wucC/458vHD6vpfJqGL2Skvv3ube/XEi9YVm27byPj35+8HpbzXV9iO2/",
+	"9HFg9hpOD1C7VD7f4PYquN1GX0ylukwl3eDd/md51ycAvMNgruXnDg//ysU1nppzkd8lzA8fbIfzy0X8",
+	"EoH+tMZ7gY+r3zZB/UDIO8L64fUfB+yXk2vgkHDt9uB+IPo3vH9PeH9a8W4T4y9K8JaQf25HbML8JRd9",
+	"4aB/A6lXw/7V1Ny/323+5SL/jWuzHSIpdfk9g/+I9C+5CF15b2QFbK3Urm8GhE99HDtgHecHQ6BSS98s",
+	"gVWWwCZNct1WfNjL0u26+cWx8CIlDCaQyjyzfBB1CpV2DjtjY/LDvb3U3jCW2hz+sP/DPu5EP7KlV/EJ",
+	"CNDa90mkjONfuZID0GSnELUemMB2e1X7rjHQ1IwR38+/8tdiAEpgS87QAYAor3exjivu6eNXz5/V3lb2",
+	"Clj7PjwCTnYsdbHRm90GSqbdPKUCSEaTsR3+LvZy46JqSlD7kDtFvv4rZQ2mtS+qKjWtfVsumXZNl8dA",
+	"qJEZT0i5ZydQcg8pBDe69gGM4Kx9dfmopwM2Ld15DnkqZ5YtInJuqIFhkZ6DichzCpkU52B2e7E4IpqL",
+	"UQoksc+5Fr+5TGeZVPmYJ8S3MHZSlTBuh5BxQY1UT4kGIEfPz7r7+/uPnCD1Y674fu3AQ6Spou9cNcvQ",
+	"IC7Y02vfVXaL6JHjlGrNh7zisn6N0n2S0hkokoMKg3/8NBb2trgzHVPzQBMuDL63C1e51MB+ijvY6s8Q",
+	"lGiWSNzuFT1FXp5wSoaFKRTEAhKpZ9pA1nWfUZCiUNZjnusIuyva293FDLIBKHtpjnxVtd7lKfszLl3s",
+	"mMrIUh6vAi0LZYlqmU0KwMa3drLJuBCXVlQNaHLJxSgW2khFQ0Py0GOLCjLGjoKF6ZGXOMw+F0NFtVFF",
+	"Yid5kY9nmic07ZMdTTOIBdXktWSwe4ivOv2NZDTXRAojSbjX8s4l2SPH5yfhxBJ2/pub+HJy4DIBSo/E",
+	"KhK4M5nzdLDDCkyJbYHLxtHY6dcTIiIDqxiIkYQuUxa7Sbp+k45sieWzWORKTriV26DImGqiqeHacV9F",
+	"wToDrp2yP6a1PO9fsC9vvRexFDi3sgf4XtUDHNtARmXv44wKOgKUBbHI5zvs9+xMw07469zYsFfh8kiO",
+	"WMZFV4p0VjZH1YeuoWXtQ0EOd7FnJuFaF1QkEMWCYs/fbtmYGSYcpj3yd0QaQeBQ+5G+awxMdpRM4W/4",
+	"0+78CO1PnQ/vP/y/AAAA//8V0aqm6GoBAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -226,7 +226,12 @@ func (m *memStore) DeleteCluster(_ context.Context, id uuid.UUID) error {
 // copyNodeMutableFromCreate mirrors every NodeMutable-derived field from a
 // NodeCreate payload onto a Node. The fake carries them as-is so tests can
 // round-trip any of the 23 fields the collector now populates.
-func copyNodeMutableFromCreate(n *Node, in NodeCreate) {
+// copyNodeCollectorFieldsFromCreate mirrors the UpsertNode DO UPDATE
+// SET clause on the PG side — every field the collector derives from
+// the Kubernetes API. Used for both fresh inserts and on-conflict
+// updates so an operator's curated edits are not overwritten on the
+// next collector tick (ADR-0008 invariant).
+func copyNodeCollectorFieldsFromCreate(n *Node, in NodeCreate) {
 	n.DisplayName = in.DisplayName
 	n.Role = in.Role
 	n.KubeletVersion = in.KubeletVersion
@@ -255,6 +260,25 @@ func copyNodeMutableFromCreate(n *Node, in NodeCreate) {
 	n.Unschedulable = in.Unschedulable
 	n.Ready = in.Ready
 	n.Labels = in.Labels
+}
+
+// copyNodeCuratedFieldsFromCreate is the second half: the
+// operator-owned columns (ADR-0008). Only applied on fresh inserts,
+// never on upsert-conflict — the collector never carries these values.
+func copyNodeCuratedFieldsFromCreate(n *Node, in NodeCreate) {
+	n.Owner = in.Owner
+	n.Criticality = in.Criticality
+	n.Notes = in.Notes
+	n.RunbookUrl = in.RunbookUrl
+	n.Annotations = in.Annotations
+	n.HardwareModel = in.HardwareModel
+}
+
+// copyNodeMutableFromCreate sets every mutable column (collector-owned
+// + curated). Used for the insert path on CreateNode and UpsertNode.
+func copyNodeMutableFromCreate(n *Node, in NodeCreate) {
+	copyNodeCollectorFieldsFromCreate(n, in)
+	copyNodeCuratedFieldsFromCreate(n, in)
 }
 
 func (m *memStore) CreateNode(_ context.Context, in NodeCreate) (Node, error) {
@@ -402,6 +426,24 @@ func (m *memStore) UpdateNode(_ context.Context, id uuid.UUID, in NodeUpdate) (N
 	}
 	if in.Labels != nil {
 		n.Labels = in.Labels
+	}
+	if in.Owner != nil {
+		n.Owner = in.Owner
+	}
+	if in.Criticality != nil {
+		n.Criticality = in.Criticality
+	}
+	if in.Notes != nil {
+		n.Notes = in.Notes
+	}
+	if in.RunbookUrl != nil {
+		n.RunbookUrl = in.RunbookUrl
+	}
+	if in.Annotations != nil {
+		n.Annotations = in.Annotations
+	}
+	if in.HardwareModel != nil {
+		n.HardwareModel = in.HardwareModel
 	}
 	now := time.Now().UTC()
 	n.UpdatedAt = &now
@@ -1336,7 +1378,11 @@ func (m *memStore) UpsertNode(_ context.Context, in NodeCreate) (Node, error) {
 
 	if existingID, exists := m.nodesByNatKey[key]; exists {
 		n := m.nodesByID[existingID]
-		copyNodeMutableFromCreate(&n, in)
+		// On conflict: copy only collector-owned fields. Mirrors the
+		// DO UPDATE SET clause on the PG side so operator-set curated
+		// columns (owner / criticality / notes / runbook_url /
+		// annotations / hardware_model) survive the collector's tick.
+		copyNodeCollectorFieldsFromCreate(&n, in)
 		n.UpdatedAt = &now
 		m.nodesByID[existingID] = n
 		return n, nil

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -339,12 +339,18 @@ const nodeColumns = `id, cluster_id, name, display_name, role,
 	capacity_cpu, capacity_memory, capacity_pods, capacity_ephemeral_storage,
 	allocatable_cpu, allocatable_memory, allocatable_pods, allocatable_ephemeral_storage,
 	conditions, taints, unschedulable, ready,
-	labels, created_at, updated_at`
+	labels,
+	owner, criticality, notes, runbook_url, annotations, hardware_model,
+	created_at, updated_at`
 
 func nodeInsertValues(in api.NodeCreate, id uuid.UUID, now time.Time) ([]any, error) {
 	labelsJSON, err := marshalLabels(in.Labels)
 	if err != nil {
 		return nil, err
+	}
+	annotationsJSON, err := marshalLabels(in.Annotations)
+	if err != nil {
+		return nil, fmt.Errorf("marshal node annotations: %w", err)
 	}
 	conditionsJSON, err := marshalPorts(in.Conditions)
 	if err != nil {
@@ -363,7 +369,9 @@ func nodeInsertValues(in api.NodeCreate, id uuid.UUID, now time.Time) ([]any, er
 		in.CapacityCpu, in.CapacityMemory, in.CapacityPods, in.CapacityEphemeralStorage,
 		in.AllocatableCpu, in.AllocatableMemory, in.AllocatablePods, in.AllocatableEphemeralStorage,
 		conditionsJSON, taintsJSON, boolOrFalse(in.Unschedulable), boolOrFalse(in.Ready),
-		labelsJSON, now,
+		labelsJSON,
+		in.Owner, in.Criticality, in.Notes, in.RunbookUrl, annotationsJSON, in.HardwareModel,
+		now,
 	}, nil
 }
 
@@ -383,10 +391,10 @@ func (p *PG) CreateNode(ctx context.Context, in api.NodeCreate) (api.Node, error
 		return api.Node{}, err
 	}
 
-	// 32 placeholders: 30 "value" slots + created_at + updated_at (both = $32).
+	// 38 placeholders: 36 "value" slots + created_at + updated_at (both = $38).
 	const q = `
 		INSERT INTO nodes (` + nodeColumns + `)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$32)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$38)
 	`
 	if _, err := p.pool.Exec(ctx, q, values...); err != nil {
 		var pgErr *pgconn.PgError
@@ -594,6 +602,30 @@ func (p *PG) UpdateNode(ctx context.Context, id uuid.UUID, in api.NodeUpdate) (a
 			return api.Node{}, err
 		}
 		appendSet("labels", b)
+	}
+	// Curated metadata — collector never writes these, so merge-patch
+	// omission is enough to keep operator edits safe across polls.
+	if in.Owner != nil {
+		appendSet("owner", *in.Owner)
+	}
+	if in.Criticality != nil {
+		appendSet("criticality", *in.Criticality)
+	}
+	if in.Notes != nil {
+		appendSet("notes", *in.Notes)
+	}
+	if in.RunbookUrl != nil {
+		appendSet("runbook_url", *in.RunbookUrl)
+	}
+	if in.Annotations != nil {
+		b, err := marshalLabels(in.Annotations)
+		if err != nil {
+			return api.Node{}, fmt.Errorf("marshal node annotations: %w", err)
+		}
+		appendSet("annotations", b)
+	}
+	if in.HardwareModel != nil {
+		appendSet("hardware_model", *in.HardwareModel)
 	}
 	appendSet("updated_at", time.Now().UTC())
 	args = append(args, id)
@@ -2391,7 +2423,7 @@ func (p *PG) UpsertNode(ctx context.Context, in api.NodeCreate) (api.Node, error
 
 	const q = `
 		INSERT INTO nodes (` + nodeColumns + `)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$32)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$38)
 		ON CONFLICT (cluster_id, name) DO UPDATE SET
 			display_name                  = EXCLUDED.display_name,
 			role                          = EXCLUDED.role,
@@ -2471,6 +2503,12 @@ func scanNode(row pgx.Row) (api.Node, error) {
 		unschedulable               bool
 		ready                       bool
 		labelsJSON                  []byte
+		owner                       sql.NullString
+		criticality                 sql.NullString
+		notes                       sql.NullString
+		runbookURL                  sql.NullString
+		annotationsJSON             []byte
+		hardwareModel               sql.NullString
 	)
 	if err := row.Scan(
 		&id, &clusterID, &n.Name, &displayName, &role,
@@ -2482,6 +2520,7 @@ func scanNode(row pgx.Row) (api.Node, error) {
 		&allocatableCPU, &allocatableMemory, &allocatablePods, &allocatableEphemeral,
 		&conditionsJSON, &taintsJSON, &unschedulable, &ready,
 		&labelsJSON,
+		&owner, &criticality, &notes, &runbookURL, &annotationsJSON, &hardwareModel,
 		&createdAt, &updatedAt,
 	); err != nil {
 		return api.Node{}, err
@@ -2535,6 +2574,21 @@ func scanNode(row pgx.Row) (api.Node, error) {
 		}
 		if len(labels) > 0 {
 			n.Labels = &labels
+		}
+	}
+
+	n.Owner = nullableString(owner)
+	n.Criticality = nullableString(criticality)
+	n.Notes = nullableString(notes)
+	n.RunbookUrl = nullableString(runbookURL)
+	n.HardwareModel = nullableString(hardwareModel)
+	if len(annotationsJSON) > 0 {
+		var annotations map[string]string
+		if err := json.Unmarshal(annotationsJSON, &annotations); err != nil {
+			return api.Node{}, fmt.Errorf("unmarshal node annotations: %w", err)
+		}
+		if len(annotations) > 0 {
+			n.Annotations = &annotations
 		}
 	}
 	return n, nil

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -1959,3 +1959,131 @@ func TestPGNamespaceCuratedMetadata(t *testing.T) {
 		t.Errorf("criticality clobbered by owner patch")
 	}
 }
+
+// Mirrors TestPGClusterCuratedMetadata for nodes (migration 00020).
+// Nodes have the most elaborate collector UPSERT (every Mercator field
+// in the DO UPDATE SET clause), so pinning the curated-field-survival
+// invariant at the SQL level matters more here than for namespaces.
+// Also round-trips `hardware_model`.
+func TestPGNodeCuratedMetadata(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	clusterName := "node-curated-" + strconv.FormatInt(int64(uuid.New().ID()), 16)
+	cluster, err := pg.CreateCluster(ctx, api.ClusterCreate{Name: clusterName})
+	if err != nil {
+		t.Fatalf("seed cluster: %v", err)
+	}
+
+	owner := "team-platform"
+	criticality := "critical"
+	notes := "hosts ingress controllers"
+	runbook := "https://runbooks.example.com/ingress-node"
+	annotations := map[string]string{"rack": "A12", "power-feed": "left"}
+	hardware := "Dell PowerEdge R640"
+	nodeName := "worker-01.example.com"
+
+	created, err := pg.CreateNode(ctx, api.NodeCreate{
+		ClusterId:     *cluster.Id,
+		Name:          nodeName,
+		Owner:         &owner,
+		Criticality:   &criticality,
+		Notes:         &notes,
+		RunbookUrl:    &runbook,
+		Annotations:   &annotations,
+		HardwareModel: &hardware,
+	})
+	if err != nil {
+		t.Fatalf("create node: %v", err)
+	}
+
+	got, err := pg.GetNode(ctx, *created.Id)
+	if err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	if got.Owner == nil || *got.Owner != owner {
+		t.Errorf("owner = %v, want %q", got.Owner, owner)
+	}
+	if got.Criticality == nil || *got.Criticality != criticality {
+		t.Errorf("criticality = %v, want %q", got.Criticality, criticality)
+	}
+	if got.Notes == nil || *got.Notes != notes {
+		t.Errorf("notes round-trip failed")
+	}
+	if got.RunbookUrl == nil || *got.RunbookUrl != runbook {
+		t.Errorf("runbook_url round-trip failed")
+	}
+	if got.Annotations == nil || (*got.Annotations)["rack"] != "A12" {
+		t.Errorf("annotations round-trip failed: %v", got.Annotations)
+	}
+	if got.HardwareModel == nil || *got.HardwareModel != hardware {
+		t.Errorf("hardware_model = %v, want %q", got.HardwareModel, hardware)
+	}
+
+	// Simulate a collector tick: UPSERT with the Kubernetes-derived
+	// fields populated and every curated/hardware_model field nil. The
+	// PG DO UPDATE SET clause deliberately omits the curated columns
+	// and hardware_model, so the operator-set values must survive.
+	role := "worker"
+	kubelet := "v1.30.3"
+	osImage := "Ubuntu 22.04.4 LTS"
+	labels := map[string]string{"kubernetes.io/hostname": nodeName}
+	ready := true
+	if _, err := pg.UpsertNode(ctx, api.NodeCreate{
+		ClusterId:      *cluster.Id,
+		Name:           nodeName,
+		Role:           &role,
+		KubeletVersion: &kubelet,
+		OsImage:        &osImage,
+		Labels:         &labels,
+		Ready:          &ready,
+	}); err != nil {
+		t.Fatalf("collector-style upsert: %v", err)
+	}
+	afterCollector, err := pg.GetNode(ctx, *created.Id)
+	if err != nil {
+		t.Fatalf("get after collector upsert: %v", err)
+	}
+	if afterCollector.Role == nil || *afterCollector.Role != role {
+		t.Errorf("role not updated by collector: %v", afterCollector.Role)
+	}
+	if afterCollector.KubeletVersion == nil || *afterCollector.KubeletVersion != kubelet {
+		t.Errorf("kubelet_version not updated by collector: %v", afterCollector.KubeletVersion)
+	}
+	if afterCollector.Owner == nil || *afterCollector.Owner != owner {
+		t.Errorf("owner clobbered by collector upsert: %v", afterCollector.Owner)
+	}
+	if afterCollector.Criticality == nil || *afterCollector.Criticality != criticality {
+		t.Errorf("criticality clobbered")
+	}
+	if afterCollector.Notes == nil || *afterCollector.Notes != notes {
+		t.Errorf("notes clobbered")
+	}
+	if afterCollector.RunbookUrl == nil || *afterCollector.RunbookUrl != runbook {
+		t.Errorf("runbook_url clobbered")
+	}
+	if afterCollector.Annotations == nil || (*afterCollector.Annotations)["rack"] != "A12" {
+		t.Errorf("annotations clobbered: %v", afterCollector.Annotations)
+	}
+	if afterCollector.HardwareModel == nil || *afterCollector.HardwareModel != hardware {
+		t.Errorf("hardware_model clobbered by collector upsert: %v", afterCollector.HardwareModel)
+	}
+
+	// Editor-style patch updates only what was sent.
+	newHardware := "Supermicro SYS-1029P"
+	if _, err := pg.UpdateNode(ctx, *created.Id, api.NodeUpdate{
+		HardwareModel: &newHardware,
+	}); err != nil {
+		t.Fatalf("hardware_model update: %v", err)
+	}
+	afterEdit2, err := pg.GetNode(ctx, *created.Id)
+	if err != nil {
+		t.Fatalf("get after hardware_model patch: %v", err)
+	}
+	if afterEdit2.HardwareModel == nil || *afterEdit2.HardwareModel != newHardware {
+		t.Errorf("hardware_model update did not stick: %v", afterEdit2.HardwareModel)
+	}
+	if afterEdit2.Owner == nil || *afterEdit2.Owner != owner {
+		t.Errorf("owner clobbered by hardware_model patch")
+	}
+}

--- a/migrations/00020_node_curated_metadata.sql
+++ b/migrations/00020_node_curated_metadata.sql
@@ -1,0 +1,35 @@
+-- +goose Up
+-- Curated (human-owned) metadata on nodes per ADR-0008, extending the
+-- pattern established on clusters (00018) and namespaces (00019).
+--
+-- In addition to the five curated columns, nodes gain `hardware_model`
+-- — a free-form TEXT field for bare-metal installs to record a server
+-- model (e.g. "Dell PowerEdge R640") alongside the existing
+-- cloud-shaped `instance_type` (which stays the well-known-label-derived
+-- value populated by the collector on GKE / EKS / AKS). This closes the
+-- "model" requirement of SNC §8.1.a for on-prem deployments.
+--
+-- The collector's UPSERT on nodes has an elaborate DO UPDATE SET clause
+-- covering every Mercator-aligned field; neither the curated columns
+-- nor `hardware_model` are listed there, so operator edits survive
+-- every poll — verified by the PG integration test.
+--
+-- DICT (disponibilité / intégrité / confidentialité / traçabilité) is
+-- NOT added to nodes. Per ADR-0008, DICT lives on the Application
+-- abstraction (Namespace and Workload), not on infrastructure.
+ALTER TABLE nodes
+    ADD COLUMN owner          TEXT,
+    ADD COLUMN criticality    TEXT,
+    ADD COLUMN notes          TEXT,
+    ADD COLUMN runbook_url    TEXT,
+    ADD COLUMN annotations    JSONB NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN hardware_model TEXT;
+
+-- +goose Down
+ALTER TABLE nodes
+    DROP COLUMN IF EXISTS hardware_model,
+    DROP COLUMN IF EXISTS annotations,
+    DROP COLUMN IF EXISTS runbook_url,
+    DROP COLUMN IF EXISTS notes,
+    DROP COLUMN IF EXISTS criticality,
+    DROP COLUMN IF EXISTS owner;

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -365,9 +365,36 @@ export interface Node {
   unschedulable?: boolean | null;
   ready?: boolean | null;
   labels?: Record<string, string> | null;
+  // Curated metadata — operator-owned, never touched by the collector.
+  owner?: string | null;
+  criticality?: string | null;
+  notes?: string | null;
+  runbook_url?: string | null;
+  annotations?: Record<string, string> | null;
+  // Bare-metal complement to instance_type; set by operators.
+  hardware_model?: string | null;
   layer: Layer;
   created_at: string;
   updated_at: string;
+}
+
+export type NodePatch = Partial<Pick<
+  Node,
+  | 'display_name'
+  | 'owner'
+  | 'criticality'
+  | 'notes'
+  | 'runbook_url'
+  | 'annotations'
+  | 'hardware_model'
+>>;
+
+export function updateNode(id: string, patch: NodePatch) {
+  return request<Node>(`/v1/nodes/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
 }
 
 export interface Namespace {

--- a/ui/src/pages/Details.tsx
+++ b/ui/src/pages/Details.tsx
@@ -17,6 +17,7 @@ import * as api from '../api';
 import { useResource, useResources } from '../hooks';
 import { ClusterCuratedCard } from './cluster_curated';
 import { NamespaceCuratedCard } from './namespace_curated';
+import { NodeCuratedCard } from './node_curated';
 import {
   AsyncView,
   Dash,
@@ -625,11 +626,13 @@ export function PodDetail() {
 
 export function NodeDetail() {
   const { id = '' } = useParams();
+  const [nonce, setNonce] = useState(0);
+  const reload = () => setNonce((n) => n + 1);
   // 1. Fetch the node record itself.
   // 2. We need pods on this node, but we only have node.name (not node_name
   //    is what pod rows carry). Fetch the node first, then filter pods by
   //    node_name. The server-side ?node_name= filter makes this cheap.
-  const node = useResource(() => api.getNode(id), [id]);
+  const node = useResource(() => api.getNode(id), [id, nonce]);
   const pods = useResource(
     async () => {
       if (node.status !== 'ready') return null;
@@ -663,6 +666,8 @@ export function NodeDetail() {
               <KV k="Instance type" v={n.instance_type && <code>{n.instance_type}</code>} />
               <KV k="Zone" v={n.zone && <code>{n.zone}</code>} />
             </dl>
+
+            <NodeCuratedCard node={n} onSaved={reload} />
 
             <SectionTitle>OS &amp; runtime</SectionTitle>
             <dl className="kv-list">

--- a/ui/src/pages/node_curated.tsx
+++ b/ui/src/pages/node_curated.tsx
@@ -1,0 +1,214 @@
+import { FormEvent, useState } from 'react';
+import * as api from '../api';
+import { canEdit, useMe } from '../me';
+import { KV, Labels } from '../components';
+import { formatKV, parseKV } from '../kv';
+
+// NodeCuratedCard surfaces the operator-owned columns added in
+// migration 00020: owner / criticality / notes / runbook_url /
+// annotations + hardware_model. Viewers and auditors see a read-only
+// summary; editors and admins get an inline Edit form. Per ADR-0008,
+// DICT data-classification is deliberately NOT on nodes — a node is
+// infrastructure, not an application.
+
+export function NodeCuratedCard({
+  node,
+  onSaved,
+}: {
+  node: api.Node;
+  onSaved: () => void;
+}) {
+  const me = useMe();
+  const [editing, setEditing] = useState(false);
+  if (editing && canEdit(me)) {
+    return (
+      <NodeCuratedForm
+        node={node}
+        onCancel={() => setEditing(false)}
+        onSaved={() => {
+          setEditing(false);
+          onSaved();
+        }}
+      />
+    );
+  }
+  const empty =
+    !node.owner &&
+    !node.criticality &&
+    !node.notes &&
+    !node.runbook_url &&
+    !node.annotations &&
+    !node.hardware_model;
+  return (
+    <section className="curated-card">
+      <div className="curated-card-header">
+        <h3>Ownership &amp; context</h3>
+        {canEdit(me) && (
+          <button type="button" className="primary" onClick={() => setEditing(true)}>
+            Edit
+          </button>
+        )}
+      </div>
+      {empty ? (
+        <p className="muted" style={{ marginTop: 0 }}>
+          {canEdit(me)
+            ? 'No curated metadata yet. Use Edit to record owner, criticality, hardware model, and a runbook link.'
+            : 'No curated metadata recorded.'}
+        </p>
+      ) : (
+        <dl className="kv-list">
+          <KV k="Owner" v={node.owner} />
+          <KV
+            k="Criticality"
+            v={
+              node.criticality ? (
+                <span className="pill">{node.criticality}</span>
+              ) : undefined
+            }
+          />
+          <KV k="Hardware model" v={node.hardware_model} />
+          <KV
+            k="Runbook"
+            v={
+              node.runbook_url ? (
+                <a href={node.runbook_url} target="_blank" rel="noreferrer">
+                  {node.runbook_url}
+                </a>
+              ) : undefined
+            }
+          />
+          <KV
+            k="Notes"
+            v={node.notes ? <pre className="curated-notes">{node.notes}</pre> : undefined}
+          />
+          <KV k="Annotations" v={<Labels labels={node.annotations} />} />
+        </dl>
+      )}
+    </section>
+  );
+}
+
+function NodeCuratedForm({
+  node,
+  onCancel,
+  onSaved,
+}: {
+  node: api.Node;
+  onCancel: () => void;
+  onSaved: () => void;
+}) {
+  const [owner, setOwner] = useState(node.owner || '');
+  const [criticality, setCriticality] = useState(node.criticality || '');
+  const [hardwareModel, setHardwareModel] = useState(node.hardware_model || '');
+  const [notes, setNotes] = useState(node.notes || '');
+  const [runbook, setRunbook] = useState(node.runbook_url || '');
+  const [annotationsText, setAnnotationsText] = useState(formatKV(node.annotations));
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    let annotations: Record<string, string>;
+    try {
+      annotations = parseKV(annotationsText, 'annotations');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      return;
+    }
+    setBusy(true);
+    try {
+      await api.updateNode(node.id, {
+        owner: owner.trim(),
+        criticality: criticality.trim(),
+        hardware_model: hardwareModel.trim(),
+        notes: notes,
+        runbook_url: runbook.trim(),
+        annotations: annotations,
+      });
+      onSaved();
+    } catch (err) {
+      setError(err instanceof api.ApiError ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="curated-card">
+      <div className="curated-card-header">
+        <h3>Edit ownership &amp; context</h3>
+      </div>
+      <form className="admin-form" onSubmit={onSubmit}>
+        <div className="admin-form-row">
+          <div>
+            <label>Owner</label>
+            <input
+              type="text"
+              value={owner}
+              onChange={(e) => setOwner(e.target.value)}
+              placeholder="team-platform / oncall@example.com"
+            />
+          </div>
+          <div>
+            <label>Criticality</label>
+            <input
+              type="text"
+              value={criticality}
+              onChange={(e) => setCriticality(e.target.value)}
+              placeholder="critical / high / medium / low"
+            />
+          </div>
+          <div>
+            <label>Hardware model</label>
+            <input
+              type="text"
+              value={hardwareModel}
+              onChange={(e) => setHardwareModel(e.target.value)}
+              placeholder="Dell PowerEdge R640"
+            />
+          </div>
+        </div>
+        <div>
+          <label>Runbook URL</label>
+          <input
+            type="url"
+            value={runbook}
+            onChange={(e) => setRunbook(e.target.value)}
+            placeholder="https://runbooks.example.com/node-bm-01"
+          />
+        </div>
+        <div style={{ marginTop: '0.75rem' }}>
+          <label>Notes</label>
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            rows={4}
+            style={{ width: '100%' }}
+          />
+        </div>
+        <div style={{ marginTop: '0.75rem' }}>
+          <label>Annotations (one key=value per line)</label>
+          <textarea
+            value={annotationsText}
+            onChange={(e) => setAnnotationsText(e.target.value)}
+            rows={3}
+            style={{
+              width: '100%',
+              fontFamily: 'ui-monospace, SFMono-Regular, Consolas, monospace',
+            }}
+          />
+        </div>
+        {error && <div className="error">{error}</div>}
+        <div className="admin-form-actions">
+          <button type="submit" className="primary" disabled={busy}>
+            {busy ? 'Saving…' : 'Save'}
+          </button>
+          <button type="button" className="danger" onClick={onCancel} disabled={busy}>
+            Cancel
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}


### PR DESCRIPTION
Propagates the curated-metadata pattern to nodes per ADR-0008. Adds owner / criticality / notes / runbook_url / annotations + a new hardware_model column (closes the SNC §8.1.a "model" requirement for bare-metal installs, complementing the cloud-shaped instance_type the collector populates from well-known labels).

The collector-no-clobber invariant matters most here because the UpsertNode DO UPDATE SET clause touches every Mercator-aligned field the collector derives from the Kubernetes API. None of the new columns are in that clause, so operator edits survive every poll — TestPGNodeCuratedMetadata pins this at the SQL level. The mem-fake splits its Upsert helper in two so the conflict path mirrors PG's collector-only column list rather than clobbering everything.

UI gets a new "Ownership & context" card on /ui/nodes/:id between the Identity and OS & runtime sections with the same inline Edit flow as clusters and namespaces.

DICT security-need columns are not added to nodes — per ADR-0008 they live on the Application abstractions (Namespace and Workload) only.

Second of the ADR-0008 migration series after #50 namespaces.