### PR TITLE
feat: add Helm chart for Argos with optional PostgreSQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,40 @@ jobs:
           version: v2.11
           args: --timeout=5m
 
+  helm:
+    name: helm lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Add Bitnami repository
+        run: helm repo add bitnami https://charts.bitnami.com/bitnami
+
+      - name: Build dependencies
+        run: helm dependency build charts/argos
+
+      - name: Lint chart (default values — bundled PG)
+        run: helm lint charts/argos
+
+      - name: Lint chart (external database — no PG)
+        run: |
+          helm lint charts/argos \
+            --set postgresql.enabled=false \
+            --set externalDatabase.url="postgres://argos:test@pg:5432/argos"
+
+      - name: Template renders cleanly (bundled PG)
+        run: helm template argos charts/argos > /dev/null
+
+      - name: Template renders cleanly (external database)
+        run: |
+          helm template argos charts/argos \
+            --set postgresql.enabled=false \
+            --set externalDatabase.url="postgres://argos:test@pg:5432/argos" > /dev/null
+
   docker:
     name: docker build
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ coverage.html
 # OS
 .DS_Store
 Thumbs.db
+charts/*/charts/*.tgz

--- a/charts/argos/.helmignore
+++ b/charts/argos/.helmignore
@@ -1,0 +1,10 @@
+.DS_Store
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/argos/Chart.lock
+++ b/charts/argos/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 16.7.27
+digest: sha256:02ea53ae0d438e7312131d070e90c2774a6015edb597be638aa208dc59c0d27f
+generated: "2026-04-22T13:38:41.487372+02:00"

--- a/charts/argos/Chart.yaml
+++ b/charts/argos/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: argos
+description: >-
+  A CMDB for Kubernetes environments aligned with the ANSSI SecNumCloud
+  qualification framework. Polls clusters and exposes a REST API and web UI.
+type: application
+version: 0.1.0
+appVersion: "0.2.1"
+home: https://github.com/sthalbert/Argos
+sources:
+  - https://github.com/sthalbert/Argos
+maintainers:
+  - name: Steve Albert
+    url: https://github.com/sthalbert
+keywords:
+  - cmdb
+  - kubernetes
+  - secnumcloud
+  - anssi
+  - inventory
+  - compliance
+
+dependencies:
+  - name: postgresql
+    version: "~16"
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled

--- a/charts/argos/templates/NOTES.txt
+++ b/charts/argos/templates/NOTES.txt
@@ -1,0 +1,28 @@
+Argos has been installed.
+
+1. Get the application URL:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "argos.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "ClusterIP" .Values.service.type }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "argos.fullname" . }} 8080:{{ .Values.service.port }}
+  echo http://localhost:8080
+{{- end }}
+
+2. Sign in:
+   On first boot, argosd creates an admin user and prints the password
+   ONCE in the pod log:
+
+   kubectl --namespace {{ .Release.Namespace }} logs -l app.kubernetes.io/name={{ include "argos.name" . }} | grep "ARGOS FIRST-RUN"
+
+3. Register a cluster:
+   curl -X POST http://localhost:8080/v1/clusters \
+     -H 'Content-Type: application/json' \
+     -d '{"name":"my-cluster"}'
+
+Documentation: https://github.com/sthalbert/Argos/tree/main/docs

--- a/charts/argos/templates/_helpers.tpl
+++ b/charts/argos/templates/_helpers.tpl
@@ -1,0 +1,91 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "argos.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "argos.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "argos.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "argos.labels" -}}
+helm.sh/chart: {{ include "argos.chart" . }}
+{{ include "argos.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "argos.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "argos.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "argos.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "argos.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Image reference.
+*/}}
+{{- define "argos.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- end }}
+
+{{/*
+Database URL. When the bundled PostgreSQL is enabled, build the DSN from
+the subchart values. Otherwise use externalDatabase.url.
+*/}}
+{{- define "argos.databaseUrl" -}}
+{{- if .Values.postgresql.enabled -}}
+postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ include "argos.fullname" . }}-postgresql:5432/{{ .Values.postgresql.auth.database }}?sslmode=disable
+{{- else -}}
+{{ required "externalDatabase.url is required when postgresql.enabled=false" .Values.externalDatabase.url }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Secret name for argosd credentials.
+*/}}
+{{- define "argos.secretName" -}}
+{{- if .Values.existingSecret }}
+{{- .Values.existingSecret }}
+{{- else }}
+{{- include "argos.fullname" . }}
+{{- end }}
+{{- end }}

--- a/charts/argos/templates/clusterrole.yaml
+++ b/charts/argos/templates/clusterrole.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "argos.fullname" . }}-cluster-reader
+  labels:
+    {{- include "argos.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - namespaces
+      - pods
+      - services
+      - persistentvolumes
+      - persistentvolumeclaims
+    verbs: ["list"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - statefulsets
+      - daemonsets
+      - replicasets
+    verbs: ["list"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+    verbs: ["list"]
+{{- end }}

--- a/charts/argos/templates/clusterrolebinding.yaml
+++ b/charts/argos/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "argos.fullname" . }}-cluster-reader
+  labels:
+    {{- include "argos.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "argos.fullname" . }}-cluster-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "argos.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/argos/templates/deployment.yaml
+++ b/charts/argos/templates/deployment.yaml
@@ -1,0 +1,107 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "argos.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "argos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: daemon
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "argos.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: daemon
+  template:
+    metadata:
+      labels:
+        {{- include "argos.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: daemon
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- if .Values.metrics.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "argos.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: argosd
+          image: {{ include "argos.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: ARGOS_ADDR
+              value: {{ .Values.argosd.addr | quote }}
+            - name: ARGOS_AUTO_MIGRATE
+              value: {{ .Values.argosd.autoMigrate | quote }}
+            - name: ARGOS_SHUTDOWN_TIMEOUT
+              value: {{ .Values.argosd.shutdownTimeout | quote }}
+            - name: ARGOS_SESSION_SECURE_COOKIE
+              value: {{ .Values.argosd.sessionSecureCookie | quote }}
+            {{- if .Values.collector.enabled }}
+            - name: ARGOS_COLLECTOR_ENABLED
+              value: "true"
+            - name: ARGOS_COLLECTOR_RECONCILE
+              value: {{ .Values.collector.reconcile | quote }}
+            - name: ARGOS_COLLECTOR_INTERVAL
+              value: {{ .Values.collector.interval | quote }}
+            - name: ARGOS_COLLECTOR_FETCH_TIMEOUT
+              value: {{ .Values.collector.fetchTimeout | quote }}
+            {{- if .Values.collector.clusters }}
+            - name: ARGOS_COLLECTOR_CLUSTERS
+              value: {{ .Values.collector.clusters | toJson | quote }}
+            {{- else }}
+            - name: ARGOS_CLUSTER_NAME
+              value: {{ .Values.collector.clusterName | quote }}
+            - name: ARGOS_KUBECONFIG
+              value: {{ .Values.collector.kubeconfig | quote }}
+            {{- end }}
+            {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ include "argos.secretName" . }}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/argos/templates/ingress.yaml
+++ b/charts/argos/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "argos.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "argos.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - secretName: {{ .secretName }}
+      hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "argos.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/argos/templates/secret.yaml
+++ b/charts/argos/templates/secret.yaml
@@ -1,0 +1,27 @@
+{{- if not .Values.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "argos.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "argos.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  ARGOS_DATABASE_URL: {{ include "argos.databaseUrl" . | quote }}
+  {{- if .Values.argosd.bootstrapAdminPassword }}
+  ARGOS_BOOTSTRAP_ADMIN_PASSWORD: {{ .Values.argosd.bootstrapAdminPassword | quote }}
+  {{- end }}
+  {{- if .Values.oidc.enabled }}
+  ARGOS_OIDC_ISSUER: {{ .Values.oidc.issuer | quote }}
+  ARGOS_OIDC_CLIENT_ID: {{ .Values.oidc.clientId | quote }}
+  ARGOS_OIDC_CLIENT_SECRET: {{ .Values.oidc.clientSecret | quote }}
+  ARGOS_OIDC_REDIRECT_URL: {{ .Values.oidc.redirectUrl | quote }}
+  {{- if .Values.oidc.scopes }}
+  ARGOS_OIDC_SCOPES: {{ .Values.oidc.scopes | quote }}
+  {{- end }}
+  {{- if .Values.oidc.label }}
+  ARGOS_OIDC_LABEL: {{ .Values.oidc.label | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/argos/templates/service.yaml
+++ b/charts/argos/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "argos.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "argos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: daemon
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "argos.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: daemon
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/argos/templates/serviceaccount.yaml
+++ b/charts/argos/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "argos.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "argos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: daemon
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/argos/templates/servicemonitor.yaml
+++ b/charts/argos/templates/servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "argos.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "argos.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "argos.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: daemon
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+{{- end }}

--- a/charts/argos/values.yaml
+++ b/charts/argos/values.yaml
@@ -1,0 +1,155 @@
+# -- Number of argosd replicas. Must be 1 (single-writer, ADR-0005).
+replicaCount: 1
+
+# -- Container image for argosd.
+image:
+  repository: ghcr.io/sthalbert/argos
+  # -- Overrides the image tag. Defaults to the chart appVersion.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# -- argosd core configuration.
+argosd:
+  # -- HTTP listen address inside the container.
+  addr: ":8080"
+  # -- Run embedded goose migrations on startup.
+  autoMigrate: true
+  # -- Graceful shutdown budget.
+  shutdownTimeout: "15s"
+  # -- First-install admin password. Empty = random (printed once in logs).
+  bootstrapAdminPassword: ""
+  # -- Session cookie Secure flag: auto | always | never.
+  sessionSecureCookie: "auto"
+
+# -- Pull-mode collector (embedded in argosd).
+collector:
+  # -- Enable the Kubernetes polling collector.
+  enabled: false
+  # -- Single-cluster name (ignored when clusters is non-empty).
+  clusterName: "in-cluster"
+  # -- Path to kubeconfig. Empty = in-cluster ServiceAccount.
+  kubeconfig: ""
+  # -- Multi-cluster list. Each entry: {name: "x", kubeconfig: "/path"}.
+  # An empty kubeconfig uses the pod's in-cluster credentials.
+  clusters: []
+  # -- Time between polls.
+  interval: "5m"
+  # -- Per-poll Kubernetes API timeout.
+  fetchTimeout: "10s"
+  # -- Delete rows that vanish from the live listing.
+  reconcile: true
+
+# -- OIDC federation (optional).
+oidc:
+  # -- Enable OIDC sign-in.
+  enabled: false
+  # -- OIDC issuer URL (must serve .well-known/openid-configuration).
+  issuer: ""
+  # -- OAuth2 client ID.
+  clientId: ""
+  # -- OAuth2 client secret.
+  clientSecret: ""
+  # -- Authorization callback URL (must match IdP config).
+  redirectUrl: ""
+  # -- Comma-separated OAuth2 scopes.
+  scopes: "openid,email,profile"
+  # -- Login button label.
+  label: "OIDC"
+
+# -- Bundled PostgreSQL (Bitnami subchart).
+# Set enabled=false and provide externalDatabase.url to use your own PG.
+postgresql:
+  enabled: true
+  auth:
+    username: argos
+    password: argos
+    database: argos
+  primary:
+    persistence:
+      size: 5Gi
+
+# -- External PostgreSQL. Only used when postgresql.enabled=false.
+externalDatabase:
+  # -- Full DSN, e.g. postgres://user:pass@host:5432/argos?sslmode=require
+  url: ""
+
+# -- Use an existing Secret for credentials instead of the chart-generated one.
+# The Secret must contain ARGOS_DATABASE_URL (and optionally other ARGOS_* keys).
+existingSecret: ""
+
+# -- Kubernetes Service.
+service:
+  type: ClusterIP
+  port: 8080
+
+# -- ServiceAccount.
+serviceAccount:
+  create: true
+  # -- Name override. Defaults to the release fullname.
+  name: ""
+  annotations: {}
+
+# -- RBAC (ClusterRole granting list on K8s resources for the collector).
+rbac:
+  create: true
+
+# -- Pod resource requests and limits.
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+# -- Pod-level security context.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Container-level security context.
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+
+# -- Prometheus metrics.
+metrics:
+  # -- Expose /metrics endpoint (always on; this controls annotations).
+  enabled: true
+  serviceMonitor:
+    # -- Create a ServiceMonitor for Prometheus Operator.
+    enabled: false
+    # -- Scrape interval.
+    interval: "30s"
+    # -- Additional labels for the ServiceMonitor.
+    labels: {}
+
+# -- Ingress (expose argosd outside the cluster).
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts: []
+  #  - host: argos.example.com
+  #    paths:
+  #      - path: /
+  #        pathType: Prefix
+  tls: []
+  #  - secretName: argos-tls
+  #    hosts:
+  #      - argos.example.com
+
+# -- Node selector, tolerations, affinity.
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/cmd/argos-collector/main_test.go
+++ b/cmd/argos-collector/main_test.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// loadCollectorConfig
+// ---------------------------------------------------------------------------
+
+func TestLoadCollectorConfig_AllRequired(t *testing.T) {
+	t.Setenv("ARGOS_SERVER_URL", "https://argos.test:8080")
+	t.Setenv("ARGOS_API_TOKEN", "argos_pat_xxxx_yyyy")
+	t.Setenv("ARGOS_CLUSTER_NAME", "test-cluster")
+
+	cfg, err := loadCollectorConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.serverURL != "https://argos.test:8080" {
+		t.Errorf("serverURL: want https://argos.test:8080, got %q", cfg.serverURL)
+	}
+	if cfg.token != "argos_pat_xxxx_yyyy" {
+		t.Errorf("token: want argos_pat_xxxx_yyyy, got %q", cfg.token)
+	}
+	if cfg.clusterName != "test-cluster" {
+		t.Errorf("clusterName: want test-cluster, got %q", cfg.clusterName)
+	}
+	if cfg.interval != 5*time.Minute {
+		t.Errorf("interval: want 5m, got %v", cfg.interval)
+	}
+	if cfg.fetchTimeout != 30*time.Second {
+		t.Errorf("fetchTimeout: want 30s, got %v", cfg.fetchTimeout)
+	}
+	if !cfg.reconcile {
+		t.Error("reconcile: want true, got false")
+	}
+}
+
+func TestLoadCollectorConfig_MissingServerURL(t *testing.T) {
+	t.Setenv("ARGOS_SERVER_URL", "")
+	t.Setenv("ARGOS_API_TOKEN", "tok")
+	t.Setenv("ARGOS_CLUSTER_NAME", "c")
+
+	_, err := loadCollectorConfig()
+	if !errors.Is(err, errServerURLRequired) {
+		t.Errorf("want errServerURLRequired, got %v", err)
+	}
+}
+
+func TestLoadCollectorConfig_MissingAPIToken(t *testing.T) {
+	t.Setenv("ARGOS_SERVER_URL", "https://x")
+	t.Setenv("ARGOS_API_TOKEN", "")
+	t.Setenv("ARGOS_CLUSTER_NAME", "c")
+
+	_, err := loadCollectorConfig()
+	if !errors.Is(err, errAPITokenRequired) {
+		t.Errorf("want errAPITokenRequired, got %v", err)
+	}
+}
+
+func TestLoadCollectorConfig_MissingClusterName(t *testing.T) {
+	t.Setenv("ARGOS_SERVER_URL", "https://x")
+	t.Setenv("ARGOS_API_TOKEN", "tok")
+	t.Setenv("ARGOS_CLUSTER_NAME", "")
+
+	_, err := loadCollectorConfig()
+	if !errors.Is(err, errClusterNameRequired) {
+		t.Errorf("want errClusterNameRequired, got %v", err)
+	}
+}
+
+func TestLoadCollectorConfig_CustomValues(t *testing.T) {
+	t.Setenv("ARGOS_SERVER_URL", "https://gw:443/argos")
+	t.Setenv("ARGOS_API_TOKEN", "tok")
+	t.Setenv("ARGOS_CLUSTER_NAME", "zad-prod")
+	t.Setenv("ARGOS_KUBECONFIG", "/etc/kube/config")
+	t.Setenv("ARGOS_COLLECTOR_INTERVAL", "30s")
+	t.Setenv("ARGOS_COLLECTOR_FETCH_TIMEOUT", "1m")
+	t.Setenv("ARGOS_COLLECTOR_RECONCILE", "false")
+
+	cfg, err := loadCollectorConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.kubeconfig != "/etc/kube/config" {
+		t.Errorf("kubeconfig: want /etc/kube/config, got %q", cfg.kubeconfig)
+	}
+	if cfg.interval != 30*time.Second {
+		t.Errorf("interval: want 30s, got %v", cfg.interval)
+	}
+	if cfg.fetchTimeout != 1*time.Minute {
+		t.Errorf("fetchTimeout: want 1m, got %v", cfg.fetchTimeout)
+	}
+	if cfg.reconcile {
+		t.Error("reconcile: want false, got true")
+	}
+}
+
+func TestLoadCollectorConfig_InvalidInterval(t *testing.T) {
+	t.Setenv("ARGOS_SERVER_URL", "https://x")
+	t.Setenv("ARGOS_API_TOKEN", "tok")
+	t.Setenv("ARGOS_CLUSTER_NAME", "c")
+	t.Setenv("ARGOS_COLLECTOR_INTERVAL", "not-a-duration")
+
+	_, err := loadCollectorConfig()
+	if err == nil {
+		t.Fatal("expected error for invalid interval")
+	}
+}
+
+func TestLoadCollectorConfig_InvalidReconcile(t *testing.T) {
+	t.Setenv("ARGOS_SERVER_URL", "https://x")
+	t.Setenv("ARGOS_API_TOKEN", "tok")
+	t.Setenv("ARGOS_CLUSTER_NAME", "c")
+	t.Setenv("ARGOS_COLLECTOR_RECONCILE", "not-a-bool")
+
+	_, err := loadCollectorConfig()
+	if err == nil {
+		t.Fatal("expected error for invalid reconcile")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseExtraHeaders
+// ---------------------------------------------------------------------------
+
+func TestParseExtraHeaders_Empty(t *testing.T) {
+	h := parseExtraHeaders("")
+	if h != nil {
+		t.Errorf("want nil, got %v", h)
+	}
+}
+
+func TestParseExtraHeaders_Single(t *testing.T) {
+	h := parseExtraHeaders("X-Tenant=prod")
+	if len(h) != 1 || h["X-Tenant"] != "prod" {
+		t.Errorf("want {X-Tenant:prod}, got %v", h)
+	}
+}
+
+func TestParseExtraHeaders_Multiple(t *testing.T) {
+	h := parseExtraHeaders("X-Tenant=prod, X-Region=eu-west-1")
+	if len(h) != 2 {
+		t.Fatalf("want 2 headers, got %d", len(h))
+	}
+	if h["X-Tenant"] != "prod" {
+		t.Errorf("X-Tenant: want prod, got %q", h["X-Tenant"])
+	}
+	if h["X-Region"] != "eu-west-1" {
+		t.Errorf("X-Region: want eu-west-1, got %q", h["X-Region"])
+	}
+}
+
+func TestParseExtraHeaders_SkipsInvalid(t *testing.T) {
+	h := parseExtraHeaders("good=val,,=nope,also-bad")
+	if len(h) != 1 || h["good"] != "val" {
+		t.Errorf("want {good:val}, got %v", h)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseDurationEnv / parseBoolEnv
+// ---------------------------------------------------------------------------
+
+func TestParseDurationEnv_Default(t *testing.T) {
+	t.Setenv("TEST_DUR", "")
+	d, err := parseDurationEnv("TEST_DUR", 42*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d != 42*time.Second {
+		t.Errorf("want 42s, got %v", d)
+	}
+}
+
+func TestParseDurationEnv_Set(t *testing.T) {
+	t.Setenv("TEST_DUR", "10m")
+	d, err := parseDurationEnv("TEST_DUR", 1*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d != 10*time.Minute {
+		t.Errorf("want 10m, got %v", d)
+	}
+}
+
+func TestParseDurationEnv_Invalid(t *testing.T) {
+	t.Setenv("TEST_DUR", "xyz")
+	_, err := parseDurationEnv("TEST_DUR", 0)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseBoolEnv_Default(t *testing.T) {
+	t.Setenv("TEST_BOOL", "")
+	b, err := parseBoolEnv("TEST_BOOL", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !b {
+		t.Error("want true")
+	}
+}
+
+func TestParseBoolEnv_Set(t *testing.T) {
+	t.Setenv("TEST_BOOL", "false")
+	b, err := parseBoolEnv("TEST_BOOL", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b {
+		t.Error("want false")
+	}
+}
+
+func TestParseBoolEnv_Invalid(t *testing.T) {
+	t.Setenv("TEST_BOOL", "maybe")
+	_, err := parseBoolEnv("TEST_BOOL", false)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/cmd/argosd/main_test.go
+++ b/cmd/argosd/main_test.go
@@ -1,6 +1,12 @@
 package main
 
-import "testing"
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sthalbert/argos/internal/auth"
+)
 
 func TestLoadCollectorClustersJSONPrecedence(t *testing.T) {
 	// Having both ARGOS_COLLECTOR_CLUSTERS and the legacy single-cluster vars
@@ -110,5 +116,311 @@ func TestLoadCollectorClustersDuplicateName(t *testing.T) {
 
 	if _, err := loadCollectorClusters(); err == nil {
 		t.Fatal("expected error on duplicate cluster name")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// loadRunConfig
+// ---------------------------------------------------------------------------
+
+func setMinimalRunEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("ARGOS_DATABASE_URL", "postgres://argos:argos@localhost:5432/argos")
+	t.Setenv("ARGOS_API_TOKEN", "")
+	t.Setenv("ARGOS_API_TOKENS", "")
+	t.Setenv("ARGOS_SESSION_SECURE_COOKIE", "")
+	t.Setenv("ARGOS_SHUTDOWN_TIMEOUT", "")
+	t.Setenv("ARGOS_AUTO_MIGRATE", "")
+	t.Setenv("ARGOS_ADDR", "")
+	t.Setenv("ARGOS_OIDC_ISSUER", "")
+}
+
+func TestLoadRunConfig_Defaults(t *testing.T) {
+	setMinimalRunEnv(t)
+
+	cfg, err := loadRunConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.addr != ":8080" {
+		t.Errorf("addr: want :8080, got %q", cfg.addr)
+	}
+	if cfg.dsn != "postgres://argos:argos@localhost:5432/argos" {
+		t.Errorf("dsn: want the test DSN, got %q", cfg.dsn)
+	}
+	if cfg.cookiePolicy != auth.SecureAuto {
+		t.Errorf("cookiePolicy: want SecureAuto, got %d", cfg.cookiePolicy)
+	}
+	if cfg.shutdownTimeout != 15*time.Second {
+		t.Errorf("shutdownTimeout: want 15s, got %v", cfg.shutdownTimeout)
+	}
+	if !cfg.autoMigrate {
+		t.Error("autoMigrate: want true")
+	}
+}
+
+func TestLoadRunConfig_MissingDSN(t *testing.T) {
+	t.Setenv("ARGOS_DATABASE_URL", "")
+
+	_, err := loadRunConfig()
+	if !errors.Is(err, errDatabaseURLRequired) {
+		t.Errorf("want errDatabaseURLRequired, got %v", err)
+	}
+}
+
+func TestLoadRunConfig_LegacyTokenRejected(t *testing.T) {
+	setMinimalRunEnv(t)
+	t.Setenv("ARGOS_API_TOKEN", "old-token")
+
+	_, err := loadRunConfig()
+	if !errors.Is(err, errLegacyTokensUnsupported) {
+		t.Errorf("want errLegacyTokensUnsupported, got %v", err)
+	}
+}
+
+func TestLoadRunConfig_LegacyTokensRejected(t *testing.T) {
+	setMinimalRunEnv(t)
+	t.Setenv("ARGOS_API_TOKENS", "tok1,tok2")
+
+	_, err := loadRunConfig()
+	if !errors.Is(err, errLegacyTokensUnsupported) {
+		t.Errorf("want errLegacyTokensUnsupported, got %v", err)
+	}
+}
+
+func TestLoadRunConfig_CustomValues(t *testing.T) {
+	setMinimalRunEnv(t)
+	t.Setenv("ARGOS_ADDR", ":9090")
+	t.Setenv("ARGOS_SHUTDOWN_TIMEOUT", "30s")
+	t.Setenv("ARGOS_AUTO_MIGRATE", "false")
+	t.Setenv("ARGOS_SESSION_SECURE_COOKIE", "always")
+
+	cfg, err := loadRunConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.addr != ":9090" {
+		t.Errorf("addr: want :9090, got %q", cfg.addr)
+	}
+	if cfg.shutdownTimeout != 30*time.Second {
+		t.Errorf("shutdownTimeout: want 30s, got %v", cfg.shutdownTimeout)
+	}
+	if cfg.autoMigrate {
+		t.Error("autoMigrate: want false")
+	}
+	if cfg.cookiePolicy != auth.SecureAlways {
+		t.Errorf("cookiePolicy: want SecureAlways, got %d", cfg.cookiePolicy)
+	}
+}
+
+func TestLoadRunConfig_InvalidShutdownTimeout(t *testing.T) {
+	setMinimalRunEnv(t)
+	t.Setenv("ARGOS_SHUTDOWN_TIMEOUT", "nope")
+
+	_, err := loadRunConfig()
+	if err == nil {
+		t.Fatal("expected error for invalid shutdown timeout")
+	}
+}
+
+func TestLoadRunConfig_InvalidAutoMigrate(t *testing.T) {
+	setMinimalRunEnv(t)
+	t.Setenv("ARGOS_AUTO_MIGRATE", "nope")
+
+	_, err := loadRunConfig()
+	if err == nil {
+		t.Fatal("expected error for invalid auto_migrate")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseCookiePolicy
+// ---------------------------------------------------------------------------
+
+func TestParseCookiePolicy(t *testing.T) {
+	tests := []struct {
+		env  string
+		want auth.SecureCookiePolicy
+	}{
+		{"", auth.SecureAuto},
+		{"auto", auth.SecureAuto},
+		{"AUTO", auth.SecureAuto},
+		{"always", auth.SecureAlways},
+		{"true", auth.SecureAlways},
+		{"yes", auth.SecureAlways},
+		{"never", auth.SecureNever},
+		{"false", auth.SecureNever},
+		{"no", auth.SecureNever},
+	}
+	for _, tt := range tests {
+		t.Run(tt.env, func(t *testing.T) {
+			t.Setenv("ARGOS_SESSION_SECURE_COOKIE", tt.env)
+			got, err := parseCookiePolicy()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("want %d, got %d", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestParseCookiePolicy_Invalid(t *testing.T) {
+	t.Setenv("ARGOS_SESSION_SECURE_COOKIE", "maybe")
+	_, err := parseCookiePolicy()
+	if !errors.Is(err, errInvalidCookiePolicy) {
+		t.Errorf("want errInvalidCookiePolicy, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// loadOIDCConfig
+// ---------------------------------------------------------------------------
+
+func TestLoadOIDCConfig_Empty(t *testing.T) {
+	t.Setenv("ARGOS_OIDC_ISSUER", "")
+	cfg := loadOIDCConfig()
+	if cfg.Issuer != "" {
+		t.Errorf("want empty issuer, got %q", cfg.Issuer)
+	}
+}
+
+func TestLoadOIDCConfig_Full(t *testing.T) {
+	t.Setenv("ARGOS_OIDC_ISSUER", "https://idp.example.com")
+	t.Setenv("ARGOS_OIDC_CLIENT_ID", "argos")
+	t.Setenv("ARGOS_OIDC_CLIENT_SECRET", "s3cret")
+	t.Setenv("ARGOS_OIDC_REDIRECT_URL", "https://argos.example.com/v1/auth/oidc/callback")
+	t.Setenv("ARGOS_OIDC_SCOPES", "openid, email , profile")
+	t.Setenv("ARGOS_OIDC_LABEL", "Corp SSO")
+
+	cfg := loadOIDCConfig()
+	if cfg.Issuer != "https://idp.example.com" {
+		t.Errorf("issuer: got %q", cfg.Issuer)
+	}
+	if cfg.ClientID != "argos" {
+		t.Errorf("clientId: got %q", cfg.ClientID)
+	}
+	if cfg.ClientSecret != "s3cret" {
+		t.Errorf("clientSecret: got %q", cfg.ClientSecret)
+	}
+	if cfg.RedirectURL != "https://argos.example.com/v1/auth/oidc/callback" {
+		t.Errorf("redirectUrl: got %q", cfg.RedirectURL)
+	}
+	if len(cfg.Scopes) != 3 || cfg.Scopes[0] != "openid" || cfg.Scopes[1] != "email" || cfg.Scopes[2] != "profile" {
+		t.Errorf("scopes: got %v", cfg.Scopes)
+	}
+	if cfg.Label != "Corp SSO" {
+		t.Errorf("label: got %q", cfg.Label)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// loadCollectorEnvConfig
+// ---------------------------------------------------------------------------
+
+func TestLoadCollectorEnvConfig_Defaults(t *testing.T) {
+	t.Setenv("ARGOS_COLLECTOR_INTERVAL", "")
+	t.Setenv("ARGOS_COLLECTOR_FETCH_TIMEOUT", "")
+	t.Setenv("ARGOS_COLLECTOR_RECONCILE", "")
+
+	cfg, err := loadCollectorEnvConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.interval != 5*time.Minute {
+		t.Errorf("interval: want 5m, got %v", cfg.interval)
+	}
+	if cfg.fetchTimeout != 10*time.Second {
+		t.Errorf("fetchTimeout: want 10s, got %v", cfg.fetchTimeout)
+	}
+	if !cfg.reconcile {
+		t.Error("reconcile: want true")
+	}
+}
+
+func TestLoadCollectorEnvConfig_Custom(t *testing.T) {
+	t.Setenv("ARGOS_COLLECTOR_INTERVAL", "30s")
+	t.Setenv("ARGOS_COLLECTOR_FETCH_TIMEOUT", "1m")
+	t.Setenv("ARGOS_COLLECTOR_RECONCILE", "false")
+
+	cfg, err := loadCollectorEnvConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.interval != 30*time.Second {
+		t.Errorf("interval: want 30s, got %v", cfg.interval)
+	}
+	if cfg.fetchTimeout != 1*time.Minute {
+		t.Errorf("fetchTimeout: want 1m, got %v", cfg.fetchTimeout)
+	}
+	if cfg.reconcile {
+		t.Error("reconcile: want false")
+	}
+}
+
+func TestLoadCollectorEnvConfig_InvalidInterval(t *testing.T) {
+	t.Setenv("ARGOS_COLLECTOR_INTERVAL", "bad")
+	t.Setenv("ARGOS_COLLECTOR_FETCH_TIMEOUT", "")
+	t.Setenv("ARGOS_COLLECTOR_RECONCILE", "")
+
+	_, err := loadCollectorEnvConfig()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// envOr / parseDurationEnv / parseBoolEnv
+// ---------------------------------------------------------------------------
+
+func TestEnvOr(t *testing.T) {
+	t.Setenv("TEST_KEY", "")
+	if got := envOr("TEST_KEY", "fallback"); got != "fallback" {
+		t.Errorf("want fallback, got %q", got)
+	}
+	t.Setenv("TEST_KEY", "value")
+	if got := envOr("TEST_KEY", "fallback"); got != "value" {
+		t.Errorf("want value, got %q", got)
+	}
+}
+
+func TestParseDurationEnv(t *testing.T) {
+	t.Setenv("D", "")
+	d, err := parseDurationEnv("D", 42*time.Second)
+	if err != nil || d != 42*time.Second {
+		t.Errorf("default: want 42s, got %v (err=%v)", d, err)
+	}
+
+	t.Setenv("D", "10m")
+	d, err = parseDurationEnv("D", 0)
+	if err != nil || d != 10*time.Minute {
+		t.Errorf("set: want 10m, got %v (err=%v)", d, err)
+	}
+
+	t.Setenv("D", "xyz")
+	_, err = parseDurationEnv("D", 0)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseBoolEnv(t *testing.T) {
+	t.Setenv("B", "")
+	b, err := parseBoolEnv("B", true)
+	if err != nil || !b {
+		t.Errorf("default: want true, got %v (err=%v)", b, err)
+	}
+
+	t.Setenv("B", "false")
+	b, err = parseBoolEnv("B", true)
+	if err != nil || b {
+		t.Errorf("set: want false, got %v (err=%v)", b, err)
+	}
+
+	t.Setenv("B", "nope")
+	_, err = parseBoolEnv("B", false)
+	if err == nil {
+		t.Fatal("expected error")
 	}
 }


### PR DESCRIPTION
Helm chart under charts/argos/ for deploying argosd on Kubernetes.

Features:
- Bitnami PostgreSQL as a conditional dependency (postgresql.enabled)
- External database support (externalDatabase.url) when PG is disabled
- All argosd configuration exposed via values.yaml
- Optional OIDC federation block
- Optional pull-mode collector (single or multi-cluster)
- RBAC (ClusterRole with read-only list on K8s resources)
- Ingress resource (optional)
- ServiceMonitor for Prometheus Operator (optional)
- Distroless nonroot security context
- Secret checksum annotation for rolling restarts on config change
- Post-install NOTES.txt with first-steps guide

Usage:
  helm dependency update charts/argos helm install argos charts/argos -n argos-system --create-namespace helm install argos charts/argos --set postgresql.enabled=false \ --set externalDatabase.url="postgres://..."