### PR TITLE
docs: add comprehensive user documentation (Diataxis framework)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,272 +1,73 @@
 # Argos
 
-A Configuration Management Database (CMDB) for Kubernetes environments, aligned
-with the [ANSSI SecNumCloud](https://cyber.gouv.fr/enjeux-technologiques/cloud/)
-(SNC) qualification framework. Argos polls one or more Kubernetes clusters on
-an interval, mirrors the result into PostgreSQL, and exposes both a REST API
-and a web UI so auditors can see the cartography and operators can annotate
-assets with information Kubernetes doesn't carry (business owner, criticality,
-runbooks).
+A Configuration Management Database (CMDB) for Kubernetes environments, aligned with the [ANSSI SecNumCloud](https://cyber.gouv.fr/enjeux-technologiques/cloud/) (SNC) qualification framework. Argos polls one or more Kubernetes clusters, mirrors the inventory into PostgreSQL, and exposes a REST API and web UI so auditors can see the cartography and operators can annotate assets with business context.
 
-Argos replaces the Kubernetes-scoped portion of [Mercator](https://github.com/dbsystel/mercator).
-See [ADR-0001](docs/adr/adr-0001-cmdb-for-snc-using-kube.md) for the foundational
-architectural decision.
+Replaces the Kubernetes-scoped portion of [Mercator](https://github.com/dbsystel/mercator). **Status:** alpha -- data model and HTTP contract are stable; expect additive changes until 1.0.
 
-**Status:** alpha. Data model and HTTP contract are stable enough to run
-against real clusters; expect additive changes until 1.0.
+## Features
 
-## What ships today
-
-### Data model
-
-- **Polling collector** against one or more Kubernetes clusters, covering
-  Clusters, Nodes, Namespaces, Workloads (Deployment / StatefulSet / DaemonSet,
-  polymorphic per [ADR-0003](docs/adr/adr-0003-workload-polymorphism.md)), Pods,
-  Services, Ingresses, PersistentVolumes, and PersistentVolumeClaims.
-- **Relationship FKs** resolved at ingest time:
-  - Pod → controlling Workload (`workload_id`), walked via the K8s
-    ownerReference chain — ReplicaSet → Deployment in one hop, direct for
-    StatefulSet / DaemonSet.
-  - PVC → bound PV (`bound_volume_id`), resolved against the PV name map each
-    tick. Both FKs use `ON DELETE SET NULL` so deletion of the parent leaves
-    the child to the reconcile pass rather than cascading.
-- **Mercator-aligned Node model** — role (control-plane / worker), cloud
-  identity (`provider_id`, `instance_type`, `zone`), networking
-  (`internal_ip`, `external_ip`, `pod_cidr`), full OS stack
-  (`kernel_version`, `operating_system`, `container_runtime_version`,
-  `kube_proxy_version`), capacity + allocatable quadruples for
-  cpu / memory / pods / ephemeral_storage, status conditions + scheduling
-  taints, and `ready` / `unschedulable` flags.
-- **External load balancer** on Ingress and Service (`load_balancer` JSONB)
-  mirroring `status.loadBalancer.ingress[]` — populated by the cloud
-  controller on managed clusters, or by MetalLB / Kube-VIP / a hardware LB
-  on-prem. Answers "what's the external entry point for this thing?"
-  without bouncing into kubectl.
-- **Reconciliation**: rows that vanish from the live listing are deleted so
-  the CMDB mirrors the cluster — required for SNC cartography fidelity.
-  Toggleable; disabled reverts to pure append behaviour.
-- **Multi-cluster**: one collector goroutine per entry in
-  `ARGOS_COLLECTOR_CLUSTERS` (JSON array), all sharing the store — see
-  [ADR-0005](docs/adr/adr-0005-multi-cluster-collector.md).
-- **ANSSI cartography layers** attached per kind via
-  [ADR-0002](docs/adr/adr-0002-kubernetes-to-anssi-cartography-layers.md)
-  (`ecosystem` / `business` / `applicative` / `administration` /
-  `infrastructure_logical` / `infrastructure_physical`).
-
-### API
-
-- **REST** (OpenAPI 3.1 contract-first, `api/openapi/openapi.yaml`) with
-  cursor pagination and merge-patch updates. Errors follow
-  [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807)
-  (`application/problem+json`).
-- **Audit log** writes every state-changing call and every admin-panel
-  read into an append-only `audit_events` table. Admins and auditors can
-  browse it at `/ui/admin/audit` with filters for actor, resource kind,
-  action verb, and time range. Password / token fields are scrubbed
-  before persistence.
-- **Curated metadata** on clusters (`owner`, `criticality`, `notes`,
-  `runbook_url`, `annotations`) editable inline at `/ui/clusters/:id`
-  by editor / admin roles. The collector never writes these columns —
-  `UpdateCluster`'s merge-patch semantics leave unset fields alone, so a
-  version refresh can't clobber operator annotations. Same pattern will
-  land on namespaces / nodes / workloads next.
-- **Dual-path auth** per
-  [ADR-0007](docs/adr/adr-0007-auth-and-rbac.md): humans log in with
-  either local username + password **or** OIDC (authorization-code flow
-  with PKCE + nonce + state; shadow users keyed on `(issuer, sub)`;
-  first-login role `viewer`, admins promote manually) → server-side
-  session cookie; machines use `Authorization: Bearer` with tokens
-  minted by an admin in the UI (argon2id-hashed, plaintext shown once,
-  immediate revocation). Four fixed roles — `admin` / `editor` /
-  `auditor` / `viewer` — map to the existing per-operation scope
-  declarations. First install bootstraps an `admin` user with a random
-  password printed once to the startup log (`must_change_password`
-  forces rotation on first login).
-- **Filter endpoints** for incident-response queries:
-  - `GET /v1/workloads?image=log4j:2.15` — case-insensitive substring match
-    over every container's `image` field, init containers included.
-  - `GET /v1/pods?image=…` — same shape for pods.
-  - `GET /v1/pods?node_name=worker-02.prod` — exact match; powers the
-    "if this node dies, which pods are lost?" view.
-
-### Web UI
-
-React + TypeScript SPA embedded in the binary at `/ui/` — see
-[ADR-0006](docs/adr/adr-0006-ui-for-audit-and-curated-metadata.md).
-
-- **List pages** for all 9 kinds with context-aware columns (Node role /
-  zone / instance-type / CPU-mem / Ready status; Ingress / Service
-  load-balancer address; PVC bound PV; Workload container images; …).
-- **Drill-down detail pages** for the core cartography chain
-  (Cluster → Namespace → Workload → Pod; Cluster → Node). Namespace detail
-  aggregates every asset in it ("application = namespace" view); Workload
-  detail aggregates its pods + unique nodes ("application = workload" view).
-- **Node detail** renders the full Mercator-aligned picture — Identity,
-  OS & runtime, Networking, Resources (capacity vs allocatable), Conditions
-  with per-row health colouring, Taints, Labels — plus an impact-analysis
-  callout and a workload-grouped breakdown of affected pods.
-- **Ingress detail** renders the load-balancer block first, then routing
-  rules and TLS, so on-prem auditors can see the VIP at a glance.
-- **Component search** (`/ui/search/image`) with URL-persisted query —
-  find every workload + pod running `log4j:2.15.0`, grouped by
-  cluster / namespace with clickable breadcrumbs.
-- Humans authenticate through the same-origin session cookie set by
-  `/v1/auth/login` (or the OIDC callback); no token paste, no CORS.
-  The "Sign in with <IdP>" button renders automatically when OIDC is
-  configured — the SPA probes `/v1/auth/config` on page load.
-
-### Ops
-
-- **Prometheus metrics** at `/metrics` (HTTP + collector upsert / reconcile /
-  error counters, per-resource last-poll gauges, `argos_build_info`).
-- **Container image** built from a multi-stage Dockerfile
-  (`gcr.io/distroless/static-debian12:nonroot`, UID 65532, static CGO-off
-  binary). A first stage builds the UI bundle with `node:22-alpine`; the
-  Go stage embeds it via `//go:embed`.
-- **Kustomize manifests** under `deploy/` for running argosd inside a
-  Kubernetes cluster as its own collector target.
-- **Demo seed** — `scripts/seed-demo.sh` populates a realistic
-  multi-cluster inventory (prod/staging × 6 namespaces × workloads + pods
-  + services + one MetalLB-style ingress) so the UI has something to show
-  without a real cluster.
-
-## Stack
-
-- Go 1.25+ (toolchain pinned via `go.mod`)
-- PostgreSQL 16+ (JSONB for heterogeneous K8s specs, `goose` for migrations
-  embedded in the binary)
-- `pgx/v5` + `pgxpool`
-- `oapi-codegen` for the REST server stubs
-- React 18 + TypeScript + Vite for the UI
-- `client-go` for Kubernetes polling
+- **Full Kubernetes inventory** -- Clusters, Nodes, Namespaces, Workloads (Deployment / StatefulSet / DaemonSet), Pods, Services, Ingresses, PersistentVolumes, PVCs.
+- **Dual-mode collection** -- pull (argosd polls clusters) and push (argos-collector runs inside air-gapped clusters and pushes over HTTPS).
+- **Multi-cluster** -- one argosd catalogues N clusters in parallel, or mixed pull+push.
+- **ANSSI cartography layers** -- every kind maps to an SNC layer (ecosystem, applicative, infrastructure, etc.).
+- **Dual-path auth** -- humans use session cookies (local login or OIDC); machines use bearer tokens (PAT).
+- **Curated metadata** -- operators annotate clusters with owner, criticality, runbook URL, and free-form notes.
+- **Audit log** -- every state-changing call is recorded; passwords and tokens are scrubbed.
+- **Embedded web UI** -- React SPA shipped inside the binary at `/ui/`.
 
 ## Quick start
 
-### Run argosd with Docker (simplest)
-
 ```bash
-# 1. Postgres on the host
+# 1. Start PostgreSQL
 docker run -d --rm --name argos-pg \
   -e POSTGRES_PASSWORD=argos -e POSTGRES_DB=argos \
   -p 5432:5432 postgres:16-alpine
 
-# 2. Build and run argosd with a known bootstrap password
-make ui-build        # produce ui/dist for embedding
-make build           # produce bin/argosd
+# 2. Build and run argosd
+make ui-build && make build
 ARGOS_DATABASE_URL="postgres://postgres:argos@localhost:5432/argos?sslmode=disable" \
-  ARGOS_BOOTSTRAP_ADMIN_PASSWORD="local-dev-bootstrap-0123456789" \
+  ARGOS_BOOTSTRAP_ADMIN_PASSWORD="changeme-on-first-login" \
   ./bin/argosd
 
-# 3. Sign in
-open http://localhost:8080/   # redirects to /ui/
-# → user: admin
-# → pass: local-dev-bootstrap-0123456789
-# → rotate on first login (must_change_password is enforced)
-
-# 4. Mint a machine token via the admin panel — or via curl, using the
-#    session cookie you just picked up in the browser.
+# 3. Open http://localhost:8080/ and sign in as admin
 ```
 
-### Deploy into a Kubernetes cluster
+See [Getting Started](docs/getting-started.md) for the full walkthrough including cluster registration, collector setup, and demo data seeding.
 
-See [`deploy/README.md`](deploy/README.md) for the full walkthrough (namespace,
-ServiceAccount, RBAC, Deployment, Service, token Secret). Supports both the
-in-cluster self-catalogue mode and the multi-cluster mode where argosd reads
-several kubeconfigs and polls every target in parallel.
+## Documentation
 
-## Configuration
-
-All configuration is env-based.
-
-| Variable | Required | Default | Purpose |
-|----------|----------|---------|---------|
-| `ARGOS_DATABASE_URL` | yes | — | PostgreSQL DSN. |
-| `ARGOS_BOOTSTRAP_ADMIN_PASSWORD` | no | random | First-install only: password for the auto-created `admin` user. If unset, argosd generates one and prints it once to the startup log. |
-| `ARGOS_SESSION_SECURE_COOKIE` | no | `auto` | Session-cookie `Secure` flag: `auto` (mirror request scheme), `always`, or `never`. |
-| `ARGOS_ADDR` | no | `:8080` | HTTP listen address. |
-| `ARGOS_AUTO_MIGRATE` | no | `true` | Run embedded goose migrations on startup. |
-| `ARGOS_SHUTDOWN_TIMEOUT` | no | `15s` | Graceful shutdown budget on SIGINT / SIGTERM. |
-| `ARGOS_COLLECTOR_ENABLED` | no | `false` | Enable the polling collector. |
-| `ARGOS_COLLECTOR_CLUSTERS` | no | — | JSON array of `{name, kubeconfig}` tuples (multi-cluster). |
-| `ARGOS_CLUSTER_NAME` / `ARGOS_KUBECONFIG` | no | — | Single-cluster shortcut (ignored when `ARGOS_COLLECTOR_CLUSTERS` is set). |
-| `ARGOS_COLLECTOR_INTERVAL` | no | `60s` | Time between polls. |
-| `ARGOS_COLLECTOR_FETCH_TIMEOUT` | no | `20s` | Per-poll Kubernetes API timeout. |
-| `ARGOS_COLLECTOR_RECONCILE` | no | `true` | Delete rows that no longer appear in the live listing. |
-
-`/healthz`, `/readyz`, `/metrics`, `/ui/*`, and `/v1/auth/login` stay
-unauthenticated. Everything else requires either a session cookie
-(obtained via login) or a machine bearer token (minted in the admin
-panel).
-
-## Development
-
-Prereqs: Go (pinned in `go.mod`), Node 22+, Docker (for the PG service
-container used by integration tests).
-
-```bash
-# Backend-only loop (no UI toolchain):
-make build-noui
-make test
-
-# Full loop (default `make build` requires ui/dist):
-make ui-install   # once, after a fresh checkout
-make ui-build
-make build
-make test
-
-# UI with hot reload (proxies /v1 + /healthz + /metrics to :8080):
-#   terminal 1
-ARGOS_DATABASE_URL=... \
-  ARGOS_BOOTSTRAP_ADMIN_PASSWORD=local-dev-passphrase \
-  ./bin/argosd
-#   terminal 2
-make ui-dev       # open http://localhost:5173/ui/, sign in with admin
-```
-
-Integration tests that hit PostgreSQL are gated on `PGX_TEST_DATABASE`. Unset
-it and they skip; set it and they run against whatever DSN you point at
-(CI uses a service container — see `.github/workflows/ci.yml`).
-
-### Common Make targets
-
-| Target | What it does |
-|--------|--------------|
-| `make build` | Compile `argosd` into `bin/` (embeds `ui/dist`). |
-| `make build-noui` | Compile without the UI (no Node required; `/ui/` replies 404). |
-| `make test` | `go test -race -cover ./...` |
-| `make check` | fmt + vet + lint + test (CI-equivalent). |
-| `make docker-build` | Build the container image as `argos:dev`. |
-| `make ui-install` | `npm ci` in `ui/`. |
-| `make ui-build` | Produce `ui/dist/` (needed by `make build`). |
-| `make ui-dev` | Vite dev server on `:5173`. |
-| `make ui-check` | TypeScript typecheck. |
+| Document | Description |
+|----------|-------------|
+| [Getting Started](docs/getting-started.md) | From zero to a working installation. |
+| [Configuration](docs/configuration.md) | All environment variables for argosd and argos-collector. |
+| [Deploy on Kubernetes](docs/deployment/kubernetes.md) | Production deployment with Kustomize. |
+| [Push Collector](docs/deployment/push-collector.md) | Deploy argos-collector in air-gapped clusters. |
+| [Docker (local dev)](docs/deployment/docker.md) | Run locally with Docker. |
+| [Authentication](docs/authentication.md) | Local users, OIDC, tokens, roles, sessions. |
+| [API Reference](docs/api-reference.md) | REST endpoints with curl examples. |
+| [Monitoring](docs/monitoring.md) | Prometheus metrics, alerts, Grafana tips. |
+| [Architecture](docs/architecture.md) | How Argos works internally. |
 
 ## Architecture
 
-High level:
-
 ```
-   Kubernetes cluster(s)
-          │
-          │ client-go (list, per-tick)
-          ▼
+   Kubernetes cluster(s)              Air-gapped cluster
+          |                                   |
+          | client-go (list)                  | client-go (list)
+          v                                   v
+   ┌──────────────┐                  ┌──────────────────┐
+   │ pull collector│                  │ argos-collector   │
+   │ (goroutine/  │                  │ (push over HTTPS) │
+   │  cluster)    │                  └────────┬─────────┘
+   └──────┬───────┘                           |
+          │ direct store                      | REST API + Bearer
+          v                                   v
    ┌──────────────┐     ┌────────────┐
-   │  collector   │────▶│  PostgreSQL│◀──── REST API / SPA / Prometheus
-   │ (goroutine/  │     │  (JSONB +  │
-   │  cluster)    │     │   goose)   │
+   │   argosd     │────>│ PostgreSQL │<──── REST API / SPA / Prometheus
+   │ (API + UI +  │     │ (JSONB +   │
+   │  collector)  │     │  goose)    │
    └──────────────┘     └────────────┘
 ```
-
-- `cmd/argosd/` — daemon entry point (HTTP server, collector goroutines, graceful shutdown).
-- `internal/api/` — REST handlers + `Store` interface + `BearerAuth` middleware.
-- `internal/store/` — PostgreSQL implementation via `pgx/v5`.
-- `internal/collector/` — Kubernetes polling + reconciliation.
-- `internal/metrics/` — Prometheus registry exposed at `/metrics`.
-- `ui/` — embedded React SPA served at `/ui/*`.
-- `migrations/` — timestamped SQL migrations embedded into the binary.
-- `api/openapi/openapi.yaml` — contract source of truth (server + TS client are generated from it).
-
-See [`CLAUDE.md`](CLAUDE.md) for the detailed module-by-module notes.
 
 ## Architectural decisions
 
@@ -278,7 +79,20 @@ See [`CLAUDE.md`](CLAUDE.md) for the detailed module-by-module notes.
 | [0004](docs/adr/adr-0004-ingress-layer-classification.md) | Classify Ingress in the `applicative` layer. |
 | [0005](docs/adr/adr-0005-multi-cluster-collector.md) | Central-pull multi-cluster topology: one argosd, N collector goroutines. |
 | [0006](docs/adr/adr-0006-ui-for-audit-and-curated-metadata.md) | Web UI bundled into argosd for audit views and curated asset metadata. |
+| [0007](docs/adr/adr-0007-auth-and-rbac.md) | Dual-path auth (session + bearer) and four-role RBAC. |
+| [0008](docs/adr/adr-0008-secnumcloud-chapter-8-asset-management.md) | SecNumCloud chapter 8 asset management alignment. |
+| [0009](docs/adr/adr-0009-push-collector-for-airgapped-clusters.md) | Push-based collector for air-gapped clusters. |
+
+## Contributing
+
+Prerequisites: Go (version in `go.mod`), Node 22+, Docker (for integration tests).
+
+```bash
+make check    # fmt + vet + lint + test -- the CI-equivalent gate
+```
+
+Integration tests require `PGX_TEST_DATABASE` pointing at a PostgreSQL instance. See [Docker (local dev)](docs/deployment/docker.md) for the development workflow.
 
 ## License
 
-GPL-3.0 — see [LICENSE](LICENSE).
+GPL-3.0 -- see [LICENSE](LICENSE).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,388 @@
+# API Reference
+
+Argos exposes a REST API at `/v1/`. The authoritative schema is the OpenAPI 3.1 spec at `api/openapi/openapi.yaml`. This page provides a concise reference with curl examples.
+
+## Conventions
+
+### Base URL
+
+```
+http://localhost:8080/v1
+```
+
+### Content types
+
+- Requests: `application/json` for create/update; `application/merge-patch+json` for PATCH.
+- Responses: `application/json`.
+- Errors: `application/problem+json` (RFC 7807).
+
+### Error format
+
+All errors follow RFC 7807:
+
+```json
+{
+  "type": "about:blank",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "cluster not found"
+}
+```
+
+### Authentication
+
+Every endpoint except health probes, metrics, and the auth flow requires authentication.
+
+**Session cookie** (humans):
+
+```bash
+curl -sS -c /tmp/argos.cookies -X POST http://localhost:8080/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"secret"}'
+
+# Subsequent requests carry the cookie:
+curl -sS -b /tmp/argos.cookies http://localhost:8080/v1/clusters
+```
+
+**Bearer token** (machines):
+
+```bash
+curl -H "Authorization: Bearer argos_pat_xxxx_yyyy" http://localhost:8080/v1/clusters
+```
+
+### Pagination
+
+All list endpoints use cursor-based pagination:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `limit` | integer | 50 | Maximum items to return. |
+| `cursor` | string | -- | Opaque cursor from a previous response's `next_cursor`. |
+
+Response shape:
+
+```json
+{
+  "items": [...],
+  "next_cursor": "eyJpZCI6Ii4uLiJ9"
+}
+```
+
+Pass `next_cursor` as the `cursor` query parameter to fetch the next page. When `next_cursor` is `null` or absent, there are no more pages.
+
+---
+
+## Clusters
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/v1/clusters` | `read` | List clusters. Optional `?name=exact-match` filter. |
+| POST | `/v1/clusters` | `write` | Register a cluster. |
+| GET | `/v1/clusters/{id}` | `read` | Get a cluster by ID. |
+| PATCH | `/v1/clusters/{id}` | `write` | Update mutable fields (merge-patch). |
+| DELETE | `/v1/clusters/{id}` | `delete` | Delete a cluster and all its children. |
+
+**Create a cluster:**
+
+```bash
+curl -sS -H "Authorization: Bearer $TOKEN" -X POST http://localhost:8080/v1/clusters \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "prod",
+    "display_name": "Production",
+    "environment": "production"
+  }'
+```
+
+**Update curated metadata:**
+
+```bash
+curl -sS -H "Authorization: Bearer $TOKEN" -X PATCH http://localhost:8080/v1/clusters/<id> \
+  -H 'Content-Type: application/merge-patch+json' \
+  -d '{
+    "owner": "platform-team",
+    "criticality": "high",
+    "runbook_url": "https://wiki.example.com/runbooks/prod"
+  }'
+```
+
+## Nodes
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/v1/nodes` | `read` | List nodes. |
+| POST | `/v1/nodes` | `write` | Create/upsert a node. |
+| GET | `/v1/nodes/{id}` | `read` | Get a node by ID. |
+| PATCH | `/v1/nodes/{id}` | `write` | Update a node. |
+| DELETE | `/v1/nodes/{id}` | `delete` | Delete a node. |
+| POST | `/v1/nodes/reconcile` | `write` | Reconcile nodes for a cluster. |
+
+## Namespaces
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/v1/namespaces` | `read` | List namespaces. |
+| POST | `/v1/namespaces` | `write` | Create/upsert a namespace. |
+| GET | `/v1/namespaces/{id}` | `read` | Get a namespace by ID. |
+| PATCH | `/v1/namespaces/{id}` | `write` | Update a namespace. |
+| DELETE | `/v1/namespaces/{id}` | `delete` | Delete a namespace. |
+| POST | `/v1/namespaces/reconcile` | `write` | Reconcile namespaces for a cluster. |
+
+## Pods
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/v1/pods` | `read` | List pods. Supports `?image=substring` and `?node_name=exact` filters. |
+| POST | `/v1/pods` | `write` | Create/upsert a pod. |
+| GET | `/v1/pods/{id}` | `read` | Get a pod by ID. |
+| PATCH | `/v1/pods/{id}` | `write` | Update a pod. |
+| DELETE | `/v1/pods/{id}` | `delete` | Delete a pod. |
+| POST | `/v1/pods/reconcile` | `write` | Reconcile pods for a namespace. |
+
+**Filter pods by image:**
+
+```bash
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  'http://localhost:8080/v1/pods?image=log4j:2.15'
+```
+
+**Filter pods by node (impact analysis):**
+
+```bash
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  'http://localhost:8080/v1/pods?node_name=worker-02.prod'
+```
+
+## Workloads
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/v1/workloads` | `read` | List workloads. Supports `?image=substring` filter. |
+| POST | `/v1/workloads` | `write` | Create/upsert a workload. |
+| GET | `/v1/workloads/{id}` | `read` | Get a workload by ID. |
+| PATCH | `/v1/workloads/{id}` | `write` | Update a workload. |
+| DELETE | `/v1/workloads/{id}` | `delete` | Delete a workload. |
+| POST | `/v1/workloads/reconcile` | `write` | Reconcile workloads for a namespace. |
+
+Workloads are polymorphic on `kind` (Deployment, StatefulSet, DaemonSet). Kind-specific detail lives in the `spec` JSONB field.
+
+## Services
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/v1/services` | `read` | List services. |
+| POST | `/v1/services` | `write` | Create/upsert a service. |
+| GET | `/v1/services/{id}` | `read` | Get a service by ID. |
+| PATCH | `/v1/services/{id}` | `write` | Update a service. |
+| DELETE | `/v1/services/{id}` | `delete` | Delete a service. |
+| POST | `/v1/services/reconcile` | `write` | Reconcile services for a namespace. |
+
+## Ingresses
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/v1/ingresses` | `read` | List ingresses. |
+| POST | `/v1/ingresses` | `write` | Create/upsert an ingress. |
+| GET | `/v1/ingresses/{id}` | `read` | Get an ingress by ID. |
+| PATCH | `/v1/ingresses/{id}` | `write` | Update an ingress. |
+| DELETE | `/v1/ingresses/{id}` | `delete` | Delete an ingress. |
+| POST | `/v1/ingresses/reconcile` | `write` | Reconcile ingresses for a namespace. |
+
+## Persistent Volumes
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/v1/persistentvolumes` | `read` | List persistent volumes. |
+| POST | `/v1/persistentvolumes` | `write` | Create/upsert a PV. |
+| GET | `/v1/persistentvolumes/{id}` | `read` | Get a PV by ID. |
+| PATCH | `/v1/persistentvolumes/{id}` | `write` | Update a PV. |
+| DELETE | `/v1/persistentvolumes/{id}` | `delete` | Delete a PV. |
+| POST | `/v1/persistentvolumes/reconcile` | `write` | Reconcile PVs for a cluster. |
+
+## Persistent Volume Claims
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/v1/persistentvolumeclaims` | `read` | List PVCs. |
+| POST | `/v1/persistentvolumeclaims` | `write` | Create/upsert a PVC. |
+| GET | `/v1/persistentvolumeclaims/{id}` | `read` | Get a PVC by ID. |
+| PATCH | `/v1/persistentvolumeclaims/{id}` | `write` | Update a PVC. |
+| DELETE | `/v1/persistentvolumeclaims/{id}` | `delete` | Delete a PVC. |
+| POST | `/v1/persistentvolumeclaims/reconcile` | `write` | Reconcile PVCs for a namespace. |
+
+## Reconcile endpoints
+
+Reconcile endpoints delete CMDB rows that no longer exist in the live Kubernetes cluster. They are used by the push collector and mirror the pull collector's internal `Delete*NotIn` logic.
+
+**Cluster-scoped** (nodes, namespaces, persistent volumes):
+
+```bash
+curl -sS -H "Authorization: Bearer $TOKEN" -X POST http://localhost:8080/v1/nodes/reconcile \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "cluster_id": "<uuid>",
+    "keep_names": ["node-1", "node-2", "node-3"]
+  }'
+```
+
+**Namespace-scoped** (pods, services, ingresses, PVCs):
+
+```bash
+curl -sS -H "Authorization: Bearer $TOKEN" -X POST http://localhost:8080/v1/pods/reconcile \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "namespace_id": "<uuid>",
+    "keep_names": ["web-abc123", "api-def456"]
+  }'
+```
+
+**Workloads** (namespace-scoped, keyed on kind + name):
+
+```bash
+curl -sS -H "Authorization: Bearer $TOKEN" -X POST http://localhost:8080/v1/workloads/reconcile \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "namespace_id": "<uuid>",
+    "keep_kinds": ["Deployment", "StatefulSet"],
+    "keep_names": ["web", "redis"]
+  }'
+```
+
+Response:
+
+```json
+{"deleted": 3}
+```
+
+---
+
+## Auth
+
+| Method | Path | Auth required | Description |
+|--------|------|---------------|-------------|
+| GET | `/v1/auth/config` | no | Public: is OIDC enabled? button label? |
+| POST | `/v1/auth/login` | no | Username/password login. Sets session cookie. |
+| POST | `/v1/auth/logout` | yes | End the current session. |
+| GET | `/v1/auth/me` | yes | Caller identity, role, scopes, `must_change_password`. |
+| POST | `/v1/auth/change-password` | session only | Change the current user's password. |
+| GET | `/v1/auth/oidc/authorize` | no | Start the OIDC flow (302 to IdP). |
+| GET | `/v1/auth/oidc/callback` | no | Complete the OIDC flow (302 to UI). |
+
+**Login:**
+
+```bash
+curl -sS -c /tmp/argos.cookies -X POST http://localhost:8080/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"my-password"}'
+# 204 No Content on success; session cookie set.
+```
+
+**Who am I:**
+
+```bash
+curl -sS -b /tmp/argos.cookies http://localhost:8080/v1/auth/me | jq .
+```
+
+```json
+{
+  "id": "...",
+  "username": "admin",
+  "role": "admin",
+  "scopes": ["read","write","delete","admin","audit"],
+  "must_change_password": false
+}
+```
+
+**Change password:**
+
+```bash
+curl -sS -b /tmp/argos.cookies -X POST http://localhost:8080/v1/auth/change-password \
+  -H 'Content-Type: application/json' \
+  -d '{"current_password":"old","new_password":"new-strong-passphrase"}'
+# 204 on success. All other sessions invalidated.
+```
+
+---
+
+## Admin
+
+All admin endpoints require the `admin` scope.
+
+### Users
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/admin/users` | List users (paginated). |
+| POST | `/v1/admin/users` | Create a user. |
+| GET | `/v1/admin/users/{id}` | Get a user. |
+| PATCH | `/v1/admin/users/{id}` | Update role, password, or disabled state. |
+| DELETE | `/v1/admin/users/{id}` | Delete a user. |
+
+**Create a user:**
+
+```bash
+curl -sS -b /tmp/argos.cookies -X POST http://localhost:8080/v1/admin/users \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"alice","password":"initial-pass","role":"editor"}'
+```
+
+### Tokens
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/admin/tokens` | List tokens (metadata only, no plaintext). |
+| POST | `/v1/admin/tokens` | Mint a new token. Plaintext shown once. |
+| DELETE | `/v1/admin/tokens/{id}` | Revoke a token. |
+
+**Mint a token:**
+
+```bash
+curl -sS -b /tmp/argos.cookies -X POST http://localhost:8080/v1/admin/tokens \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"ci-pipeline","scopes":["read","write"]}'
+```
+
+### Sessions
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/admin/sessions` | List active sessions. |
+| DELETE | `/v1/admin/sessions/{id}` | Revoke a session. |
+
+### Audit
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/v1/admin/audit` | `audit` | Paginated audit events (newest first). |
+
+**Query audit events:**
+
+```bash
+curl -sS -b /tmp/argos.cookies \
+  'http://localhost:8080/v1/admin/audit?resource_type=cluster&action=cluster.create&since=2026-01-01T00:00:00Z' \
+  | jq '.items[:3]'
+```
+
+Filter parameters:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `actor_id` | UUID | Events by a specific user. |
+| `resource_type` | string | e.g., `cluster`, `user`, `token`. |
+| `resource_id` | string | Events for a specific resource. |
+| `action` | string | e.g., `user.create`, `cluster.delete`. |
+| `since` | datetime | Lower bound (inclusive). |
+| `until` | datetime | Upper bound (exclusive). |
+
+---
+
+## Health
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/healthz` | no | Liveness probe. Returns `{"status":"ok"}`. |
+| GET | `/readyz` | no | Readiness probe. Verifies database connectivity. |
+
+---
+
+For the full schema (request/response bodies, field types, constraints), see the OpenAPI specification at `api/openapi/openapi.yaml`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,223 @@
+# Architecture
+
+This document explains how Argos works internally -- its components, data flow, storage model, and design decisions.
+
+## High-level diagram
+
+```
+   Kubernetes cluster A               Kubernetes cluster B (air-gapped)
+          |                                       |
+          | client-go (list)                      | client-go (list)
+          v                                       v
+   ┌──────────────┐                      ┌──────────────────┐
+   │ pull collector│                      │ argos-collector   │
+   │ (goroutine    │                      │ (push binary)     │
+   │  in argosd)   │                      └────────┬─────────┘
+   └──────┬───────┘                               |
+          │ direct store calls                     | HTTPS + Bearer token
+          │                                        | POST /v1/*, /reconcile
+          v                                        v
+   ┌─────────────────────────────────────────────────┐
+   │                    argosd                        │
+   │  ┌───────────┐  ┌──────────┐  ┌──────────────┐  │
+   │  │ REST API  │  │ Auth     │  │ Audit        │  │
+   │  │ (OpenAPI) │  │ (ADR-07) │  │ Middleware   │  │
+   │  └─────┬─────┘  └──────────┘  └──────────────┘  │
+   │        │                                          │
+   │        v                                          │
+   │  ┌──────────────────┐   ┌─────────────────────┐  │
+   │  │ PostgreSQL Store │   │ Prometheus /metrics  │  │
+   │  │ (pgx/v5, goose)  │   └─────────────────────┘  │
+   │  └────────┬─────────┘                             │
+   │           │                                       │
+   └───────────┼───────────────────────────────────────┘
+               v
+        ┌────────────┐         ┌────────────────────┐
+        │ PostgreSQL │         │ Web UI (embedded    │
+        │ (JSONB +   │         │  React SPA at /ui/) │
+        │  goose     │         └────────────────────┘
+        │  migrations│
+        └────────────┘
+```
+
+## Components
+
+### argosd
+
+The main daemon, built from `cmd/argosd/main.go`. It combines several subsystems into a single binary:
+
+- **REST API** -- generated from `api/openapi/openapi.yaml` via `oapi-codegen`. Handlers live in `internal/api/`. Errors follow RFC 7807.
+- **Auth middleware** -- resolves requests as either session-cookie (humans) or bearer-token (machines), attaching a `Caller{id, kind, role, scopes}` to the context. Implemented in `internal/auth/`.
+- **Audit middleware** -- records every state-changing request and every admin-panel read. Sensitive fields are scrubbed.
+- **Pull collector** -- one goroutine per configured cluster, polling the Kubernetes API at a configurable interval. Implemented in `internal/collector/`.
+- **PostgreSQL store** -- cursor-paginated CRUD with merge-patch updates. Implemented in `internal/store/`.
+- **Metrics** -- Prometheus counters and gauges at `/metrics`. Implemented in `internal/metrics/`.
+- **Embedded UI** -- the React SPA built into the binary via `//go:embed` and served at `/ui/*`.
+
+### argos-collector
+
+A standalone push-mode collector binary, built from `cmd/argos-collector/`. It shares the same `internal/collector` package as the pull collector but writes through an HTTP client (`internal/collector/apiclient`) instead of the direct store interface.
+
+Key differences from the pull collector:
+
+- No database dependency.
+- No HTTP server -- it is a pure client.
+- Authenticates to argosd with a bearer token (PAT).
+- Supports gateway/proxy traversal: custom CA, mTLS, path prefix rewrite, extra headers.
+
+See [ADR-0009](adr/adr-0009-push-collector-for-airgapped-clusters.md) for the design rationale.
+
+## Pull collector
+
+The pull collector runs as goroutines inside argosd. Each goroutine handles one cluster.
+
+### Polling cycle
+
+On each tick (default: 60 seconds), the collector:
+
+1. Fetches the Kubernetes API server version, updating the cluster record's `kubernetes_version`.
+2. Lists **nodes** cluster-wide. Upserts by `(cluster_id, name)`. Reads the full field set: role, cloud identity, networking, OS stack, capacity, allocatable, conditions, taints.
+3. Lists **PersistentVolumes** cluster-wide. Upserts by `(cluster_id, name)`. Builds a name-to-ID map for PVC linking.
+4. Lists **namespaces**. Upserts by `(cluster_id, name)`. Builds a name-to-ID map.
+5. For each namespace:
+   - Lists **workloads** (Deployments, StatefulSets, DaemonSets via three `AppsV1` calls). Upserts by `(namespace_id, kind, name)`.
+   - Lists **pods**. Upserts by `(namespace_id, name)`. Resolves the controlling workload via the ownerReference chain (ReplicaSet -> Deployment, or direct for StatefulSet/DaemonSet).
+   - Lists **services**. Upserts by `(namespace_id, name)`. Flattens `status.loadBalancer.ingress[]` into the `load_balancer` JSONB.
+   - Lists **ingresses**. Upserts by `(namespace_id, name)`. Flattens rules, TLS, and load-balancer into JSONB.
+   - Lists **PersistentVolumeClaims**. Upserts by `(namespace_id, name)`. Resolves `spec.volumeName` against the PV map to set `bound_volume_id`.
+
+### Reconciliation
+
+When `ARGOS_COLLECTOR_RECONCILE=true` (default), after each successful listing the collector deletes rows that disappeared from the live Kubernetes listing:
+
+- **Cluster-scoped**: nodes and PVs reconcile against `(cluster_id, name)`.
+- **Namespace-scoped**: pods, services, ingresses, PVCs reconcile per namespace against `(namespace_id, name)`.
+- **Workloads**: reconcile keys on `(namespace_id, kind, name)` so deleting a Deployment named "web" does not affect a StatefulSet also named "web".
+
+Reconciliation only runs after a successful list. A transient Kubernetes API error never wipes the store.
+
+### Multi-cluster
+
+Configured via `ARGOS_COLLECTOR_CLUSTERS` (JSON array of `{name, kubeconfig}` tuples). One goroutine per entry, all sharing the store. The legacy `ARGOS_CLUSTER_NAME` + `ARGOS_KUBECONFIG` works as a single-cluster shortcut.
+
+## Push collector
+
+The push collector (`argos-collector`) runs inside an air-gapped cluster. It performs the same polling cycle as the pull collector but writes observations to argosd over HTTPS using the REST API:
+
+- **Upserts** map to `POST /v1/<resource>` (idempotent on the natural key).
+- **Reconciliation** maps to `POST /v1/<resource>/reconcile`.
+
+The HTTP client retries transient 5xx errors with exponential backoff (3 attempts max). On 401/403, the collector stops (token revoked or misconfigured).
+
+## Data model
+
+### Entity hierarchy
+
+```
+Cluster
+├── Node
+├── Namespace
+│   ├── Workload (Deployment | StatefulSet | DaemonSet)
+│   ├── Pod  ──→ Workload (workload_id FK, ON DELETE SET NULL)
+│   ├── Service
+│   ├── Ingress
+│   └── PersistentVolumeClaim  ──→ PersistentVolume (bound_volume_id FK, ON DELETE SET NULL)
+└── PersistentVolume
+```
+
+The FK chain from `clusters` cascades on delete: deleting a cluster removes all its children. The `workload_id` and `bound_volume_id` FKs use `ON DELETE SET NULL` -- deleting a workload or PV leaves the referencing row to be cleaned up by reconciliation.
+
+### Polymorphic workloads
+
+Workloads use a single `workloads` table with a `kind` discriminator (`Deployment`, `StatefulSet`, `DaemonSet`). Kind-specific details live in the `spec` JSONB column. See [ADR-0003](adr/adr-0003-workload-polymorphism.md).
+
+### JSONB columns
+
+Several columns use PostgreSQL JSONB for semi-structured data:
+
+- `containers` (pods, workloads): `[{name, image, image_id, init}]`
+- `load_balancer` (services, ingresses): `[{ip, hostname, ports}]`
+- `conditions` (nodes): `[{type, status, reason, message}]`
+- `taints` (nodes): `[{key, value, effect}]`
+- `spec` (workloads): kind-specific configuration
+- `annotations` (clusters): operator-defined key-value pairs
+
+### Curated metadata
+
+Clusters carry operator-editable columns (`owner`, `criticality`, `notes`, `runbook_url`, `annotations`) that the collector never touches. The merge-patch update semantics in `UpdateCluster` leave unset fields alone, so a collector tick cannot overwrite operator annotations.
+
+## ANSSI cartography layers
+
+Each Kubernetes kind maps to an ANSSI SecNumCloud cartography layer (per [ADR-0002](adr/adr-0002-kubernetes-to-anssi-cartography-layers.md)):
+
+| Kind | ANSSI Layer |
+|------|-------------|
+| Node | `infrastructure_physical` |
+| PersistentVolume | `infrastructure_physical` |
+| Namespace | `infrastructure_logical` |
+| Service | `infrastructure_logical` |
+| Workload (Deployment, StatefulSet, DaemonSet) | `applicative` |
+| Pod | `applicative` |
+| Ingress | `applicative` |
+| PersistentVolumeClaim | `applicative` |
+| Cluster | `ecosystem` |
+
+## Auth model
+
+Dual-path authentication per [ADR-0007](adr/adr-0007-auth-and-rbac.md):
+
+- **Humans**: session cookie (HttpOnly, SameSite=Strict, 8h sliding expiry) obtained via local login or OIDC.
+- **Machines**: bearer token (`argos_pat_<prefix>_<secret>`, argon2id-hashed at rest).
+- **RBAC**: four fixed roles (admin, editor, auditor, viewer) mapping to scope sets. Scope checks happen at the operation level.
+
+See [Authentication](authentication.md) for operational details.
+
+## Storage
+
+### PostgreSQL
+
+Argos uses PostgreSQL 14+ with `pgx/v5` for connection pooling. JSONB columns store heterogeneous Kubernetes specs without schema sprawl. All queries use parameterized statements.
+
+### Migrations
+
+SQL migrations are embedded in the binary via `migrations/embed.go` and run by `goose` on startup (when `ARGOS_AUTO_MIGRATE=true`, the default). Migrations are timestamped and forward-only.
+
+### Pagination
+
+All list endpoints use cursor-based pagination. The cursor is an opaque base64-encoded token containing the last-seen ID. This avoids the offset-skip performance degradation of traditional pagination.
+
+## Build and embed
+
+The argosd binary embeds the React UI bundle:
+
+1. `make ui-build` produces `ui/dist/` (Vite build).
+2. `go build` picks it up via `//go:embed all:dist` in `ui/embed.go`.
+3. The embedded files are served at `/ui/*`; root `/` redirects to `/ui/`.
+
+The build tag `noui` disables the embed (`make build-noui`), making `/ui/` return 404. Useful for backend-only development or headless deployments.
+
+### Container image
+
+The `Dockerfile` uses a three-stage build:
+
+1. `node:22-alpine` builds the UI bundle.
+2. `golang` compiles argosd with the embedded UI (`CGO_ENABLED=0` for a static binary).
+3. `gcr.io/distroless/static-debian12:nonroot` runs the binary as UID 65532.
+
+The push collector has its own `Dockerfile.collector` following the same pattern without the UI stage.
+
+## Architectural Decision Records
+
+Detailed design rationale is recorded in ADRs under `docs/adr/`:
+
+| ADR | Topic |
+|-----|-------|
+| [0001](adr/adr-0001-cmdb-for-snc-using-kube.md) | Build a CMDB for SNC against the Kubernetes API. |
+| [0002](adr/adr-0002-kubernetes-to-anssi-cartography-layers.md) | Map Kubernetes kinds to ANSSI cartography layers. |
+| [0003](adr/adr-0003-workload-polymorphism.md) | Single workloads table polymorphic on kind. |
+| [0004](adr/adr-0004-ingress-layer-classification.md) | Classify Ingress in the applicative layer. |
+| [0005](adr/adr-0005-multi-cluster-collector.md) | Central-pull multi-cluster topology. |
+| [0006](adr/adr-0006-ui-for-audit-and-curated-metadata.md) | Web UI for audit views and curated metadata. |
+| [0007](adr/adr-0007-auth-and-rbac.md) | Dual-path auth and RBAC. |
+| [0008](adr/adr-0008-secnumcloud-chapter-8-asset-management.md) | SecNumCloud chapter 8 asset management. |
+| [0009](adr/adr-0009-push-collector-for-airgapped-clusters.md) | Push-based collector for air-gapped clusters. |

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,252 @@
+# Authentication and Authorization
+
+Argos uses dual-path authentication: humans authenticate via session cookies, machines authenticate via bearer tokens. Both paths feed the same role-based access control (RBAC) system.
+
+## Overview
+
+```
+  Human (browser)                   Machine (CI, collector, script)
+       |                                       |
+  POST /v1/auth/login               Authorization: Bearer argos_pat_...
+  or OIDC flow                                 |
+       |                                       |
+  Set-Cookie: argos_session          Token lookup (argon2id hash)
+       |                                       |
+       +------- Caller{id, role, scopes} ------+
+                         |
+                   Scope check per endpoint
+```
+
+Every authenticated request resolves to a `Caller` with an identity, role, and set of scopes. The middleware checks the required scope for each endpoint; if the caller lacks it, the request gets a 403.
+
+## Roles and scopes
+
+Argos has four fixed roles. Roles are not customizable -- they map directly to scope sets.
+
+| Role | Scopes | Typical use |
+|------|--------|-------------|
+| `admin` | `read`, `write`, `delete`, `admin`, `audit` | Full access. Manages users, tokens, sessions. |
+| `editor` | `read`, `write` | Creates and updates CMDB resources. Cannot manage users or tokens. |
+| `auditor` | `read`, `audit` | Read-only access plus the audit log. For compliance teams. |
+| `viewer` | `read` | Read-only access to all CMDB data. Default role for new OIDC users. |
+
+Scope requirements per endpoint group:
+
+| Endpoint pattern | Required scope |
+|------------------|---------------|
+| `GET /v1/*` (list, get) | `read` |
+| `POST /v1/*` (create, upsert) | `write` |
+| `PATCH /v1/*` (update) | `write` |
+| `DELETE /v1/*` (delete) | `delete` |
+| `POST /v1/*/reconcile` | `write` |
+| `GET /v1/admin/audit` | `audit` |
+| `GET/POST/PATCH/DELETE /v1/admin/*` (users, tokens, sessions) | `admin` |
+
+## Local users
+
+### Bootstrap admin
+
+On first startup with an empty database, argosd creates a single `admin` user:
+
+- If `ARGOS_BOOTSTRAP_ADMIN_PASSWORD` is set, it uses that value.
+- Otherwise, it generates a random 16-character password and prints it **once** to the startup log inside a banner.
+
+The bootstrap admin has `must_change_password=true`, which blocks every API endpoint except `/v1/auth/change-password` until the password is rotated. `/healthz`, `/readyz`, and `/metrics` remain accessible.
+
+### Creating additional users
+
+Admins create users through the admin panel or the API:
+
+```bash
+curl -sS -b /tmp/argos.cookies -X POST http://localhost:8080/v1/admin/users \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"alice","password":"initial-password","role":"editor"}'
+```
+
+The new user must change their password on first login.
+
+### Updating users
+
+Admins can change a user's role, reset their password, or disable them:
+
+```bash
+# Promote to admin
+curl -sS -b /tmp/argos.cookies -X PATCH http://localhost:8080/v1/admin/users/<id> \
+  -H 'Content-Type: application/merge-patch+json' \
+  -d '{"role":"admin"}'
+
+# Disable (revokes all active sessions)
+curl -sS -b /tmp/argos.cookies -X PATCH http://localhost:8080/v1/admin/users/<id> \
+  -H 'Content-Type: application/merge-patch+json' \
+  -d '{"disabled":true}'
+```
+
+## OIDC federation
+
+OIDC is optional. When enabled, a "Sign in with ..." button appears on the login page alongside the local username/password form.
+
+### Setup
+
+1. Register argosd at your IdP as an application:
+   - **Redirect URI:** `https://<argos-host>/v1/auth/oidc/callback`
+   - **Grant types:** `authorization_code`
+   - **Scopes:** `openid email profile`
+
+2. Configure argosd (see [Configuration](configuration.md) for all variables):
+   ```bash
+   ARGOS_OIDC_ISSUER="https://idp.example.com/realms/argos"
+   ARGOS_OIDC_CLIENT_ID="argos"
+   ARGOS_OIDC_CLIENT_SECRET="your-secret"
+   ARGOS_OIDC_REDIRECT_URL="https://argos.example.com/v1/auth/oidc/callback"
+   ```
+
+3. Restart argosd. It fetches the issuer's OpenID Connect discovery document on boot and fails fatally if unreachable.
+
+### How it works
+
+1. The user clicks "Sign in with ..." in the UI.
+2. The browser hits `GET /v1/auth/oidc/authorize`, which generates a state + PKCE challenge + nonce, stores them in the database, and 302-redirects to the IdP.
+3. After authentication at the IdP, the browser arrives at `GET /v1/auth/oidc/callback` with an authorization code.
+4. argosd exchanges the code, verifies the ID token (issuer, audience, signature, nonce), and finds or creates a "shadow user" keyed on `(issuer, sub)`.
+5. A session cookie is set and the browser redirects to `/ui/`.
+
+### Shadow users
+
+OIDC users are called "shadow users" in Argos. Key properties:
+
+- They are created automatically on first OIDC login.
+- They start with role `viewer`. Argos does **not** trust OIDC group claims for authorization -- an admin must promote them manually.
+- They carry an unusable password hash, so they cannot log in via the local username/password form.
+- They are identified by the `(issuer, sub)` pair, not by email or username.
+
+### Important notes
+
+- OIDC is additive. The local `admin` bootstrap still works, providing a break-glass login.
+- `GET /v1/auth/config` is public and tells the UI whether OIDC is configured and what the button label should be.
+- The authorize-code flow uses PKCE (S256) and a server-side nonce for security.
+
+## Machine tokens (PAT)
+
+Machine tokens are for non-human callers: CI pipelines, the push-mode collector, monitoring scripts, and automation.
+
+### Creating tokens
+
+Only admins can create tokens, via the admin panel or the API:
+
+```bash
+curl -sS -b /tmp/argos.cookies -X POST http://localhost:8080/v1/admin/tokens \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"ci-pipeline","scopes":["read","write"]}'
+```
+
+The response contains the plaintext token **exactly once**:
+
+```json
+{
+  "id": "...",
+  "name": "ci-pipeline",
+  "prefix": "abcd1234",
+  "token": "argos_pat_abcd1234_xxxxxxxxxxxxxxxxxxxxxxxx",
+  "scopes": ["read", "write"],
+  "created_at": "..."
+}
+```
+
+Store the `token` value in a secrets manager immediately. argosd persists only its argon2id hash -- the plaintext cannot be retrieved later.
+
+### Token format
+
+Tokens follow the format `argos_pat_<8-char-prefix>_<32-char-secret>`. The prefix is stored in plaintext for O(1) lookup; the secret is hashed with argon2id.
+
+### Using tokens
+
+```bash
+curl -H "Authorization: Bearer argos_pat_abcd1234_xxxxxxxxxxxxxxxxxxxxxxxx" \
+  http://localhost:8080/v1/clusters
+```
+
+### Revoking tokens
+
+```bash
+# Via API
+curl -sS -b /tmp/argos.cookies -X DELETE http://localhost:8080/v1/admin/tokens/<id>
+
+# Or via the admin panel at /ui/admin/tokens
+```
+
+Revocation is immediate. Subsequent requests bearing the revoked token receive 401. Token rows are retained for audit continuity.
+
+### Best practices
+
+- One token per use case (one per push collector, one per CI pipeline).
+- Grant minimal scopes -- the push collector needs `read` + `write`, not `admin`.
+- Rotate tokens periodically. Revoke and re-mint.
+
+## Forced password rotation
+
+Users with `must_change_password=true` are blocked from every endpoint except:
+
+- `POST /v1/auth/change-password`
+- `GET /v1/auth/me` (so the UI knows to redirect)
+- `/healthz`, `/readyz`, `/metrics` (always unauthenticated)
+
+The UI detects this flag on every route change and redirects to the password-change page.
+
+Changing the password clears the flag and invalidates all other active sessions for the same user.
+
+## Session management
+
+### How sessions work
+
+- Sessions are server-side, stored in the database.
+- The `argos_session` cookie is `HttpOnly` + `SameSite=Strict` with an 8-hour sliding expiry.
+- The `Secure` flag is controlled by `ARGOS_SESSION_SECURE_COOKIE` (default: `auto`).
+
+### Viewing and revoking sessions
+
+Admins can view and revoke active sessions in the admin panel at `/ui/admin/sessions`, or via the API:
+
+```bash
+# List sessions
+curl -sS -b /tmp/argos.cookies http://localhost:8080/v1/admin/sessions | jq .
+
+# Revoke a session
+curl -sS -b /tmp/argos.cookies -X DELETE http://localhost:8080/v1/admin/sessions/<id>
+```
+
+### Logout
+
+```bash
+curl -sS -b /tmp/argos.cookies -X POST http://localhost:8080/v1/auth/logout
+```
+
+Deletes the server-side session and clears the cookie.
+
+## Unauthenticated endpoints
+
+These endpoints do not require any authentication:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /healthz` | Liveness probe. |
+| `GET /readyz` | Readiness probe (verifies database connectivity). |
+| `GET /metrics` | Prometheus metrics. |
+| `GET /v1/auth/config` | Public auth configuration (OIDC enabled? button label?). |
+| `POST /v1/auth/login` | Local username/password login. |
+| `GET /v1/auth/oidc/authorize` | OIDC flow start. |
+| `GET /v1/auth/oidc/callback` | OIDC flow completion. |
+| `GET /ui/*` | Static UI assets. |
+
+## Audit log
+
+Every state-changing API call and every admin-panel read is recorded in the `audit_events` table. Read-only cluster-browsing GETs are not logged to keep the table bounded.
+
+Sensitive fields (passwords, tokens, OIDC secrets) are scrubbed before persistence. Audit insertion failures are logged at ERROR but never cause a 5xx response.
+
+The audit log is accessible to users with the `audit` scope (roles `admin` and `auditor`):
+
+```bash
+curl -sS -b /tmp/argos.cookies 'http://localhost:8080/v1/admin/audit?resource_type=user&action=user.create' | jq .
+```
+
+See [API Reference](api-reference.md) for full filter options.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,128 @@
+# Configuration Reference
+
+All Argos configuration is environment-variable based. There are no config files.
+
+## argosd
+
+The main daemon that serves the REST API, web UI, and optionally runs the pull-mode collector.
+
+### Core
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ARGOS_DATABASE_URL` | yes | -- | PostgreSQL connection string (DSN). Example: `postgres://user:pass@host:5432/argos?sslmode=require`. |
+| `ARGOS_ADDR` | no | `:8080` | HTTP listen address. Set to `:443` or `127.0.0.1:8080` as needed. |
+| `ARGOS_AUTO_MIGRATE` | no | `true` | Run embedded goose migrations on startup. Set to `false` if you manage migrations externally. |
+| `ARGOS_SHUTDOWN_TIMEOUT` | no | `15s` | Graceful shutdown budget on SIGINT / SIGTERM. In-flight requests drain until this deadline. |
+
+### Bootstrap
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ARGOS_BOOTSTRAP_ADMIN_PASSWORD` | no | random 16-char string | Password for the auto-created `admin` user on first boot. Only consulted when no active admin exists in the database. If unset, argosd generates a random password and prints it **once** to the startup log. |
+
+### Session and cookies
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ARGOS_SESSION_SECURE_COOKIE` | no | `auto` | Controls the `Secure` flag on the session cookie. Values: `auto` (mirror the request scheme -- HTTPS sets Secure), `always`, or `never`. Use `never` only for local HTTP development. |
+
+### OIDC (optional)
+
+OIDC is disabled by default. Set `ARGOS_OIDC_ISSUER` to enable it.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ARGOS_OIDC_ISSUER` | no | (empty = off) | OIDC issuer URL. argosd fetches the `.well-known/openid-configuration` from this URL on startup and fails fatally if unreachable. Example: `https://idp.example.com/realms/argos`. |
+| `ARGOS_OIDC_CLIENT_ID` | when OIDC enabled | -- | OAuth 2.0 client ID registered at the IdP. |
+| `ARGOS_OIDC_CLIENT_SECRET` | for confidential clients | -- | OAuth 2.0 client secret. Omit for public clients (not recommended). |
+| `ARGOS_OIDC_REDIRECT_URL` | when OIDC enabled | -- | Full callback URL registered at the IdP. Must be `https://<argos-host>/v1/auth/oidc/callback`. |
+| `ARGOS_OIDC_SCOPES` | no | `openid,email,profile` | Comma-separated list of scopes to request from the IdP. |
+| `ARGOS_OIDC_LABEL` | no | `OIDC` | Text shown on the "Sign in with ..." button in the UI. |
+
+### Pull collector
+
+The embedded pull-mode collector is disabled by default.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ARGOS_COLLECTOR_ENABLED` | no | `false` | Enable the polling collector. Set to `true` to start ingesting data from Kubernetes. |
+| `ARGOS_COLLECTOR_INTERVAL` | no | `60s` | Time between polling ticks. Accepts Go duration syntax (`30s`, `5m`). |
+| `ARGOS_COLLECTOR_FETCH_TIMEOUT` | no | `20s` | Per-tick timeout for Kubernetes API calls. |
+| `ARGOS_COLLECTOR_RECONCILE` | no | `true` | Delete rows from the CMDB that no longer appear in the live Kubernetes listing. Required for ANSSI cartography fidelity. Set to `false` for append-only behavior. |
+
+#### Single-cluster mode
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ARGOS_CLUSTER_NAME` | when single-cluster | -- | Name of the cluster to poll. Must match a cluster registered via `POST /v1/clusters`. |
+| `ARGOS_KUBECONFIG` | no | (in-cluster) | Path to a kubeconfig file. Empty string or unset falls back to the in-cluster ServiceAccount. |
+
+#### Multi-cluster mode
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ARGOS_COLLECTOR_CLUSTERS` | no | -- | JSON array of `{"name":"...","kubeconfig":"..."}` tuples. One collector goroutine spawns per entry. An empty `kubeconfig` falls back to in-cluster config. Overrides `ARGOS_CLUSTER_NAME` / `ARGOS_KUBECONFIG` when set. |
+
+Example:
+
+```json
+[
+  {"name":"prod","kubeconfig":"/etc/argos/kubeconfigs/prod.yaml"},
+  {"name":"staging","kubeconfig":"/etc/argos/kubeconfigs/staging.yaml"},
+  {"name":"in-cluster","kubeconfig":""}
+]
+```
+
+### Legacy (removed)
+
+| Variable | Status | Migration |
+|----------|--------|-----------|
+| `ARGOS_API_TOKEN` | **removed** | argosd refuses to start if set. Migrate to admin-panel-issued tokens per ADR-0007. |
+| `ARGOS_API_TOKENS` | **removed** | Same as above. |
+
+---
+
+## argos-collector (push mode)
+
+The standalone push-mode collector binary. It runs inside an air-gapped or network-restricted cluster and pushes observations to a remote argosd over HTTPS. See [ADR-0009](../docs/adr/adr-0009-push-collector-for-airgapped-clusters.md) for background.
+
+### Connection
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ARGOS_SERVER_URL` | yes | -- | Base URL of the argosd instance. Example: `https://argos.internal:8080`. Supports a path prefix for gateway deployments: `https://gateway:443/argos`. |
+| `ARGOS_API_TOKEN` | yes | -- | Bearer token (PAT) with `write` scope, created in the argosd admin panel. Format: `argos_pat_<prefix>_<secret>`. |
+
+### Cluster identity
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ARGOS_CLUSTER_NAME` | yes | -- | Name of this cluster. Must match a cluster pre-registered in argosd via `POST /v1/clusters`. |
+| `ARGOS_KUBECONFIG` | no | (in-cluster) | Path to a kubeconfig file. Empty or unset falls back to the in-cluster ServiceAccount. |
+
+### Collector behavior
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ARGOS_COLLECTOR_INTERVAL` | no | `5m` | Time between polling ticks. |
+| `ARGOS_COLLECTOR_RECONCILE` | no | `true` | Delete stale rows via the `/reconcile` endpoints after each successful listing. |
+
+### TLS and gateway
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ARGOS_CA_CERT` | no | system CA pool | Path to a PEM-encoded CA certificate for verifying the argosd (or gateway) TLS certificate. Required when argosd uses a private CA. |
+| `ARGOS_CLIENT_CERT` | no | -- | Path to a PEM-encoded client certificate for mTLS to a gateway. |
+| `ARGOS_CLIENT_KEY` | no | -- | Path to a PEM-encoded client private key for mTLS. Required when `ARGOS_CLIENT_CERT` is set. |
+| `ARGOS_EXTRA_HEADERS` | no | -- | Comma-separated `key=value` pairs injected into every outbound HTTP request. Useful for gateway routing or tenant identification. Example: `X-Tenant-Id=zad-prod,X-Route-Key=argos`. |
+
+### Proxy
+
+The collector honors the standard Go proxy environment variables:
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `HTTPS_PROXY` | no | -- | Forward proxy URL for HTTPS traffic. |
+| `HTTP_PROXY` | no | -- | Forward proxy URL for HTTP traffic. |
+| `NO_PROXY` | no | -- | Comma-separated list of hosts/CIDRs to bypass the proxy. |

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -1,0 +1,162 @@
+# Run Argos with Docker
+
+This guide covers running argosd locally with Docker for development, testing, and demos.
+
+## Start PostgreSQL
+
+```bash
+docker run -d --rm --name argos-pg \
+  -e POSTGRES_PASSWORD=argos -e POSTGRES_DB=argos \
+  -p 5432:5432 postgres:16-alpine
+```
+
+Verify it is ready:
+
+```bash
+docker exec argos-pg pg_isready
+```
+
+## Build and run argosd
+
+### With the UI (full build)
+
+```bash
+make ui-install    # first time only
+make ui-build      # produces ui/dist/
+make build         # produces bin/argosd
+```
+
+### Without the UI (backend-only)
+
+```bash
+make build-noui    # no Node/npm required; /ui/ returns 404
+```
+
+### Start argosd
+
+```bash
+ARGOS_DATABASE_URL="postgres://postgres:argos@localhost:5432/argos?sslmode=disable" \
+  ARGOS_BOOTSTRAP_ADMIN_PASSWORD="local-dev-passphrase" \
+  ./bin/argosd
+```
+
+argosd listens on `http://localhost:8080` by default.
+
+### Using the Docker image
+
+If you prefer to run argosd itself in a container:
+
+```bash
+make docker-build    # tags argos:dev
+
+docker run --rm \
+  --network host \
+  -e ARGOS_DATABASE_URL="postgres://postgres:argos@localhost:5432/argos?sslmode=disable" \
+  -e ARGOS_BOOTSTRAP_ADMIN_PASSWORD="local-dev-passphrase" \
+  argos:dev
+```
+
+On macOS, replace `--network host` with `-p 8080:8080` and use `host.docker.internal` instead of `localhost` in the DSN:
+
+```bash
+docker run --rm \
+  -p 8080:8080 \
+  -e ARGOS_DATABASE_URL="postgres://postgres:argos@host.docker.internal:5432/argos?sslmode=disable" \
+  -e ARGOS_BOOTSTRAP_ADMIN_PASSWORD="local-dev-passphrase" \
+  argos:dev
+```
+
+## Seed demo data
+
+The demo seed script populates a realistic multi-cluster inventory without needing a real Kubernetes cluster:
+
+```bash
+# 1. Log in and create a token.
+curl -sS -c /tmp/argos.cookies -X POST http://localhost:8080/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"<your password after rotation>"}'
+
+curl -sS -b /tmp/argos.cookies -X POST http://localhost:8080/v1/admin/tokens \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"seed","scopes":["read","write","delete"]}'
+
+# 2. Run the seed script with the token.
+ARGOS_URL=http://localhost:8080 ARGOS_TOKEN=argos_pat_... ./scripts/seed-demo.sh
+```
+
+The script creates two clusters (prod, staging) with namespaces, workloads, pods, services, and a MetalLB-style ingress. Re-runnable after a `TRUNCATE clusters CASCADE` in PostgreSQL.
+
+## UI access
+
+Open `http://localhost:8080/` in a browser. It redirects to `/ui/`.
+
+Sign in with:
+- **Username:** `admin`
+- **Password:** `local-dev-passphrase` (or whatever you set above; rotated on first login)
+
+## Development workflow
+
+For iterative development, run argosd and the Vite dev server in parallel for hot reload:
+
+### Terminal 1 -- argosd
+
+```bash
+ARGOS_DATABASE_URL="postgres://postgres:argos@localhost:5432/argos?sslmode=disable" \
+  ARGOS_BOOTSTRAP_ADMIN_PASSWORD="local-dev-passphrase" \
+  ./bin/argosd
+```
+
+### Terminal 2 -- Vite dev server
+
+```bash
+make ui-dev
+```
+
+This starts the Vite dev server on `http://localhost:5173` and proxies `/v1`, `/healthz`, and `/metrics` to argosd on `:8080`. Edit React/TypeScript files and see changes instantly.
+
+Open `http://localhost:5173/ui/` and sign in with the admin credentials.
+
+### Backend-only development
+
+If you are only working on Go code:
+
+```bash
+make build-noui && ./bin/argosd   # quick rebuild, no UI toolchain
+make test                          # run all tests with -race
+make test-one TEST=TestMyFunction  # run a single test
+```
+
+### Integration tests
+
+Integration tests that hit PostgreSQL are gated on `PGX_TEST_DATABASE`:
+
+```bash
+PGX_TEST_DATABASE="postgres://postgres:argos@localhost:5432/argos?sslmode=disable" \
+  make test
+```
+
+Without `PGX_TEST_DATABASE`, those tests skip automatically.
+
+## Make targets reference
+
+| Target | What it does |
+|--------|--------------|
+| `make build` | Compile argosd into `bin/` (embeds `ui/dist`). |
+| `make build-noui` | Compile without the UI (no Node required). |
+| `make build-collector` | Compile the push-mode collector into `bin/`. |
+| `make test` | `go test -race -cover ./...` |
+| `make check` | fmt + vet + lint + test (CI-equivalent). |
+| `make docker-build` | Build the argosd container image as `argos:dev`. |
+| `make docker-build-collector` | Build the collector image as `argos-collector:dev`. |
+| `make ui-install` | `npm ci` in `ui/`. |
+| `make ui-build` | Produce `ui/dist/`. |
+| `make ui-dev` | Vite dev server on `:5173`. |
+| `make ui-check` | TypeScript typecheck. |
+
+## Cleanup
+
+```bash
+docker stop argos-pg
+```
+
+This removes the PostgreSQL container and all its data (the `--rm` flag was set at creation).

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -1,0 +1,232 @@
+# Deploy argosd on Kubernetes
+
+This guide deploys argosd into a Kubernetes cluster using the reference Kustomize manifests in `deploy/`. argosd catalogues the cluster it runs on (and optionally remote clusters) via its ServiceAccount.
+
+## Prerequisites
+
+- A Kubernetes cluster (kind, minikube, or a production cluster).
+- A PostgreSQL 14+ instance reachable from the cluster. The argosd pod needs `CREATE` privileges on the target database for goose migrations.
+- A container image. The image is not yet published to a registry -- see [Build the image](#build-the-image) below.
+- `kubectl` configured to talk to the cluster.
+
+## Files overview
+
+The `deploy/` directory contains:
+
+| File | Purpose |
+|------|---------|
+| `namespace.yaml` | Creates the `argos-system` namespace. |
+| `rbac.yaml` | ServiceAccount + ClusterRole (read-only `list` on ingested kinds) + ClusterRoleBinding. |
+| `deployment.yaml` | Single-replica argosd with probes, resource limits, non-root security context. |
+| `service.yaml` | ClusterIP Service on port 8080. |
+| `kustomization.yaml` | Ties everything together for `kubectl apply -k`. |
+| `secrets.example.yaml` | Template for credentials -- copy, fill, apply separately. |
+
+The Secret is intentionally excluded from the Kustomization to prevent accidental deployment with placeholder values.
+
+## Build the image
+
+```bash
+make docker-build    # tags argos:dev
+```
+
+Load it into your cluster:
+
+```bash
+# kind
+kind load docker-image argos:dev --name <your-kind-cluster>
+
+# minikube
+minikube image load argos:dev
+
+# Remote registry
+docker tag argos:dev registry.example.com/argos:dev
+docker push registry.example.com/argos:dev
+```
+
+Update the `image:` field in `deployment.yaml` to match.
+
+## Step-by-step deployment
+
+### 1. Create the credentials Secret
+
+```bash
+cp deploy/secrets.example.yaml /tmp/argos-credentials.yaml
+```
+
+Edit `/tmp/argos-credentials.yaml` and set at minimum:
+
+- `ARGOS_DATABASE_URL` -- your PostgreSQL DSN.
+- `ARGOS_BOOTSTRAP_ADMIN_PASSWORD` -- (optional) a known password for the first admin. If omitted, argosd generates one and prints it to the startup log.
+
+```bash
+kubectl apply -f /tmp/argos-credentials.yaml
+```
+
+### 2. Apply the manifests
+
+```bash
+kubectl apply -k deploy/
+```
+
+### 3. Watch it start
+
+```bash
+kubectl -n argos-system get pods -w
+kubectl -n argos-system logs -l app.kubernetes.io/name=argos -f
+```
+
+## First-run bootstrap
+
+On first boot with an empty database, argosd creates an `admin` user and prints the password once to the startup log:
+
+```
+WARN  ========================================================================
+      ARGOS FIRST-RUN BOOTSTRAP
+      A default admin user has been created:
+        username: admin
+        password: <16 random chars, or your ARGOS_BOOTSTRAP_ADMIN_PASSWORD>
+        source:   generated randomly; capture now -- it won't be printed again
+      This account MUST rotate its password on first login.
+      ========================================================================
+```
+
+Capture this password immediately. The first login (via UI or API) requires a password change.
+
+## Register the cluster
+
+The collector will not ingest data until the cluster is registered. Port-forward the service and register:
+
+```bash
+kubectl -n argos-system port-forward svc/argosd 8080:8080 &
+
+# Log in and stash the session cookie.
+curl -sS -c /tmp/argos.cookies -X POST http://localhost:8080/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"<your rotated password>"}'
+
+# Register the cluster.
+curl -sS -b /tmp/argos.cookies -X POST http://localhost:8080/v1/clusters \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"in-cluster","display_name":"Self","environment":"production"}'
+```
+
+The `name` value must match `ARGOS_CLUSTER_NAME` in the Deployment env vars (default: `in-cluster`).
+
+On the next collector tick (default: 60 seconds), nodes, namespaces, pods, workloads, services, ingresses, PVs, and PVCs populate.
+
+## Multi-cluster setup
+
+To catalogue multiple clusters from a single argosd (per ADR-0005):
+
+### 1. Create a kubeconfig Secret
+
+```bash
+kubectl -n argos-system create secret generic argos-kubeconfigs \
+  --from-file=prod.yaml=/path/to/prod-kubeconfig \
+  --from-file=staging.yaml=/path/to/staging-kubeconfig
+```
+
+### 2. Mount it into the argosd pod
+
+Add to the Deployment:
+
+```yaml
+volumes:
+  - name: kubeconfigs
+    secret:
+      secretName: argos-kubeconfigs
+containers:
+  - name: argosd
+    volumeMounts:
+      - name: kubeconfigs
+        mountPath: /etc/argos/kubeconfigs
+        readOnly: true
+```
+
+### 3. Switch to ARGOS_COLLECTOR_CLUSTERS
+
+Replace `ARGOS_CLUSTER_NAME` / `ARGOS_KUBECONFIG` in the Deployment env with:
+
+```yaml
+env:
+  - name: ARGOS_COLLECTOR_CLUSTERS
+    value: |
+      [
+        {"name":"prod","kubeconfig":"/etc/argos/kubeconfigs/prod.yaml"},
+        {"name":"staging","kubeconfig":"/etc/argos/kubeconfigs/staging.yaml"},
+        {"name":"in-cluster","kubeconfig":""}
+      ]
+```
+
+The empty `kubeconfig` entry falls back to the pod's in-cluster ServiceAccount.
+
+### 4. RBAC on each remote cluster
+
+Each kubeconfig must authenticate a ServiceAccount with the same read-only RBAC as `deploy/rbac.yaml` on its own cluster. The ClusterRole grants `list` on:
+
+- Core: `nodes`, `namespaces`, `pods`, `services`, `persistentvolumes`, `persistentvolumeclaims`
+- Apps: `deployments`, `statefulsets`, `daemonsets`, `replicasets`
+- Networking: `ingresses`
+
+No `get`, no `watch`, no write. argosd is read-only by design.
+
+### 5. Register each cluster
+
+```bash
+curl -sS -b /tmp/argos.cookies -X POST http://localhost:8080/v1/clusters \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"prod","display_name":"Production","environment":"production"}'
+
+curl -sS -b /tmp/argos.cookies -X POST http://localhost:8080/v1/clusters \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"staging","display_name":"Staging","environment":"staging"}'
+```
+
+## OIDC setup (optional)
+
+To let users federate from your Identity Provider:
+
+1. Register argosd as an application at the IdP. Set the redirect URI to `https://<argos-host>/v1/auth/oidc/callback`. Grant types: `authorization_code`. Request scopes: `openid email profile`.
+
+2. Add the OIDC variables to the credentials Secret:
+
+```yaml
+stringData:
+  ARGOS_OIDC_ISSUER: "https://idp.example.com/realms/argos"
+  ARGOS_OIDC_CLIENT_ID: "argos"
+  ARGOS_OIDC_CLIENT_SECRET: "your-client-secret"
+  ARGOS_OIDC_REDIRECT_URL: "https://argos.example.com/v1/auth/oidc/callback"
+  # Optional:
+  ARGOS_OIDC_LABEL: "Sign in with Keycloak"
+  ARGOS_OIDC_SCOPES: "openid,email,profile"
+```
+
+3. Restart argosd. It fetches the issuer's discovery document on boot and fails loudly if unreachable.
+
+First-time OIDC users land as role `viewer`. An admin promotes them through the admin panel at `/ui/admin/users`.
+
+See [Authentication](../authentication.md) for full details.
+
+## Verify
+
+```bash
+# Check the health endpoint.
+curl -sS http://localhost:8080/healthz | jq .
+
+# Count namespaces (requires auth).
+curl -sS -b /tmp/argos.cookies http://localhost:8080/v1/namespaces | jq '.items | length'
+
+# Check metrics.
+curl -sS http://localhost:8080/metrics | grep argos_collector_last_poll
+```
+
+## Uninstall
+
+```bash
+kubectl delete -k deploy/
+kubectl delete -f /tmp/argos-credentials.yaml
+kubectl delete namespace argos-system
+```
+
+The PostgreSQL database is untouched. Drop the `argos` database separately if you want a clean slate.

--- a/docs/deployment/push-collector.md
+++ b/docs/deployment/push-collector.md
@@ -1,0 +1,219 @@
+# Deploy the Push Collector (Air-Gapped Clusters)
+
+The push collector (`argos-collector`) runs inside a cluster that argosd cannot reach -- air-gapped environments, dedicated administration zones (ZAD), or clusters behind strict egress firewalls. It polls the local Kubernetes API and pushes observations to a remote argosd instance over HTTPS.
+
+## When to use push vs. pull
+
+| Scenario | Mode |
+|----------|------|
+| argosd can reach the target cluster's API server | **Pull** -- enable the embedded collector in argosd. No extra binary needed. |
+| The target cluster is air-gapped or network-restricted | **Push** -- deploy `argos-collector` inside the target cluster. |
+| Multi-tenant: the CMDB operator cannot obtain a kubeconfig | **Push** -- the tenant deploys the collector and pushes data out. |
+
+Both modes coexist. An environment can mix pulled and pushed clusters -- the CMDB sees no difference.
+
+## Prerequisites
+
+1. **argosd is running** and reachable over HTTPS from the air-gapped cluster (directly or through a gateway/proxy).
+2. **The cluster is registered** in argosd:
+   ```bash
+   curl -sS -H "Authorization: Bearer $TOKEN" -X POST https://argos.internal:8080/v1/clusters \
+     -H 'Content-Type: application/json' \
+     -d '{"name":"zad-prod","display_name":"ZAD Production","environment":"production"}'
+   ```
+   The `name` must match `ARGOS_CLUSTER_NAME` in the collector config.
+3. **A PAT with `write` scope** is minted in the argosd admin panel:
+   ```bash
+   curl -sS -b /tmp/argos.cookies -X POST https://argos.internal:8080/v1/admin/tokens \
+     -H 'Content-Type: application/json' \
+     -d '{"name":"zad-prod-collector","scopes":["read","write"]}'
+   ```
+   Store the plaintext token securely -- it is shown only once.
+
+## Build the image
+
+```bash
+make docker-build-collector    # tags argos-collector:dev
+```
+
+This produces a minimal static binary in a distroless image (`gcr.io/distroless/static-debian12:nonroot`, UID 65532). Transfer it to the air-gapped cluster's registry as needed.
+
+## Deploy with Kustomize
+
+Reference manifests live in `deploy/collector/`.
+
+### 1. Create the credentials Secret
+
+```bash
+cp deploy/collector/secret.example.yaml /tmp/argos-collector-secret.yaml
+```
+
+Edit `/tmp/argos-collector-secret.yaml`:
+
+```yaml
+stringData:
+  ARGOS_SERVER_URL: "https://argos.internal:8080"
+  ARGOS_API_TOKEN: "argos_pat_xxxxxxxx_yyyyyyyyyyyyyyyyyyyyyyyy"
+```
+
+Apply it:
+
+```bash
+kubectl apply -f /tmp/argos-collector-secret.yaml
+```
+
+### 2. Customize the Deployment
+
+Edit `deploy/collector/deployment.yaml` if needed:
+
+- Set `ARGOS_CLUSTER_NAME` to match the cluster name registered in argosd.
+- Adjust `ARGOS_COLLECTOR_INTERVAL` (default: `5m`).
+- Update the `image:` field to point to your registry.
+
+### 3. Apply
+
+```bash
+kubectl apply -k deploy/collector/
+```
+
+### 4. Verify
+
+```bash
+kubectl -n argos-system logs -l app.kubernetes.io/component=push-collector -f
+```
+
+You should see log lines indicating successful upserts for nodes, namespaces, pods, workloads, services, ingresses, PVs, and PVCs. Check argosd:
+
+```bash
+curl -sS -H "Authorization: Bearer $TOKEN" https://argos.internal:8080/v1/namespaces?cluster_name=zad-prod | jq '.items | length'
+```
+
+## Configuration
+
+All configuration is via environment variables. See the [configuration reference](../configuration.md) for the full table.
+
+Key variables for the push collector:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `ARGOS_SERVER_URL` | yes | argosd base URL. |
+| `ARGOS_API_TOKEN` | yes | PAT with `write` scope. |
+| `ARGOS_CLUSTER_NAME` | yes | Must match a pre-registered cluster. |
+| `ARGOS_KUBECONFIG` | no | Empty = in-cluster ServiceAccount. |
+| `ARGOS_COLLECTOR_INTERVAL` | no | Polling interval (default `5m`). |
+| `ARGOS_COLLECTOR_RECONCILE` | no | Delete stale rows (default `true`). |
+
+## Gateway and proxy support
+
+In SecNumCloud environments, outbound traffic from an air-gapped cluster typically transits through an API gateway or forward proxy.
+
+### HTTP(S) proxy
+
+Set the standard environment variables:
+
+```yaml
+env:
+  - name: HTTPS_PROXY
+    value: "http://proxy.zad.internal:3128"
+  - name: NO_PROXY
+    value: "10.0.0.0/8,.zad.internal"
+```
+
+Go's `net/http` honors these automatically.
+
+### Reverse proxy / API gateway in front of argosd
+
+If a gateway (Envoy, HAProxy, Nginx) exposes argosd under a sub-path, include the path prefix in the server URL:
+
+```yaml
+env:
+  - name: ARGOS_SERVER_URL
+    value: "https://gateway.zad.internal:443/argos"
+```
+
+The collector prepends this base path to every API request (`/argos/v1/clusters`, etc.).
+
+### Custom headers
+
+Some gateways require extra headers for routing or tenant identification:
+
+```yaml
+env:
+  - name: ARGOS_EXTRA_HEADERS
+    value: "X-Tenant-Id=zad-prod,X-Route-Key=argos"
+```
+
+### mTLS to the gateway
+
+When the gateway requires client-certificate authentication:
+
+```yaml
+env:
+  - name: ARGOS_CA_CERT
+    value: "/etc/argos/tls/ca.pem"
+  - name: ARGOS_CLIENT_CERT
+    value: "/etc/argos/tls/client.crt"
+  - name: ARGOS_CLIENT_KEY
+    value: "/etc/argos/tls/client.key"
+```
+
+Mount the certificates from a Secret:
+
+```yaml
+volumes:
+  - name: tls
+    secret:
+      secretName: argos-collector-tls
+containers:
+  - name: argos-collector
+    volumeMounts:
+      - name: tls
+        mountPath: /etc/argos/tls
+        readOnly: true
+```
+
+## RBAC
+
+The push collector needs the same read-only Kubernetes RBAC as the pull collector. The `deploy/collector/rbac.yaml` grants `list` on:
+
+- Core: `nodes`, `namespaces`, `pods`, `services`, `persistentvolumes`, `persistentvolumeclaims`
+- Apps: `deployments`, `statefulsets`, `daemonsets`, `replicasets`
+- Networking: `ingresses`
+
+No write access to Kubernetes. The collector is read-only.
+
+## Troubleshooting
+
+### 401 Unauthorized
+
+- The PAT is invalid, expired, or revoked. Check the argosd admin panel under Tokens.
+- The `Authorization: Bearer` header is malformed. Verify `ARGOS_API_TOKEN` starts with `argos_pat_`.
+
+### 404 cluster not found
+
+- The cluster name in `ARGOS_CLUSTER_NAME` does not match any cluster registered in argosd. Register it first with `POST /v1/clusters`.
+
+### 403 Forbidden
+
+- The PAT does not have the `write` scope. Create a new token with `scopes: ["read", "write"]`.
+
+### Connection refused / timeout
+
+- argosd is unreachable from the collector pod. Check network policies and egress rules.
+- If using a proxy, verify `HTTPS_PROXY` is set correctly and the proxy allows traffic to the argosd host.
+
+### TLS certificate errors
+
+- The argosd (or gateway) TLS certificate is signed by a private CA. Set `ARGOS_CA_CERT` to the CA PEM file.
+- For mTLS, ensure both `ARGOS_CLIENT_CERT` and `ARGOS_CLIENT_KEY` are set and the files are mounted.
+
+### 503 from gateway
+
+- The gateway cannot reach argosd. This is a gateway-side issue, not a collector issue. Check the gateway logs.
+- The collector logs the full response status and body to help distinguish gateway errors from argosd errors.
+
+### Data not appearing
+
+- Wait for at least one full polling interval.
+- Check collector logs for upsert errors.
+- Verify the cluster name matches exactly between the collector and the registered cluster in argosd.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,176 @@
+# Getting Started
+
+This guide walks you from zero to a working Argos installation with data flowing in. By the end you will have argosd running, the web UI accessible, and at least one cluster registered.
+
+## Prerequisites
+
+Regardless of the path you choose below, you need:
+
+- **Docker** (for the PostgreSQL container; Docker Desktop or a standalone engine both work)
+- **Git** (to clone the repository)
+
+For the "build from source" path you also need:
+
+- **Go** (version pinned in `go.mod` -- currently 1.25+)
+- **Node.js 22+** and **npm** (for the UI build)
+- **golangci-lint** (optional, for `make lint`)
+
+## Option A -- Docker quick start (5 minutes)
+
+### 1. Start PostgreSQL
+
+```bash
+docker run -d --rm --name argos-pg \
+  -e POSTGRES_PASSWORD=argos -e POSTGRES_DB=argos \
+  -p 5432:5432 postgres:16-alpine
+```
+
+### 2. Build and run argosd
+
+```bash
+git clone https://github.com/sthalbert/argos.git
+cd argos
+
+make ui-install    # first time only -- installs npm deps
+make ui-build      # produces ui/dist/ for embedding
+make build         # produces bin/argosd
+
+ARGOS_DATABASE_URL="postgres://postgres:argos@localhost:5432/argos?sslmode=disable" \
+  ARGOS_BOOTSTRAP_ADMIN_PASSWORD="changeme-on-first-login" \
+  ./bin/argosd
+```
+
+argosd runs database migrations automatically on startup, then starts listening on `:8080`.
+
+### 3. Open the UI and sign in
+
+```
+http://localhost:8080/
+```
+
+The root URL redirects to `/ui/`. Sign in with:
+
+- **Username:** `admin`
+- **Password:** `changeme-on-first-login` (or whatever you set above)
+
+The first login forces you to choose a new password -- this is the `must_change_password` enforcement. Pick something strong, then the dashboard appears.
+
+### 4. Seed demo data (optional)
+
+If you do not have a Kubernetes cluster handy, the demo seed script populates a realistic multi-cluster inventory so the UI has something to show:
+
+```bash
+# First, mint a token for the script.
+# Log in via curl, then create a token:
+curl -sS -c /tmp/argos.cookies -X POST http://localhost:8080/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"<your new password>"}'
+
+curl -sS -b /tmp/argos.cookies -X POST http://localhost:8080/v1/admin/tokens \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"seed","scopes":["read","write","delete"]}'
+# Copy the "token" value from the response.
+
+ARGOS_URL=http://localhost:8080 ARGOS_TOKEN=argos_pat_... ./scripts/seed-demo.sh
+```
+
+Refresh the UI -- you should see clusters, namespaces, workloads, pods, services, and ingresses.
+
+## Option B -- Binary from source (no Docker for argosd)
+
+If you prefer to skip Docker entirely for the argosd binary (you still need PostgreSQL somewhere):
+
+```bash
+git clone https://github.com/sthalbert/argos.git
+cd argos
+
+make ui-install
+make ui-build
+make build
+```
+
+Point argosd at any PostgreSQL 14+ instance:
+
+```bash
+export ARGOS_DATABASE_URL="postgres://user:pass@pg-host:5432/argos?sslmode=require"
+export ARGOS_BOOTSTRAP_ADMIN_PASSWORD="changeme-on-first-login"
+./bin/argosd
+```
+
+If you only need the API (no web UI), skip the Node toolchain entirely:
+
+```bash
+make build-noui
+```
+
+The `/ui/` path returns 404 in this mode; the REST API works normally.
+
+## First steps after login
+
+### Change the admin password
+
+This happens automatically on first login in the UI. If you are scripting against the API:
+
+```bash
+curl -sS -b /tmp/argos.cookies -X POST http://localhost:8080/v1/auth/change-password \
+  -H 'Content-Type: application/json' \
+  -d '{"current_password":"changeme-on-first-login","new_password":"a-strong-passphrase"}'
+```
+
+### Register a cluster
+
+The CMDB requires explicit cluster registration before any collector can write data. Create a cluster:
+
+```bash
+curl -sS -b /tmp/argos.cookies -X POST http://localhost:8080/v1/clusters \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"my-cluster","display_name":"My Cluster","environment":"dev"}'
+```
+
+The `name` field must match the `ARGOS_CLUSTER_NAME` (or the `name` in `ARGOS_COLLECTOR_CLUSTERS`) that the collector uses.
+
+### Enable the pull collector
+
+Add these environment variables when starting argosd:
+
+```bash
+ARGOS_COLLECTOR_ENABLED=true \
+ARGOS_CLUSTER_NAME=my-cluster \
+ARGOS_KUBECONFIG=~/.kube/config \
+ARGOS_DATABASE_URL="postgres://..." \
+  ./bin/argosd
+```
+
+On the next tick (default: 60 seconds) the collector populates nodes, namespaces, pods, workloads, services, ingresses, persistent volumes, and PVCs.
+
+### Verify data appears
+
+```bash
+curl -sS -b /tmp/argos.cookies http://localhost:8080/v1/namespaces | jq '.items | length'
+```
+
+Or simply refresh the UI -- the cluster detail page shows all discovered resources.
+
+### Mint a machine token
+
+For CI pipelines, automation scripts, or the push-mode collector, create a bearer token:
+
+```bash
+curl -sS -b /tmp/argos.cookies -X POST http://localhost:8080/v1/admin/tokens \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"ci-pipeline","scopes":["read","write"]}'
+```
+
+The response contains the plaintext token exactly once -- store it in a secrets manager immediately. Subsequent API calls use it as:
+
+```bash
+curl -H "Authorization: Bearer argos_pat_..." http://localhost:8080/v1/clusters
+```
+
+## Next steps
+
+- [Configuration reference](configuration.md) -- all environment variables for argosd and argos-collector.
+- [Deploy on Kubernetes](deployment/kubernetes.md) -- production deployment with Kustomize.
+- [Push collector for air-gapped clusters](deployment/push-collector.md) -- deploy argos-collector.
+- [Authentication guide](authentication.md) -- OIDC, roles, tokens.
+- [API reference](api-reference.md) -- every endpoint with curl examples.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,185 @@
+# Monitoring
+
+Argos exposes Prometheus metrics for HTTP request tracking, collector health, and build information.
+
+## Metrics endpoint
+
+| Property | Value |
+|----------|-------|
+| Path | `/metrics` |
+| Port | Same as the API (default `8080`) |
+| Authentication | None (Prometheus scrape convention) |
+| Format | Prometheus text exposition |
+
+The endpoint is unauthenticated to match standard Prometheus scraping. If your threat model requires access control, restrict it with a NetworkPolicy, a reverse proxy, or a separate listener.
+
+## Exported metrics
+
+### HTTP
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `argos_http_requests_total` | counter | `method`, `route`, `status` | Total HTTP requests handled. `status` is the HTTP status class (e.g., `2xx`, `4xx`). |
+| `argos_http_request_duration_seconds` | histogram | `method`, `route` | Request handling duration in seconds. Uses default Prometheus buckets. |
+
+### Collector
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `argos_collector_upserted_total` | counter | `cluster`, `resource` | Cumulative count of entities upserted per collector tick. |
+| `argos_collector_reconciled_total` | counter | `cluster`, `resource` | Cumulative count of entities removed by reconciliation. |
+| `argos_collector_errors_total` | counter | `cluster`, `resource`, `phase` | Collector errors. `phase` is `list`, `upsert`, `reconcile`, or `lookup`. |
+| `argos_collector_last_poll_timestamp_seconds` | gauge | `cluster`, `resource` | Unix timestamp of the last successful poll. |
+
+The `resource` label is one of: `version`, `cluster`, `nodes`, `namespaces`, `pods`, `workloads`, `services`, `ingresses`, `persistentvolumes`, `persistentvolumeclaims`, `replicasets`.
+
+### Build
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `argos_build_info` | gauge | `version`, `go_version` | Always 1. Carries version and Go toolchain info as labels. |
+
+### Go runtime
+
+The standard `go_*` and `process_*` collectors from `client_golang` are also registered (goroutine count, GC stats, memory stats, open file descriptors, etc.).
+
+## Scrape configuration
+
+### Annotation-based (kube-prometheus)
+
+The argosd Deployment carries the standard annotations:
+
+```yaml
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
+    prometheus.io/path: "/metrics"
+```
+
+Most Prometheus deployments with annotation-based service discovery will pick this up automatically.
+
+### ServiceMonitor (Prometheus Operator)
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: argosd
+  namespace: argos-system
+  labels:
+    app.kubernetes.io/name: argos
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argos
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+```
+
+### PodMonitor
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: argosd
+  namespace: argos-system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argos
+  podMetricsEndpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+```
+
+## Example alerts
+
+### Collector freshness
+
+Fire if any resource kind has not been polled in 10 minutes:
+
+```yaml
+- alert: ArgosCollectorStale
+  expr: time() - argos_collector_last_poll_timestamp_seconds > 600
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Argos collector stale for {{ $labels.cluster }}/{{ $labels.resource }}"
+    description: "No successful poll in the last 10 minutes."
+```
+
+### Collector errors
+
+Fire if the collector encounters persistent errors:
+
+```yaml
+- alert: ArgosCollectorErrors
+  expr: rate(argos_collector_errors_total[5m]) > 0
+  for: 10m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Argos collector errors for {{ $labels.cluster }}/{{ $labels.resource }} ({{ $labels.phase }})"
+    description: "Sustained collector errors over the last 10 minutes."
+```
+
+### HTTP error rate
+
+Fire if more than 5% of requests return 5xx:
+
+```yaml
+- alert: ArgosHighErrorRate
+  expr: |
+    sum(rate(argos_http_requests_total{status=~"5.."}[5m]))
+    /
+    sum(rate(argos_http_requests_total[5m]))
+    > 0.05
+  for: 5m
+  labels:
+    severity: critical
+  annotations:
+    summary: "Argos HTTP 5xx rate above 5%"
+```
+
+### HTTP latency
+
+Fire if p95 request duration exceeds 2 seconds:
+
+```yaml
+- alert: ArgosHighLatency
+  expr: |
+    histogram_quantile(0.95, sum(rate(argos_http_request_duration_seconds_bucket[5m])) by (le))
+    > 2
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Argos p95 latency above 2s"
+```
+
+## Grafana dashboard tips
+
+### Useful panels
+
+- **Request rate** by route: `sum(rate(argos_http_requests_total[5m])) by (route)`
+- **Error rate** by route: `sum(rate(argos_http_requests_total{status=~"[45].."}[5m])) by (route, status)`
+- **Latency heatmap**: use `argos_http_request_duration_seconds_bucket` as a heatmap source.
+- **Collector freshness**: `time() - argos_collector_last_poll_timestamp_seconds` per `(cluster, resource)` -- show as a stat panel with thresholds at 120s (green) / 300s (yellow) / 600s (red).
+- **Upserts per tick**: `increase(argos_collector_upserted_total[5m])` per `(cluster, resource)` as a stacked bar chart.
+- **Reconciled per tick**: `increase(argos_collector_reconciled_total[5m])` -- a sudden spike may indicate a cluster-wide event.
+- **Build info**: use `argos_build_info` as a stat panel to show the running version.
+
+### Variables
+
+Define Grafana template variables for:
+
+- `cluster` sourced from `label_values(argos_collector_last_poll_timestamp_seconds, cluster)`
+- `resource` sourced from `label_values(argos_collector_last_poll_timestamp_seconds, resource)`
+
+This lets operators drill into a specific cluster or resource kind.


### PR DESCRIPTION
Rewrite README.md as a concise landing page with links to docs/.

New documentation pages:
- getting-started.md: tutorial from zero to working installation
- configuration.md: complete env var reference (argosd + argos-collector)
- deployment/kubernetes.md: deploy on K8s (pull mode, multi-cluster, OIDC)
- deployment/push-collector.md: deploy in air-gapped clusters (push mode)
- deployment/docker.md: local development with Docker
- authentication.md: auth setup (local, OIDC, PAT, roles/scopes)
- api-reference.md: REST API reference with curl examples
- monitoring.md: Prometheus metrics, scrape config, alert examples
- architecture.md: system design, data model, pull vs push, ANSSI layers