### PR TITLE
fix(ui): resolve parent names on namespace / workload / node detail

### DIFF
--- a/ui/src/pages/Details.tsx
+++ b/ui/src/pages/Details.tsx
@@ -217,6 +217,18 @@ export function NamespaceDetail() {
               {ns.name} <LayerPill layer={ns.layer} />
             </h2>
             <dl className="kv-list">
+              <KV
+                k="Cluster"
+                v={
+                  clusterResult.status === 'ready' && clusterResult.data ? (
+                    <Link to={`/clusters/${clusterResult.data.id}`}>
+                      <strong>{clusterResult.data.name}</strong>
+                    </Link>
+                  ) : (
+                    <IdLink to={`/clusters/${ns.cluster_id}`} id={ns.cluster_id} />
+                  )
+                }
+              />
               <KV k="Phase" v={ns.phase} />
               <KV k="Labels" v={<Labels labels={ns.labels} />} />
             </dl>
@@ -419,11 +431,39 @@ export function WorkloadDetail() {
   // We fetch ALL pods and filter by workload_id client-side, since
   // /v1/pods doesn't yet have a workload_id query param. Namespace_id
   // narrowing happens after we know the workload's namespace.
+  //
+  // Resolve the parent namespace so the KV row shows its name (and its
+  // cluster's name) rather than a bare UUID.
+  const workloadData = state.status === 'ready' ? state.data[0] : null;
+  const namespaceResult = useResource(
+    async () => (workloadData ? api.getNamespace(workloadData.namespace_id) : null),
+    [workloadData?.namespace_id ?? ''],
+  );
+  const clusterResult = useResource(
+    async () =>
+      namespaceResult.status === 'ready' && namespaceResult.data
+        ? api.getCluster(namespaceResult.data.cluster_id)
+        : null,
+    [namespaceResult.status === 'ready' && namespaceResult.data ? namespaceResult.data.cluster_id : ''],
+  );
 
   return (
     <>
       <div className="breadcrumb">
-        <Link to="/workloads">Workloads</Link> / <span>this workload</span>
+        <Link to="/workloads">Workloads</Link> /{' '}
+        {clusterResult.status === 'ready' && clusterResult.data && (
+          <>
+            <Link to={`/clusters/${clusterResult.data.id}`}>{clusterResult.data.name}</Link>
+            {' / '}
+          </>
+        )}
+        {namespaceResult.status === 'ready' && namespaceResult.data && (
+          <>
+            <Link to={`/namespaces/${namespaceResult.data.id}`}>{namespaceResult.data.name}</Link>
+            {' / '}
+          </>
+        )}
+        <span>this workload</span>
       </div>
       <AsyncView state={state}>
         {([workload, pods]) => {
@@ -447,7 +487,25 @@ export function WorkloadDetail() {
                 />
                 <KV
                   k="Namespace"
-                  v={<IdLink to={`/namespaces/${workload.namespace_id}`} id={workload.namespace_id} />}
+                  v={
+                    namespaceResult.status === 'ready' && namespaceResult.data ? (
+                      <Link to={`/namespaces/${namespaceResult.data.id}`}>
+                        <strong>{namespaceResult.data.name}</strong>
+                      </Link>
+                    ) : (
+                      <IdLink to={`/namespaces/${workload.namespace_id}`} id={workload.namespace_id} />
+                    )
+                  }
+                />
+                <KV
+                  k="Cluster"
+                  v={
+                    clusterResult.status === 'ready' && clusterResult.data ? (
+                      <Link to={`/clusters/${clusterResult.data.id}`}>
+                        <strong>{clusterResult.data.name}</strong>
+                      </Link>
+                    ) : undefined
+                  }
                 />
                 <KV k="Labels" v={<Labels labels={workload.labels} />} />
               </dl>
@@ -640,6 +698,11 @@ export function NodeDetail() {
   // Also pull all workloads so we can attach name/kind to each pod's
   // workload_id for the impact grouping.
   const workloads = useResource(() => api.listWorkloads(), []);
+  // Resolve parent cluster so the Identity row shows its name, not its UUID.
+  const clusterResult = useResource(
+    async () => (node.status === 'ready' ? api.getCluster(node.data.cluster_id) : null),
+    [node.status === 'ready' ? node.data.cluster_id : ''],
+  );
 
   return (
     <>
@@ -657,7 +720,18 @@ export function NodeDetail() {
             <SectionTitle>Identity</SectionTitle>
             <dl className="kv-list">
               <KV k="Name" v={<code>{n.name}</code>} />
-              <KV k="Cluster" v={<IdLink to={`/clusters/${n.cluster_id}`} id={n.cluster_id} />} />
+              <KV
+                k="Cluster"
+                v={
+                  clusterResult.status === 'ready' && clusterResult.data ? (
+                    <Link to={`/clusters/${clusterResult.data.id}`}>
+                      <strong>{clusterResult.data.name}</strong>
+                    </Link>
+                  ) : (
+                    <IdLink to={`/clusters/${n.cluster_id}`} id={n.cluster_id} />
+                  )
+                }
+              />
               <KV k="Role" v={n.role && <span className="pill">{n.role}</span>} />
               <KV k="Provider ID" v={n.provider_id && <code>{n.provider_id}</code>} />
               <KV k="Instance type" v={n.instance_type && <code>{n.instance_type}</code>} />


### PR DESCRIPTION
Three detail pages rendered foreign-key UUIDs in the kv-list where the user expected human-readable names:

  * /ui/namespaces/:id had no Cluster row at all; operators had to read the breadcrumb to find out which cluster a namespace belonged to.
  * /ui/nodes/:id showed the cluster id as a truncated UUID link.
  * /ui/workloads/:id showed the namespace id as a truncated UUID link and had no Cluster row.

Each page now fires a small follow-up fetch (useResource) to resolve the parent name and renders a <Link> with the name when available, falling back to the existing IdLink while the resolution is in flight. The workload breadcrumb also gains cluster + namespace hops so the drill-down trail reads "Workloads / <cluster> / <namespace> / this workload" instead of a dead-end.

Layout-only change; no API or store impact.