### PR TITLE
feat(api,ui): admin-only cluster deletion with enriched audit trail (…

### DIFF
--- a/docs/adr/adr-0010-admin-only-cluster-deletion-with-audit.md
+++ b/docs/adr/adr-0010-admin-only-cluster-deletion-with-audit.md
@@ -1,0 +1,133 @@
+---
+title: "ADR-0010: Admin-only cluster deletion with mandatory audit trail"
+status: "Proposed"
+date: "2026-04-23"
+authors: "Steve ALBERT"
+tags: ["architecture", "decision", "security", "rbac", "audit", "deletion"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0010: Admin-only cluster deletion with mandatory audit trail
+
+## Status
+
+**Proposed** | Accepted | Rejected | Superseded | Deprecated
+
+## Context
+
+Deleting a cluster is the single most destructive operation in Argos. The `clusters` table sits at the root of the FK tree; a `DELETE FROM clusters WHERE id = $1` cascades through every child table — namespaces, nodes, persistent volumes, and transitively all pods, workloads, services, ingresses, and PVCs belonging to those namespaces. A single API call can erase the entire inventory of a production cluster from the CMDB.
+
+Today the `DELETE /v1/clusters/{id}` endpoint is gated on the `delete` scope, which per ADR-0007 is granted exclusively to the `admin` role. That satisfies the "only admins can do it" requirement at the scope level. However, two gaps remain:
+
+1. **No explicit confirmation safeguard.** A single `DELETE` call — whether from the UI, a script, or an accidental `curl` — immediately drops the cluster and all its children. There is no "are you sure?" at the API level and no soft-delete window.
+2. **Audit coverage is implicit.** The `AuditMiddleware` already captures every non-GET request including `DELETE /v1/clusters/{id}`, recording the actor, timestamp, HTTP method/path, response status, and scrubbed body. But the audit record does not capture _what_ was lost — no count of cascaded children, no cluster name snapshot. If the cluster row is gone, the audit event's `resource_id` (a UUID) becomes an opaque string with no human context.
+
+ANSSI SecNumCloud chapter 8 (asset management) requires that the CMDB maintain an accurate, auditable inventory. Deleting an entire cluster's worth of assets is a significant event that must be traceable to a named human actor with enough context to answer "what happened and what was lost."
+
+## Decision
+
+Restrict cluster deletion to the `admin` role and enrich the audit trail so every cluster deletion is fully traceable. Specifically:
+
+### 1. Scope stays `delete` — admin-only by role mapping
+
+The existing `security: - BearerAuth: [delete]` declaration on `DELETE /v1/clusters/{id}` is correct. Only the `admin` role carries the `delete` scope (ADR-0007). No other role — `editor`, `auditor`, `viewer` — can invoke this endpoint. Machine tokens (`api_tokens`) can only carry `read`, `write`, or `delete` scopes; in practice, issuing a token with `delete` is an admin decision made in the admin UI.
+
+This decision explicitly **does not** elevate the scope to `admin`; that would break symmetry with the other `DELETE` endpoints (nodes, pods, etc.) without adding real security, since `delete` is already admin-exclusive.
+
+### 2. Enriched audit event for cluster deletion
+
+The `AuditMiddleware` will enrich the `details` JSONB payload for `cluster.delete` events with a **pre-deletion snapshot**:
+
+```json
+{
+  "cluster_name": "prod-eu-west-1",
+  "cluster_display_name": "Production EU West",
+  "cluster_environment": "production",
+  "cluster_owner": "platform-team",
+  "cluster_criticality": "critical",
+  "cascade_counts": {
+    "namespaces": 12,
+    "nodes": 8,
+    "pods": 347,
+    "workloads": 42,
+    "services": 28,
+    "ingresses": 15,
+    "persistent_volumes": 6,
+    "persistent_volume_claims": 9
+  }
+}
+```
+
+This snapshot is captured **before** the `DELETE` executes so the data is still available to query. If the handler returns a non-2xx status (e.g., 404 — cluster not found), the snapshot is omitted and the audit event records only the failed attempt.
+
+### 3. Database-level cascade remains the deletion mechanism
+
+The FK chain (`clusters → namespaces/nodes/PVs → pods/workloads/services/ingresses/PVCs`) with `ON DELETE CASCADE` is the correct mechanism. No application-level loop deleting children one-by-one — that would be slower, race-prone, and add no value since the DB enforces referential integrity atomically.
+
+### 4. No soft-delete (v1)
+
+Soft-delete (a `deleted_at` column with a grace period) was considered and rejected for v1. The collector's reconciliation loop would immediately conflict: it would try to re-create a "soft-deleted" cluster on the next poll tick, or the reconciler would need to learn about soft-delete semantics. The complexity is not justified at current scale. The enriched audit snapshot provides the "what was lost" answer without keeping zombie rows.
+
+### 5. UI confirmation gate
+
+The UI must present a confirmation dialog before calling `DELETE /v1/clusters/{id}`. The dialog shows the cluster name, environment, owner, and cascade counts (fetched via existing endpoints) and requires the user to type the cluster name to confirm. This is a UI-only safeguard — the API itself does not enforce a confirmation token, keeping it simple for automation that genuinely needs to delete clusters.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Cluster deletion is restricted to the `admin` role by construction (ADR-0007 scope mapping). No configuration needed, no way to bypass without changing the role.
+- **POS-002**: Every cluster deletion is traceable to a named human (or a named API token created by a named human) with full context — cluster identity, ownership, and a count of cascaded assets.
+- **POS-003**: The enriched audit event satisfies ANSSI SecNumCloud chapter 8 traceability requirements: auditors can answer "who deleted what, when, and how much was lost" without the cluster row existing.
+- **POS-004**: UI confirmation gate with name-typing prevents accidental deletions — the most common destructive mistake.
+- **POS-005**: No schema changes required for the deletion path itself; the `ON DELETE CASCADE` FKs already handle child cleanup.
+
+### Negative
+
+- **NEG-001**: The pre-deletion snapshot requires counting children across multiple tables before the DELETE executes. For very large clusters (thousands of pods), the count queries add latency to the delete call. Acceptable for a rare, admin-only operation.
+- **NEG-002**: No undo. Once deleted, recovery requires re-collecting the cluster (re-add it to `ARGOS_COLLECTOR_CLUSTERS` and wait for the next poll tick). Curated metadata (owner, criticality, notes, runbook_url, annotations) is permanently lost.
+- **NEG-003**: UI confirmation is bypassable via direct API call. This is by design (automation use-case), but means a mistyped `curl` from an admin can still drop a cluster.
+
+### Neutral
+
+- **NEU-001**: Other `DELETE` endpoints (nodes, namespaces, pods, etc.) are unchanged. They carry the same `delete` scope and are logged by the same audit middleware, but without the enriched cascade snapshot (their blast radius is smaller).
+
+## Alternatives Considered
+
+### Elevate cluster deletion to `admin` scope
+
+- **ALT-001**: **Description**: Change `DELETE /v1/clusters/{id}` from `BearerAuth: [delete]` to `BearerAuth: [admin]`, preventing machine tokens from ever deleting clusters.
+- **ALT-002**: **Rejection Reason**: The `delete` scope is already admin-exclusive. Switching to `admin` scope would break the scope model's symmetry and create a confusing precedent (some DELETEs need `delete`, one needs `admin`). If a future role needs `delete` without `admin`, that's a future ADR's problem.
+
+### Soft-delete with grace period
+
+- **ALT-003**: **Description**: Set `deleted_at` instead of hard-deleting. A background job purges after 7 days. Admin can "undelete" within the window.
+- **ALT-004**: **Rejection Reason**: Conflicts with the collector's reconciliation loop, which would re-create or re-poll the cluster. Every query would need `WHERE deleted_at IS NULL` guards. Complexity not justified at current scale; the enriched audit snapshot provides the forensic value without the operational cost.
+
+### Require a confirmation token from the API
+
+- **ALT-005**: **Description**: `DELETE /v1/clusters/{id}` returns a `409 Conflict` with a one-time confirmation token; the caller must retry with `X-Confirm: <token>` within 60 seconds.
+- **ALT-006**: **Rejection Reason**: Adds API complexity for a dubious gain — scripts that auto-delete would just blindly retry with the token. The UI confirmation dialog achieves the same goal for human users without complicating the API contract.
+
+### Two-admin approval (four-eyes principle)
+
+- **ALT-007**: **Description**: Cluster deletion requires approval from a second admin before executing.
+- **ALT-008**: **Rejection Reason**: Argos is typically operated by small teams (1-3 admins). Requiring a second admin blocks single-admin installations entirely. The audit trail provides after-the-fact accountability; the UI confirmation gate provides before-the-fact friction. Four-eyes can be added as an optional policy in a future ADR if customers request it.
+
+## Implementation Notes
+
+- **IMP-001**: Add a `Store` method `CountClusterChildren(ctx, clusterID) (CascadeCounts, error)` that runs count queries against namespaces, nodes, PVs, pods, workloads, services, ingresses, and PVCs for the given cluster. Use a single round-trip with a multi-CTE query for efficiency.
+- **IMP-002**: In the `DeleteCluster` handler (before calling `s.store.DeleteCluster`), fetch the cluster record and cascade counts. On successful deletion, attach the snapshot to the audit event's `details` JSONB. The audit middleware will need a mechanism for handlers to enrich the `details` field — e.g., a context key `audit.Details` that the middleware reads after the handler returns.
+- **IMP-003**: The UI cluster detail page (`/ui/clusters/:id`) adds a "Delete cluster" button visible only to `admin` role. Clicking opens a confirmation modal showing cluster name, environment, owner, and child counts. The user must type the cluster name exactly to enable the "Delete" button.
+- **IMP-004**: Integration test: create a cluster with namespaces, nodes, and pods; delete it as admin; verify 204, verify all children are gone, verify the audit event contains the cascade snapshot. Test as `editor` / `viewer` and verify 403.
+- **IMP-005**: The existing `AuditMiddleware` already logs the `DELETE` as action `cluster.delete` with `resource_type: cluster` and `resource_id: <uuid>`. The enrichment in IMP-002 adds the `details` payload without changing the middleware's core logic.
+- **IMP-006**: OpenAPI spec: no changes needed — `DELETE /v1/clusters/{id}` already exists with the correct scope and response codes.
+
+## References
+
+- **REF-001**: ADR-0007 — Human authentication, roles, and admin-issued machine tokens — `docs/adr/adr-0007-auth-and-rbac.md`
+- **REF-002**: ADR-0008 — SecNumCloud chapter 8 asset management — `docs/adr/adr-0008-secnumcloud-chapter-8-asset-management.md`
+- **REF-003**: ADR-0006 — UI for audit and curated metadata — `docs/adr/adr-0006-ui-for-audit-and-curated-metadata.md`
+- **REF-004**: ANSSI SecNumCloud — Chapter 8 (asset management and traceability) — https://cyber.gouv.fr/enjeux-technologiques/cloud/
+- **REF-005**: PostgreSQL ON DELETE CASCADE — https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK

--- a/internal/api/audit.go
+++ b/internal/api/audit.go
@@ -30,6 +30,34 @@ type AuditRecorder interface {
 	InsertAuditEvent(ctx context.Context, in AuditEventInsert) error
 }
 
+// auditBag is a mutable holder placed in the context before the handler
+// runs. Handlers call SetAuditDetails to attach extra fields; the
+// middleware reads them after the handler returns. A pointer-in-context
+// pattern is necessary because the strict-server handler receives a
+// derived context that cannot propagate values back to the middleware's
+// original request context.
+type auditBag struct {
+	details map[string]any
+}
+
+type ctxKeyAuditBag struct{}
+
+// withAuditBag returns a child context carrying a mutable audit bag.
+func withAuditBag(ctx context.Context) (context.Context, *auditBag) {
+	bag := &auditBag{}
+	return context.WithValue(ctx, ctxKeyAuditBag{}, bag), bag
+}
+
+// SetAuditDetails stores extra detail fields in the audit bag carried
+// by ctx. Handlers call this to enrich the audit event with domain-
+// specific data (e.g., a pre-deletion cascade snapshot per ADR-0010).
+// Safe to call when no bag is present (no-op).
+func SetAuditDetails(ctx context.Context, details map[string]any) {
+	if bag, ok := ctx.Value(ctxKeyAuditBag{}).(*auditBag); ok && bag != nil {
+		bag.details = details
+	}
+}
+
 // AuditMiddleware wraps the generated router and records every call
 // that looks state-changing. Recording happens after the downstream
 // handler returns so we capture the response status alongside the
@@ -54,11 +82,25 @@ func AuditMiddleware(recorder AuditRecorder) MiddlewareFunc {
 				r.Body = io.NopCloser(bytes.NewReader(buf))
 			}
 
+			// Inject a mutable audit bag so handlers can enrich
+			// the event via SetAuditDetails (ADR-0010).
+			ctx, bag := withAuditBag(r.Context())
+			r = r.WithContext(ctx)
+
 			rw := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 			next.ServeHTTP(rw, r)
 
 			ev := buildAuditEvent(r, rw.status, bodySnap)
-			if err := recorder.InsertAuditEvent(r.Context(), ev); err != nil {
+			// Merge handler-injected details (e.g., cascade snapshot).
+			if bag.details != nil {
+				if ev.Details == nil {
+					ev.Details = make(map[string]any)
+				}
+				for k, v := range bag.details {
+					ev.Details[k] = v
+				}
+			}
+			if err := recorder.InsertAuditEvent(ctx, ev); err != nil {
 				slog.Error("audit: insert failed",
 					slog.Any("error", err),
 					slog.String("method", r.Method),

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -214,8 +214,29 @@ func (s *Server) UpdateCluster(ctx context.Context, req UpdateClusterRequestObje
 	return UpdateCluster200JSONResponse(withClusterLayer(c)), nil
 }
 
-// DeleteCluster removes a cluster.
+// DeleteCluster removes a cluster. Before deleting, it snapshots the
+// cluster metadata and cascade counts into the audit event so the
+// record is self-contained even after the row is gone (ADR-0010).
 func (s *Server) DeleteCluster(ctx context.Context, req DeleteClusterRequestObject) (DeleteClusterResponseObject, error) {
+	// Capture the pre-deletion snapshot for audit enrichment.
+	cluster, err := s.store.GetCluster(ctx, req.Id)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return DeleteCluster404ApplicationProblemPlusJSONResponse{
+				NotFoundApplicationProblemPlusJSONResponse(problemNotFound()),
+			}, nil
+		}
+		return nil, fmt.Errorf("deleteCluster: get snapshot: %w", err)
+	}
+
+	counts, err := s.store.CountClusterChildren(ctx, req.Id)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		slog.Error("deleteCluster: count children failed, proceeding without cascade counts",
+			slog.Any("error", err),
+			slog.String("cluster_id", req.Id.String()),
+		)
+	}
+
 	if err := s.store.DeleteCluster(ctx, req.Id); err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return DeleteCluster404ApplicationProblemPlusJSONResponse{
@@ -224,7 +245,41 @@ func (s *Server) DeleteCluster(ctx context.Context, req DeleteClusterRequestObje
 		}
 		return nil, fmt.Errorf("deleteCluster: %w", err)
 	}
+
+	SetAuditDetails(ctx, clusterDeletionSnapshot(&cluster, counts))
 	return DeleteCluster204Response{}, nil
+}
+
+// clusterDeletionSnapshot builds the audit-event details map for a
+// cluster deletion, capturing identity, curated metadata, and the
+// cascade impact (ADR-0010).
+func clusterDeletionSnapshot(c *Cluster, counts CascadeCounts) map[string]any {
+	details := map[string]any{
+		"cluster_name": c.Name,
+		"cascade_counts": map[string]int{
+			"namespaces":               counts.Namespaces,
+			"nodes":                    counts.Nodes,
+			"pods":                     counts.Pods,
+			"workloads":                counts.Workloads,
+			"services":                 counts.Services,
+			"ingresses":                counts.Ingresses,
+			"persistent_volumes":       counts.PersistentVolumes,
+			"persistent_volume_claims": counts.PersistentVolumeClaims,
+		},
+	}
+	if c.DisplayName != nil {
+		details["cluster_display_name"] = *c.DisplayName
+	}
+	if c.Environment != nil {
+		details["cluster_environment"] = *c.Environment
+	}
+	if c.Owner != nil {
+		details["cluster_owner"] = *c.Owner
+	}
+	if c.Criticality != nil {
+		details["cluster_criticality"] = *c.Criticality
+	}
+	return details
 }
 
 // ── Nodes ────────────────────────────────────────────────────────────

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -224,6 +224,63 @@ func (m *memStore) DeleteCluster(_ context.Context, id uuid.UUID) error {
 	return nil
 }
 
+//nolint:gocyclo // test fake mirrors PG multi-CTE shape
+func (m *memStore) CountClusterChildren(_ context.Context, clusterID uuid.UUID) (CascadeCounts, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.byID[clusterID]; !ok {
+		return CascadeCounts{}, ErrNotFound
+	}
+	var cc CascadeCounts
+	// Collect namespace IDs belonging to this cluster.
+	nsIDs := make(map[uuid.UUID]bool)
+	for id := range m.nsByID {
+		ns := m.nsByID[id]
+		if ns.ClusterId == clusterID {
+			cc.Namespaces++
+			if ns.Id != nil {
+				nsIDs[*ns.Id] = true
+			}
+		}
+	}
+	for id := range m.nodesByID {
+		if m.nodesByID[id].ClusterId == clusterID {
+			cc.Nodes++
+		}
+	}
+	for id := range m.pvsByID {
+		if m.pvsByID[id].ClusterId == clusterID {
+			cc.PersistentVolumes++
+		}
+	}
+	for id := range m.podsByID {
+		if nsIDs[m.podsByID[id].NamespaceId] {
+			cc.Pods++
+		}
+	}
+	for id := range m.workloadsByID {
+		if nsIDs[m.workloadsByID[id].NamespaceId] {
+			cc.Workloads++
+		}
+	}
+	for id := range m.servicesByID {
+		if nsIDs[m.servicesByID[id].NamespaceId] {
+			cc.Services++
+		}
+	}
+	for id := range m.ingressesByID {
+		if nsIDs[m.ingressesByID[id].NamespaceId] {
+			cc.Ingresses++
+		}
+	}
+	for id := range m.pvcsByID {
+		if nsIDs[m.pvcsByID[id].NamespaceId] {
+			cc.PersistentVolumeClaims++
+		}
+	}
+	return cc, nil
+}
+
 // copyNodeMutableFromCreate mirrors every NodeMutable-derived field from a
 // NodeCreate payload onto a Node. The fake carries them as-is so tests can
 // round-trip any of the 23 fields the collector now populates.
@@ -2616,6 +2673,146 @@ func TestUnknownRoute404(t *testing.T) {
 	rr := do(h, http.MethodGet, "/no-such-path", "")
 	if rr.Code != http.StatusNotFound {
 		t.Errorf("status=%d", rr.Code)
+	}
+}
+
+// TestDeleteClusterAuditEnrichment verifies that deleting a cluster
+// populates the audit event with the pre-deletion snapshot containing
+// cluster metadata and cascade counts (ADR-0010).
+func TestDeleteClusterAuditEnrichment(t *testing.T) { //nolint:gocyclo // end-to-end test asserting multiple audit fields
+	t.Parallel()
+	store := newMemStore()
+
+	// Build handler with audit middleware wrapping it.
+	strict := NewStrictHandlerWithOptions(
+		NewServer("test", store, auth.SecureNever, nil),
+		[]StrictMiddlewareFunc{InjectRequestMiddleware},
+		StrictHTTPServerOptions{
+			RequestErrorHandlerFunc: func(w http.ResponseWriter, _ *http.Request, err error) {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+			},
+			ResponseErrorHandlerFunc: func(w http.ResponseWriter, _ *http.Request, err error) {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			},
+		},
+	)
+	h := AuditMiddleware(store)(Handler(strict))
+
+	// Create a cluster with curated metadata.
+	env := "production"
+	owner := "platform-team"
+	crit := "critical"
+	displayName := "Prod EU West"
+	rr := do(h, http.MethodPost, "/v1/clusters",
+		`{"name":"prod-eu","environment":"production","owner":"platform-team","criticality":"critical","display_name":"Prod EU West"}`)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create cluster status=%d body=%q", rr.Code, rr.Body.String())
+	}
+	var cluster Cluster
+	if err := json.Unmarshal(rr.Body.Bytes(), &cluster); err != nil {
+		t.Fatalf("decode cluster: %v", err)
+	}
+
+	// Add a namespace under the cluster.
+	cID := cluster.Id.String()
+	rr = do(h, http.MethodPost, "/v1/namespaces",
+		`{"name":"default","cluster_id":"`+cID+`"}`)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create namespace status=%d body=%q", rr.Code, rr.Body.String())
+	}
+	var ns Namespace
+	if err := json.Unmarshal(rr.Body.Bytes(), &ns); err != nil {
+		t.Fatalf("decode ns: %v", err)
+	}
+
+	// Add a node under the cluster.
+	rr = do(h, http.MethodPost, "/v1/nodes",
+		`{"name":"node-1","cluster_id":"`+cID+`"}`)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create node status=%d body=%q", rr.Code, rr.Body.String())
+	}
+
+	// Add a pod under the namespace.
+	nsID := ns.Id.String()
+	rr = do(h, http.MethodPost, "/v1/pods",
+		`{"name":"pod-1","namespace_id":"`+nsID+`"}`)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create pod status=%d body=%q", rr.Code, rr.Body.String())
+	}
+
+	// Clear audit events from creation calls.
+	store.mu.Lock()
+	store.authState.auditEvents = nil
+	store.mu.Unlock()
+
+	// Delete the cluster.
+	rr = do(h, http.MethodDelete, "/v1/clusters/"+cluster.Id.String(), "")
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("delete cluster status=%d body=%q", rr.Code, rr.Body.String())
+	}
+
+	// Verify the audit event contains the enriched details.
+	evs, _, err := store.ListAuditEvents(context.Background(), AuditEventFilter{}, 10, "")
+	if err != nil {
+		t.Fatalf("list audit events: %v", err)
+	}
+	if len(evs) != 1 {
+		t.Fatalf("expected 1 audit event, got %d", len(evs))
+	}
+	ev := evs[0]
+	if ev.Action != "cluster.delete" {
+		t.Errorf("action = %q, want cluster.delete", ev.Action)
+	}
+	if ev.Details == nil {
+		t.Fatal("expected enriched details, got nil")
+	}
+
+	// Marshal and re-parse to inspect the details map.
+	detailsJSON, err := json.Marshal(*ev.Details)
+	if err != nil {
+		t.Fatalf("marshal details: %v", err)
+	}
+	var details map[string]any
+	if err := json.Unmarshal(detailsJSON, &details); err != nil {
+		t.Fatalf("unmarshal details: %v", err)
+	}
+
+	if details["cluster_name"] != "prod-eu" {
+		t.Errorf("cluster_name = %v", details["cluster_name"])
+	}
+	if details["cluster_display_name"] != displayName {
+		t.Errorf("cluster_display_name = %v, want %v", details["cluster_display_name"], displayName)
+	}
+	if details["cluster_environment"] != env {
+		t.Errorf("cluster_environment = %v, want %v", details["cluster_environment"], env)
+	}
+	if details["cluster_owner"] != owner {
+		t.Errorf("cluster_owner = %v, want %v", details["cluster_owner"], owner)
+	}
+	if details["cluster_criticality"] != crit {
+		t.Errorf("cluster_criticality = %v, want %v", details["cluster_criticality"], crit)
+	}
+
+	// Check cascade counts.
+	cascadeRaw, ok := details["cascade_counts"]
+	if !ok {
+		t.Fatal("missing cascade_counts in details")
+	}
+	cascade, ok := cascadeRaw.(map[string]any)
+	if !ok {
+		t.Fatalf("cascade_counts type = %T", cascadeRaw)
+	}
+	// JSON numbers are float64.
+	wantCounts := map[string]float64{
+		"namespaces": 1, "nodes": 1, "pods": 1,
+		"workloads": 0, "services": 0, "ingresses": 0,
+		"persistent_volumes": 0, "persistent_volume_claims": 0,
+	}
+	for k, want := range wantCounts {
+		got, _ := cascade[k].(float64)
+		if got != want {
+			t.Errorf("cascade_counts[%s] = %v, want %v", k, got, want)
+		}
 	}
 }
 

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -35,6 +35,20 @@ type WorkloadListFilter struct {
 	ImageSubstring *string
 }
 
+// CascadeCounts holds the number of child resources that will be removed
+// when a cluster is deleted via ON DELETE CASCADE. Used by the DeleteCluster
+// handler to enrich the audit event with a pre-deletion impact snapshot.
+type CascadeCounts struct {
+	Namespaces             int `json:"namespaces"`
+	Nodes                  int `json:"nodes"`
+	Pods                   int `json:"pods"`
+	Workloads              int `json:"workloads"`
+	Services               int `json:"services"`
+	Ingresses              int `json:"ingresses"`
+	PersistentVolumes      int `json:"persistent_volumes"`
+	PersistentVolumeClaims int `json:"persistent_volume_claims"`
+}
+
 // Store is the persistence contract consumed by the REST handlers.
 // Implementations must be safe for concurrent use by multiple goroutines.
 type Store interface {
@@ -62,6 +76,11 @@ type Store interface {
 
 	// DeleteCluster removes a cluster by id. Returns ErrNotFound if absent.
 	DeleteCluster(ctx context.Context, id uuid.UUID) error
+
+	// CountClusterChildren counts child resources that will be cascade-deleted
+	// when the given cluster is removed. Returns ErrNotFound if the cluster
+	// does not exist. Used to build the pre-deletion audit snapshot (ADR-0010).
+	CountClusterChildren(ctx context.Context, clusterID uuid.UUID) (CascadeCounts, error)
 
 	// CreateNode inserts a new node. Returns ErrNotFound when the parent
 	// cluster does not exist; ErrConflict when (cluster_id, name) already

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -337,6 +337,60 @@ func (p *PG) DeleteCluster(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
+// CountClusterChildren counts every child resource that ON DELETE CASCADE
+// will remove when the cluster is deleted. A single round-trip multi-CTE
+// query keeps the cost bounded regardless of how many resource types
+// exist (ADR-0010).
+func (p *PG) CountClusterChildren(ctx context.Context, clusterID uuid.UUID) (api.CascadeCounts, error) {
+	const q = `
+		WITH ns_ids AS (
+			SELECT id FROM namespaces WHERE cluster_id = $1
+		),
+		ns_count   AS (SELECT COUNT(*) AS c FROM ns_ids),
+		node_count AS (SELECT COUNT(*) AS c FROM nodes WHERE cluster_id = $1),
+		pv_count   AS (SELECT COUNT(*) AS c FROM persistent_volumes WHERE cluster_id = $1),
+		pod_count  AS (SELECT COUNT(*) AS c FROM pods WHERE namespace_id IN (SELECT id FROM ns_ids)),
+		wl_count   AS (SELECT COUNT(*) AS c FROM workloads WHERE namespace_id IN (SELECT id FROM ns_ids)),
+		svc_count  AS (SELECT COUNT(*) AS c FROM services WHERE namespace_id IN (SELECT id FROM ns_ids)),
+		ing_count  AS (SELECT COUNT(*) AS c FROM ingresses WHERE namespace_id IN (SELECT id FROM ns_ids)),
+		pvc_count  AS (SELECT COUNT(*) AS c FROM persistent_volume_claims WHERE namespace_id IN (SELECT id FROM ns_ids))
+		SELECT
+			(SELECT c FROM ns_count),
+			(SELECT c FROM node_count),
+			(SELECT c FROM pod_count),
+			(SELECT c FROM wl_count),
+			(SELECT c FROM svc_count),
+			(SELECT c FROM ing_count),
+			(SELECT c FROM pv_count),
+			(SELECT c FROM pvc_count)
+	`
+	// Verify the cluster exists before running counts; a non-existent
+	// cluster would just return all zeroes, which is misleading.
+	var exists bool
+	if err := p.pool.QueryRow(ctx, "SELECT EXISTS(SELECT 1 FROM clusters WHERE id=$1)", clusterID).Scan(&exists); err != nil {
+		return api.CascadeCounts{}, fmt.Errorf("count cluster children: existence check: %w", err)
+	}
+	if !exists {
+		return api.CascadeCounts{}, api.ErrNotFound
+	}
+
+	var cc api.CascadeCounts
+	err := p.pool.QueryRow(ctx, q, clusterID).Scan(
+		&cc.Namespaces,
+		&cc.Nodes,
+		&cc.Pods,
+		&cc.Workloads,
+		&cc.Services,
+		&cc.Ingresses,
+		&cc.PersistentVolumes,
+		&cc.PersistentVolumeClaims,
+	)
+	if err != nil {
+		return api.CascadeCounts{}, fmt.Errorf("count cluster children: %w", err)
+	}
+	return cc, nil
+}
+
 // CreateNode inserts a new node. Returns api.ErrNotFound when the parent
 // cluster does not exist (FK violation), api.ErrConflict on duplicate
 // (cluster_id, name).

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -572,6 +572,9 @@ export function listClusters() {
 export function getCluster(id: string) {
   return request<Cluster>(`/v1/clusters/${id}`);
 }
+export function deleteCluster(id: string) {
+  return request<void>(`/v1/clusters/${id}`, { method: 'DELETE' });
+}
 
 export function listNodes(filter?: { cluster_id?: string }) {
   return request<PagedResponse<Node>>('/v1/nodes' + query({ limit: 200, ...filter }));

--- a/ui/src/me.tsx
+++ b/ui/src/me.tsx
@@ -20,3 +20,9 @@ export function useMe(): Me | null {
 export function canEdit(me: Me | null): boolean {
   return me?.role === 'admin' || me?.role === 'editor';
 }
+
+// isAdmin answers "does this role carry the delete scope?". Used to
+// gate destructive affordances like cluster deletion (ADR-0010).
+export function isAdmin(me: Me | null): boolean {
+  return me?.role === 'admin';
+}

--- a/ui/src/pages/Details.tsx
+++ b/ui/src/pages/Details.tsx
@@ -12,9 +12,10 @@
 // feels consistent across the app.
 
 import { useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import * as api from '../api';
 import { useResource, useResources } from '../hooks';
+import { useMe, isAdmin } from '../me';
 import { ClusterCuratedCard } from './cluster_curated';
 import { NamespaceCuratedCard } from './namespace_curated';
 import { NodeCuratedCard } from './node_curated';
@@ -53,7 +54,10 @@ function NodeStatusInline({
 
 export function ClusterDetail() {
   const { id = '' } = useParams();
+  const navigate = useNavigate();
+  const me = useMe();
   const [nonce, setNonce] = useState(0);
+  const [deleting, setDeleting] = useState(false);
   const reload = () => setNonce((n) => n + 1);
   const state = useResources(
     [
@@ -65,16 +69,48 @@ export function ClusterDetail() {
     [id, nonce],
   );
 
+  const handleDelete = async (cluster: api.Cluster, childCount: number) => {
+    const typed = prompt(
+      `This will permanently delete cluster "${cluster.name}" and all its ${childCount} child resources.\n\nType the cluster name to confirm:`,
+    );
+    if (typed === null) return; // cancelled
+    if (typed !== cluster.name) {
+      alert(`Name does not match. Expected "${cluster.name}".`);
+      return;
+    }
+    setDeleting(true);
+    try {
+      await api.deleteCluster(cluster.id);
+      navigate('/clusters', { replace: true });
+    } catch (err) {
+      alert(err instanceof api.ApiError ? err.message : String(err));
+      setDeleting(false);
+    }
+  };
+
   return (
     <>
       <div className="breadcrumb">
         <Link to="/clusters">Clusters</Link> / <span>this cluster</span>
       </div>
       <AsyncView state={state}>
-        {([cluster, nodes, namespaces, pvs]) => (
+        {([cluster, nodes, namespaces, pvs]) => {
+          const childCount =
+            nodes.items.length + namespaces.items.length + pvs.items.length;
+          return (
           <>
             <h2>
               {cluster.display_name || cluster.name} <LayerPill layer={cluster.layer} />
+              {isAdmin(me) && (
+                <button
+                  className="danger"
+                  style={{ marginLeft: '1rem', fontSize: '0.85rem' }}
+                  disabled={deleting}
+                  onClick={() => handleDelete(cluster, childCount)}
+                >
+                  {deleting ? 'Deleting…' : 'Delete cluster'}
+                </button>
+              )}
             </h2>
             <dl className="kv-list">
               <KV k="Name" v={<code>{cluster.name}</code>} />
@@ -170,7 +206,8 @@ export function ClusterDetail() {
               </table>
             )}
           </>
-        )}
+          );
+        }}
       </AsyncView>
     </>
   );


### PR DESCRIPTION
…ADR-0010)

Cluster deletion is the most destructive operation in Argos — it cascades through every child table. This commit adds a pre-deletion audit snapshot so the event is self-contained even after the row is gone, and surfaces the action in the UI behind an admin-only gate with name-confirmation.

Backend:
- Add CascadeCounts type and CountClusterChildren store method (multi-CTE)
- Enrich DeleteCluster handler with pre-deletion snapshot (cluster metadata
  + cascade counts) injected into the audit event via a mutable context bag
- AuditMiddleware merges handler-provided details into the event's JSONB

UI:
- Add deleteCluster API call and isAdmin helper
- Add "Delete cluster" button on cluster detail page (admin-only, red)
- Name-confirmation prompt before deletion, navigate to /clusters on success