### PR TITLE
chore: bump Helm chart appVersion to 0.4.1

### DIFF
--- a/charts/argos/Chart.yaml
+++ b/charts/argos/Chart.yaml
@@ -5,7 +5,7 @@ description: >-
   qualification framework. Polls clusters and exposes a REST API and web UI.
 type: application
 version: 0.6.0
-appVersion: "0.4.0"
+appVersion: "0.4.1"
 home: https://github.com/sthalbert/Argos
 sources:
   - https://github.com/sthalbert/Argos


### PR DESCRIPTION
Aligns the chart's appVersion with the v0.4.1 security patch release (PG credential exposure fix + runbook_url XSS fix).