### PR TITLE
fix(ui): show workload name in namespace pods table

### DIFF
--- a/ui/src/pages/Details.tsx
+++ b/ui/src/pages/Details.tsx
@@ -287,38 +287,58 @@ export function NamespaceDetail() {
             {pods.items.length === 0 ? (
               <Empty message="None." />
             ) : (
-              <table className="entities">
-                <thead>
-                  <tr>
-                    <th>Name</th>
-                    <th>Phase</th>
-                    <th>Node</th>
-                    <th>Pod IP</th>
-                    <th>Workload</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {pods.items.map((p) => (
-                    <tr key={p.id}>
-                      <td>
-                        <Link to={`/pods/${p.id}`}>
-                          <strong>{p.name}</strong>
-                        </Link>
-                      </td>
-                      <td>{p.phase || <Dash />}</td>
-                      <td>{p.node_name ? <code>{p.node_name}</code> : <Dash />}</td>
-                      <td>{p.pod_ip ? <code>{p.pod_ip}</code> : <Dash />}</td>
-                      <td>
-                        {p.workload_id ? (
-                          <IdLink to={`/workloads/${p.workload_id}`} id={p.workload_id} />
-                        ) : (
-                          <Dash />
-                        )}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+              (() => {
+                // Build a workload_id -> workload lookup once per render
+                // so each pod row can resolve its workload name without
+                // a separate network call.
+                const wlByID = new Map(workloads.items.map((w) => [w.id, w]));
+                return (
+                  <table className="entities">
+                    <thead>
+                      <tr>
+                        <th>Name</th>
+                        <th>Phase</th>
+                        <th>Node</th>
+                        <th>Pod IP</th>
+                        <th>Workload</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {pods.items.map((p) => {
+                        const wl = p.workload_id ? wlByID.get(p.workload_id) : undefined;
+                        return (
+                          <tr key={p.id}>
+                            <td>
+                              <Link to={`/pods/${p.id}`}>
+                                <strong>{p.name}</strong>
+                              </Link>
+                            </td>
+                            <td>{p.phase || <Dash />}</td>
+                            <td>{p.node_name ? <code>{p.node_name}</code> : <Dash />}</td>
+                            <td>{p.pod_ip ? <code>{p.pod_ip}</code> : <Dash />}</td>
+                            <td>
+                              {wl ? (
+                                <Link to={`/workloads/${wl.id}`}>
+                                  <strong>{wl.name}</strong>
+                                  {wl.kind && (
+                                    <span className="muted" style={{ marginLeft: '0.4rem', fontSize: '0.8rem' }}>
+                                      {wl.kind}
+                                    </span>
+                                  )}
+                                </Link>
+                              ) : p.workload_id ? (
+                                <IdLink to={`/workloads/${p.workload_id}`} id={p.workload_id} />
+                              ) : (
+                                <Dash />
+                              )}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                );
+              })()
             )}
 
             <SectionTitle count={services.items.length}>Services</SectionTitle>


### PR DESCRIPTION
Namespace detail's Pods table rendered each pod's workload_id as a truncated UUID link — unreadable when you actually want to match a pod to its deployment. The page already fetches the full workload list for the namespace, so resolve workload_id against that in-scope list (one Map built per render, no extra network call) and render the workload's name + kind. Falls back to the IdLink for pods whose workload_id is not in the fetched set (shouldn't happen in practice but keeps the UI robust to stale joins).