### PR TITLE
ci: publish container images to GHCR on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  images:
+    name: Build and push container images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - image: argos
+            dockerfile: Dockerfile
+          - image: argos-collector
+            dockerfile: Dockerfile.collector
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU (multi-arch)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,scope=${{ matrix.image }},mode=max
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -25,7 +25,7 @@ The Secret is intentionally out of the Kustomization so the example file can't b
 
 ## Image
 
-The [`Dockerfile`](../Dockerfile) builds a distroless static image. It's **not yet published to a registry** — a future PR wires GHCR publish into CI. Until then, for a first smoke test on a local cluster:
+The [`Dockerfile`](../Dockerfile) builds a distroless static image. Pre-built images are published to `ghcr.io/sthalbert/argos` (and `ghcr.io/sthalbert/argos-collector`) on every tagged release. To build locally for a smoke test:
 
 ```sh
 # 1. Build locally.

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -6,7 +6,7 @@ This guide deploys argosd into a Kubernetes cluster using the reference Kustomiz
 
 - A Kubernetes cluster (kind, minikube, or a production cluster).
 - A PostgreSQL 14+ instance reachable from the cluster. The argosd pod needs `CREATE` privileges on the target database for goose migrations.
-- A container image. The image is not yet published to a registry -- see [Build the image](#build-the-image) below.
+- A container image. Pre-built images are published to `ghcr.io/sthalbert/argos` on every release. To build your own, see [Build the image](#build-the-image) below.
 - `kubectl` configured to talk to the cluster.
 
 ## Files overview


### PR DESCRIPTION
New workflow .github/workflows/release.yml triggers on semver tags (v*) and builds + pushes both images to GitHub Container Registry:

- ghcr.io/sthalbert/argos (argosd)
- ghcr.io/sthalbert/argos-collector (push collector)

Features:
- Multi-arch builds (linux/amd64 + linux/arm64)
- Semantic version tags (v0.3.0 → 0.3.0, 0.3, 0, latest)
- GHA cache for fast rebuilds
- Build matrix (one job per image, parallel)

Also updates docs and deploy/README.md to reflect that images are now published (no longer "not yet published").