### PR TITLE
feat: collector auto-creates cluster on first contact

### DIFF
--- a/internal/collector/apiclient/client.go
+++ b/internal/collector/apiclient/client.go
@@ -127,6 +127,17 @@ func buildTransport(cfg *Config) (*http.Transport, error) {
 
 // ── collector.CmdbStore implementation ──────────────────────────────
 
+// CreateCluster registers a new cluster in the CMDB.
+//
+//nolint:gocritic // hugeParam: signature matches CmdbStore interface
+func (s *Store) CreateCluster(ctx context.Context, in api.ClusterCreate) (api.Cluster, error) {
+	var out api.Cluster
+	if err := s.doJSON(ctx, http.MethodPost, "/v1/clusters", in, &out); err != nil {
+		return api.Cluster{}, fmt.Errorf("create cluster: %w", err)
+	}
+	return out, nil
+}
+
 // GetClusterByName retrieves a cluster by its unique name.
 func (s *Store) GetClusterByName(ctx context.Context, name string) (api.Cluster, error) {
 	path := "/v1/clusters?name=" + url.QueryEscape(name) + "&limit=1"

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -246,6 +246,7 @@ type KubeSource interface {
 // CmdbStore is the subset of api.Store the collector consumes. Exported so
 // the apiclient package (push-mode HTTP store) can implement it.
 type CmdbStore interface {
+	CreateCluster(ctx context.Context, in api.ClusterCreate) (api.Cluster, error)
 	GetClusterByName(ctx context.Context, name string) (api.Cluster, error)
 	UpdateCluster(ctx context.Context, id uuid.UUID, in api.ClusterUpdate) (api.Cluster, error)
 	UpsertNode(ctx context.Context, in api.NodeCreate) (api.Node, error)
@@ -331,13 +332,22 @@ func (c *Collector) poll(parent context.Context) {
 
 	cluster, err := c.store.GetClusterByName(ctx, c.clusterName)
 	if err != nil {
-		metrics.ObserveError(c.clusterName, "cluster", "lookup")
 		if errors.Is(err, api.ErrNotFound) {
-			slog.Warn("collector: cluster not registered; POST /v1/clusters first", slog.String("cluster_name", c.clusterName))
+			// Auto-create the cluster on first contact.
+			cluster, err = c.store.CreateCluster(ctx, api.ClusterCreate{Name: c.clusterName})
+			if err != nil {
+				metrics.ObserveError(c.clusterName, "cluster", "create")
+				slog.Error("collector: auto-create cluster failed",
+					slog.Any("error", err), slog.String("cluster_name", c.clusterName))
+				return
+			}
+			slog.Info("collector: auto-created cluster", slog.String("cluster_name", c.clusterName))
+		} else {
+			metrics.ObserveError(c.clusterName, "cluster", "lookup")
+			slog.Error("collector: lookup cluster failed",
+				slog.Any("error", err), slog.String("cluster_name", c.clusterName))
 			return
 		}
-		slog.Error("collector: lookup cluster failed", slog.Any("error", err), slog.String("cluster_name", c.clusterName))
-		return
 	}
 	if cluster.Id == nil {
 		slog.Error("collector: stored cluster has nil id", slog.String("cluster_name", c.clusterName))

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -165,6 +165,16 @@ func newFakeStore() *fakeStore {
 	}
 }
 
+//nolint:gocritic // hugeParam: signature matches CmdbStore interface
+func (s *fakeStore) CreateCluster(_ context.Context, in api.ClusterCreate) (api.Cluster, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := uuid.New()
+	c := api.Cluster{Id: &id, Name: in.Name}
+	s.clusters = append(s.clusters, c)
+	return c, nil
+}
+
 func (s *fakeStore) GetClusterByName(_ context.Context, name string) (api.Cluster, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -628,15 +638,16 @@ func TestPollSkipsOnGetClusterByNameError(t *testing.T) {
 	}
 }
 
-func TestPollSkipsWhenClusterNotRegistered(t *testing.T) {
+func TestPollAutoCreatesClusterWhenMissing(t *testing.T) {
 	t.Parallel()
 	store := newFakeStore()
 	c := New(store, &fakeSource{version: "v1.29.5"}, "missing", time.Minute, time.Second, true)
 
 	c.poll(context.Background())
 
-	if len(store.updates) != 0 || len(store.upsertedNode) != 0 {
-		t.Errorf("expected no store writes when cluster missing")
+	// The cluster should have been auto-created.
+	if len(store.clusters) != 1 || store.clusters[0].Name != "missing" {
+		t.Errorf("expected cluster 'missing' to be auto-created, got %+v", store.clusters)
 	}
 }
 


### PR DESCRIPTION
When the collector polls and the cluster is not yet registered in the CMDB, it now creates it automatically instead of logging a warning and skipping the tick. This removes the manual prerequisite of calling POST /v1/clusters before starting the collector.

- Add CreateCluster to CmdbStore interface
- Implement CreateCluster in apiclient HTTP store
- Auto-create on ErrNotFound in collector.poll()
- Update test: TestPollAutoCreatesClusterWhenMissing