### PR TITLE
fix(chart): remove ARGOS_KUBECONFIG env var, add kubeconfigSecret vol…

### DIFF
--- a/charts/argos/templates/deployment.yaml
+++ b/charts/argos/templates/deployment.yaml
@@ -66,8 +66,6 @@ spec:
             {{- else }}
             - name: ARGOS_CLUSTER_NAME
               value: {{ .Values.collector.clusterName | quote }}
-            - name: ARGOS_KUBECONFIG
-              value: {{ .Values.collector.kubeconfig | quote }}
             {{- end }}
             {{- end }}
           envFrom:
@@ -93,6 +91,18 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- if .Values.collector.kubeconfigSecret }}
+          volumeMounts:
+            - name: kubeconfigs
+              mountPath: /etc/argos/kubeconfigs
+              readOnly: true
+          {{- end }}
+      {{- if .Values.collector.kubeconfigSecret }}
+      volumes:
+        - name: kubeconfigs
+          secret:
+            secretName: {{ .Values.collector.kubeconfigSecret }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/argos/values.yaml
+++ b/charts/argos/values.yaml
@@ -31,8 +31,6 @@ collector:
   enabled: false
   # -- Single-cluster name (ignored when clusters is non-empty).
   clusterName: "in-cluster"
-  # -- Path to kubeconfig. Empty = in-cluster ServiceAccount.
-  kubeconfig: ""
   # -- Multi-cluster list. Each entry: {name: "x", kubeconfig: "/path"}.
   # An empty kubeconfig uses the pod's in-cluster credentials.
   clusters: []
@@ -42,6 +40,10 @@ collector:
   fetchTimeout: "10s"
   # -- Delete rows that vanish from the live listing.
   reconcile: true
+  # -- Name of an existing Secret containing kubeconfig files.
+  # Each key in the Secret is mounted as a file under /etc/argos/kubeconfigs/.
+  # Reference the mounted path in kubeconfig or clusters[].kubeconfig.
+  kubeconfigSecret: ""
 
 # -- OIDC federation (optional).
 oidc:


### PR DESCRIPTION
…ume mount

Kubeconfig paths must not appear as env vars in the pod spec — they are readable by anyone with pod-get RBAC. Replace the single-cluster ARGOS_KUBECONFIG env var with the kubeconfigSecret volume mount pattern that keeps credentials off the pod spec entirely.