### PR TITLE
fix(audit): resolve always-anonymous actor in audit events

### DIFF
--- a/cmd/argosd/main.go
+++ b/cmd/argosd/main.go
@@ -171,12 +171,13 @@ func buildHTTPServer(cfg *runConfig, pg *store.PG, oidcProvider *auth.OIDCProvid
 	)
 	api.HandlerWithOptions(strict, api.StdHTTPServerOptions{
 		BaseRouter: mux,
-		// Order matters: the outer middleware runs first, so the audit
-		// layer sits *after* auth — it sees the resolved caller on the
-		// request context and the final response status.
+		// Order matters: oapi-codegen wraps in list order, so the last
+		// entry becomes the outermost handler (runs first). Auth must be
+		// outermost so it resolves the caller before the audit layer reads
+		// it from the request context.
 		Middlewares: []api.MiddlewareFunc{
-			api.AuthMiddleware(pg, cfg.cookiePolicy),
 			api.AuditMiddleware(pg),
+			api.AuthMiddleware(pg, cfg.cookiePolicy),
 		},
 	})
 


### PR DESCRIPTION
oapi-codegen wraps middlewares in list order, making the last entry the outermost handler. The previous ordering placed AuditMiddleware last (outermost), so it ran before AuthMiddleware could attach the caller to the request context — every audit event recorded actor_kind=anonymous.

Swap the middleware order so Auth wraps last (runs first, resolves the caller) and Audit wraps first (runs second, reads the caller).