### PR TITLE
fix(helm): pin PostgreSQL image tag to avoid stale Bitnami tags

### DIFF
--- a/charts/argos/values.yaml
+++ b/charts/argos/values.yaml
@@ -64,6 +64,10 @@ oidc:
 # Set enabled=false and provide externalDatabase.url to use your own PG.
 postgresql:
   enabled: true
+  image:
+    # -- Pin to a stable tag. The subchart default may reference a tag
+    # that has been removed from Docker Hub (Bitnami rotates tags frequently).
+    tag: "17"
   auth:
     username: argos
     password: argos


### PR DESCRIPTION
The Bitnami subchart's default image tag (e.g. 17.6.0-debian-12-r4) is frequently removed from Docker Hub, causing ImagePullBackOff on fresh installs. Pin to the stable 'postgresql:17' tag.