### PR TITLE
chore: bump Helm chart version to 0.6.0

### DIFF
--- a/charts/argos/Chart.yaml
+++ b/charts/argos/Chart.yaml
@@ -4,7 +4,7 @@ description: >-
   A CMDB for Kubernetes environments aligned with the ANSSI SecNumCloud
   qualification framework. Polls clusters and exposes a REST API and web UI.
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: "0.4.0"
 home: https://github.com/sthalbert/Argos
 sources:

--- a/charts/argos/templates/postgresql.yaml
+++ b/charts/argos/templates/postgresql.yaml
@@ -59,7 +59,10 @@ spec:
             - name: POSTGRES_USER
               value: {{ .Values.postgresql.auth.username | quote }}
             - name: POSTGRES_PASSWORD
-              value: {{ .Values.postgresql.auth.password | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "argos.secretName" . }}
+                  key: POSTGRES_PASSWORD
             - name: POSTGRES_DB
               value: {{ .Values.postgresql.auth.database | quote }}
             - name: PGDATA

--- a/charts/argos/templates/secret.yaml
+++ b/charts/argos/templates/secret.yaml
@@ -9,6 +9,9 @@ metadata:
 type: Opaque
 stringData:
   ARGOS_DATABASE_URL: {{ include "argos.databaseUrl" . | quote }}
+  {{- if .Values.postgresql.enabled }}
+  POSTGRES_PASSWORD: {{ .Values.postgresql.auth.password | quote }}
+  {{- end }}
   {{- if .Values.argosd.bootstrapAdminPassword }}
   ARGOS_BOOTSTRAP_ADMIN_PASSWORD: {{ .Values.argosd.bootstrapAdminPassword | quote }}
   {{- end }}

--- a/internal/api/runbook_url_test.go
+++ b/internal/api/runbook_url_test.go
@@ -1,0 +1,225 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestRunbookURLValidation verifies that the server rejects runbook_url
+// values with non-HTTP schemes (e.g. javascript:, data:) and accepts
+// valid http/https URLs across all create and update endpoints for
+// clusters, namespaces, and nodes.
+func TestRunbookURLValidation(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		url    string
+		reject bool
+	}{
+		{"https", "https://runbooks.example.com/prod", false},
+		{"http", "http://runbooks.internal/page", false},
+		{"empty string", "", false},
+		{"javascript scheme", "javascript:alert(document.cookie)", true},
+		{"data scheme", "data:text/html,<script>alert(1)</script>", true},
+		{"ftp scheme", "ftp://files.example.com/runbook.pdf", true},
+		{"no scheme", "runbooks.example.com/prod", true},
+	}
+
+	t.Run("CreateCluster", func(t *testing.T) {
+		t.Parallel()
+		for i, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				h := newTestHandler(t, newMemStore())
+				body := fmt.Sprintf(`{"name":"c-%d","runbook_url":%q}`, i, tc.url)
+				if tc.url == "" {
+					body = fmt.Sprintf(`{"name":"c-%d"}`, i)
+				}
+				rr := do(h, http.MethodPost, "/v1/clusters", body)
+				assertRunbookStatus(t, rr, tc.reject, http.StatusCreated)
+			})
+		}
+	})
+
+	t.Run("UpdateCluster", func(t *testing.T) {
+		t.Parallel()
+		for i, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				h := newTestHandler(t, newMemStore())
+
+				id := seedCluster(t, h, fmt.Sprintf("uc-%d", i))
+				patch := fmt.Sprintf(`{"runbook_url":%q}`, tc.url)
+				rr := do(h, http.MethodPatch, "/v1/clusters/"+id, patch)
+				assertRunbookStatus(t, rr, tc.reject, http.StatusOK)
+			})
+		}
+	})
+
+	t.Run("CreateNamespace", func(t *testing.T) {
+		t.Parallel()
+		for i, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				h := newTestHandler(t, newMemStore())
+
+				clusterID := seedCluster(t, h, fmt.Sprintf("cn-cl-%d", i))
+				body := fmt.Sprintf(`{"name":"ns-%d","cluster_id":%q,"runbook_url":%q}`, i, clusterID, tc.url)
+				if tc.url == "" {
+					body = fmt.Sprintf(`{"name":"ns-%d","cluster_id":%q}`, i, clusterID)
+				}
+				rr := do(h, http.MethodPost, "/v1/namespaces", body)
+				assertRunbookStatus(t, rr, tc.reject, http.StatusCreated)
+			})
+		}
+	})
+
+	t.Run("UpdateNamespace", func(t *testing.T) {
+		t.Parallel()
+		for i, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				h := newTestHandler(t, newMemStore())
+
+				clusterID := seedCluster(t, h, fmt.Sprintf("un-cl-%d", i))
+				nsID := seedNamespace(t, h, clusterID, fmt.Sprintf("uns-%d", i))
+				patch := fmt.Sprintf(`{"runbook_url":%q}`, tc.url)
+				rr := do(h, http.MethodPatch, "/v1/namespaces/"+nsID, patch)
+				assertRunbookStatus(t, rr, tc.reject, http.StatusOK)
+			})
+		}
+	})
+
+	t.Run("CreateNode", func(t *testing.T) {
+		t.Parallel()
+		for i, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				h := newTestHandler(t, newMemStore())
+
+				clusterID := seedCluster(t, h, fmt.Sprintf("cno-cl-%d", i))
+				body := fmt.Sprintf(`{"name":"node-%d","cluster_id":%q,"runbook_url":%q}`, i, clusterID, tc.url)
+				if tc.url == "" {
+					body = fmt.Sprintf(`{"name":"node-%d","cluster_id":%q}`, i, clusterID)
+				}
+				rr := do(h, http.MethodPost, "/v1/nodes", body)
+				assertRunbookStatus(t, rr, tc.reject, http.StatusCreated)
+			})
+		}
+	})
+
+	t.Run("UpdateNode", func(t *testing.T) {
+		t.Parallel()
+		for i, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				h := newTestHandler(t, newMemStore())
+
+				clusterID := seedCluster(t, h, fmt.Sprintf("uno-cl-%d", i))
+				nodeID := seedNode(t, h, clusterID, fmt.Sprintf("unode-%d", i))
+				patch := fmt.Sprintf(`{"runbook_url":%q}`, tc.url)
+				rr := do(h, http.MethodPatch, "/v1/nodes/"+nodeID, patch)
+				assertRunbookStatus(t, rr, tc.reject, http.StatusOK)
+			})
+		}
+	})
+}
+
+// TestValidateRunbookURL is a unit test for the validation function itself.
+func TestValidateRunbookURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		input   *string
+		wantErr bool
+	}{
+		{"nil pointer", nil, false},
+		{"empty string", ptr(""), false},
+		{"https url", ptr("https://example.com/runbook"), false},
+		{"http url", ptr("http://internal.corp/page"), false},
+		{"javascript", ptr("javascript:alert(1)"), true},
+		{"data uri", ptr("data:text/html,<h1>hi</h1>"), true},
+		{"ftp", ptr("ftp://example.com/file"), true},
+		{"mailto", ptr("mailto:admin@example.com"), true},
+		{"bare path", ptr("runbooks.example.com/prod"), true},
+		{"HTTPS uppercase", ptr("HTTPS://EXAMPLE.COM"), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateRunbookURL(tc.input)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error for %v, got nil", tc.input)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error for %v: %v", tc.input, err)
+			}
+		})
+	}
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func ptr(s string) *string { return &s }
+
+func seedCluster(t *testing.T, h http.Handler, name string) string {
+	t.Helper()
+	rr := do(h, http.MethodPost, "/v1/clusters", fmt.Sprintf(`{"name":%q}`, name))
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed cluster %q: status=%d body=%q", name, rr.Code, rr.Body.String())
+	}
+	var c Cluster
+	if err := json.Unmarshal(rr.Body.Bytes(), &c); err != nil {
+		t.Fatalf("decode cluster: %v", err)
+	}
+	return c.Id.String()
+}
+
+func seedNamespace(t *testing.T, h http.Handler, clusterID, name string) string {
+	t.Helper()
+	body := fmt.Sprintf(`{"name":%q,"cluster_id":%q}`, name, clusterID)
+	rr := do(h, http.MethodPost, "/v1/namespaces", body)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed namespace %q: status=%d body=%q", name, rr.Code, rr.Body.String())
+	}
+	var ns Namespace
+	if err := json.Unmarshal(rr.Body.Bytes(), &ns); err != nil {
+		t.Fatalf("decode namespace: %v", err)
+	}
+	return ns.Id.String()
+}
+
+func seedNode(t *testing.T, h http.Handler, clusterID, name string) string {
+	t.Helper()
+	body := fmt.Sprintf(`{"name":%q,"cluster_id":%q}`, name, clusterID)
+	rr := do(h, http.MethodPost, "/v1/nodes", body)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed node %q: status=%d body=%q", name, rr.Code, rr.Body.String())
+	}
+	var n Node
+	if err := json.Unmarshal(rr.Body.Bytes(), &n); err != nil {
+		t.Fatalf("decode node: %v", err)
+	}
+	return n.Id.String()
+}
+
+func assertRunbookStatus(t *testing.T, rr *httptest.ResponseRecorder, reject bool, successCode int) {
+	t.Helper()
+	if reject {
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d body=%q", rr.Code, rr.Body.String())
+		}
+		if !strings.Contains(rr.Body.String(), "runbook_url") {
+			t.Errorf("error body should mention runbook_url: %s", rr.Body.String())
+		}
+	} else if rr.Code != successCode {
+		t.Errorf("expected %d, got %d body=%q", successCode, rr.Code, rr.Body.String())
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -5,11 +5,36 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
+	"strings"
 
 	"github.com/google/uuid"
 
 	"github.com/sthalbert/argos/internal/auth"
 )
+
+var (
+	errRunbookURLInvalid = errors.New("runbook_url is not a valid URL")
+	errRunbookURLScheme  = errors.New("runbook_url must use http or https scheme")
+)
+
+// validateRunbookURL rejects runbook URLs that use a scheme other than
+// http or https. This prevents javascript: and data: XSS vectors when
+// the URL is rendered as an <a href> in the UI.
+func validateRunbookURL(raw *string) error {
+	if raw == nil || *raw == "" {
+		return nil
+	}
+	u, err := url.Parse(*raw)
+	if err != nil {
+		return errRunbookURLInvalid
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return errRunbookURLScheme
+	}
+	return nil
+}
 
 // Server implements StrictServerInterface for the Argos REST API.
 type Server struct {
@@ -129,6 +154,11 @@ func (s *Server) CreateCluster(ctx context.Context, req CreateClusterRequestObje
 			BadRequestApplicationProblemPlusJSONResponse(problemBadRequest("Missing field", "field 'name' is required")),
 		}, nil
 	}
+	if err := validateRunbookURL(body.RunbookUrl); err != nil {
+		return CreateCluster400ApplicationProblemPlusJSONResponse{
+			BadRequestApplicationProblemPlusJSONResponse(problemBadRequest("Invalid field", err.Error())),
+		}, nil
+	}
 
 	c, err := s.store.CreateCluster(ctx, body)
 	if err != nil {
@@ -167,6 +197,11 @@ func (s *Server) GetCluster(ctx context.Context, req GetClusterRequestObject) (G
 
 // UpdateCluster applies merge-patch updates to a cluster.
 func (s *Server) UpdateCluster(ctx context.Context, req UpdateClusterRequestObject) (UpdateClusterResponseObject, error) {
+	if err := validateRunbookURL(req.Body.RunbookUrl); err != nil {
+		return UpdateCluster400ApplicationProblemPlusJSONResponse{
+			BadRequestApplicationProblemPlusJSONResponse(problemBadRequest("Invalid field", err.Error())),
+		}, nil
+	}
 	c, err := s.store.UpdateCluster(ctx, req.Id, *req.Body)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
@@ -233,6 +268,11 @@ func (s *Server) CreateNode(ctx context.Context, req CreateNodeRequestObject) (C
 			BadRequestApplicationProblemPlusJSONResponse(problemBadRequest("Missing field", "field 'cluster_id' is required")),
 		}, nil
 	}
+	if err := validateRunbookURL(body.RunbookUrl); err != nil {
+		return CreateNode400ApplicationProblemPlusJSONResponse{
+			BadRequestApplicationProblemPlusJSONResponse(problemBadRequest("Invalid field", err.Error())),
+		}, nil
+	}
 
 	n, err := s.store.UpsertNode(ctx, body)
 	if err != nil {
@@ -276,6 +316,11 @@ func (s *Server) GetNode(ctx context.Context, req GetNodeRequestObject) (GetNode
 
 // UpdateNode applies merge-patch updates to a node.
 func (s *Server) UpdateNode(ctx context.Context, req UpdateNodeRequestObject) (UpdateNodeResponseObject, error) {
+	if err := validateRunbookURL(req.Body.RunbookUrl); err != nil {
+		return UpdateNode400ApplicationProblemPlusJSONResponse{
+			BadRequestApplicationProblemPlusJSONResponse(problemBadRequest("Invalid field", err.Error())),
+		}, nil
+	}
 	n, err := s.store.UpdateNode(ctx, req.Id, *req.Body)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
@@ -342,6 +387,11 @@ func (s *Server) CreateNamespace(ctx context.Context, req CreateNamespaceRequest
 			BadRequestApplicationProblemPlusJSONResponse(problemBadRequest("Missing field", "field 'cluster_id' is required")),
 		}, nil
 	}
+	if err := validateRunbookURL(body.RunbookUrl); err != nil {
+		return CreateNamespace400ApplicationProblemPlusJSONResponse{
+			BadRequestApplicationProblemPlusJSONResponse(problemBadRequest("Invalid field", err.Error())),
+		}, nil
+	}
 
 	n, err := s.store.UpsertNamespace(ctx, body)
 	if err != nil {
@@ -385,6 +435,11 @@ func (s *Server) GetNamespace(ctx context.Context, req GetNamespaceRequestObject
 
 // UpdateNamespace applies merge-patch updates.
 func (s *Server) UpdateNamespace(ctx context.Context, req UpdateNamespaceRequestObject) (UpdateNamespaceResponseObject, error) {
+	if err := validateRunbookURL(req.Body.RunbookUrl); err != nil {
+		return UpdateNamespace400ApplicationProblemPlusJSONResponse{
+			BadRequestApplicationProblemPlusJSONResponse(problemBadRequest("Invalid field", err.Error())),
+		}, nil
+	}
 	n, err := s.store.UpdateNamespace(ctx, req.Id, *req.Body)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {


### PR DESCRIPTION
BREAKING: collector.kubeconfig value removed in 0.5.0. Use collector.kubeconfigSecret to mount kubeconfig files from a Kubernetes Secret instead.