### PR TITLE
docs(adr-0011): document collector auto-creates cluster on first contact

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -101,11 +101,11 @@ First-time OIDC users land as role `viewer` (authorization is not
 claim-driven — ADR-0007). An `admin` promotes them through the admin
 panel at `/ui/admin/users` as needed.
 
-### Register a cluster
+### Cluster registration
 
-The CMDB requires explicit cluster registration before the collector writes
-anything (per ADR-0005). Register it through the admin session — first
-log in with the bootstrap password, then:
+The collector auto-creates a minimal cluster record (name only) on first contact if the cluster doesn't exist in the CMDB (ADR-0011). No manual step is required — after `kubectl apply -k deploy/`, the collector starts ingesting on the next tick.
+
+**Optional: pre-register with curated metadata.** If you want display name, environment, owner, or criticality populated before the first tick, register the cluster manually:
 
 ```sh
 # Port-forward the argosd service for a local curl.
@@ -116,7 +116,7 @@ curl -sS -c /tmp/argos.cookies -X POST http://localhost:8080/v1/auth/login \
   -H 'Content-Type: application/json' \
   -d '{"username":"admin","password":"<your new rotated password>"}'
 
-# Register the cluster.
+# Pre-register the cluster with metadata.
 curl -sS -b /tmp/argos.cookies -X POST http://localhost:8080/v1/clusters \
   -H 'Content-Type: application/json' \
   -d '{"name":"in-cluster","display_name":"Self","environment":"dev"}'
@@ -253,7 +253,7 @@ To catalogue multiple clusters from a single argosd (per ADR-0005):
 
 4. Each kubeconfig should authenticate a ServiceAccount in *its own* cluster with the same RBAC as `rbac.yaml`. A compromise of the argosd pod exposes every catalogued cluster — keep the kubeconfigs read-only-scoped (ADR-0005 NEG-001).
 
-5. `POST /v1/clusters` for each named cluster before the collectors start ingesting them.
+5. **Optional:** pre-register each cluster via `POST /v1/clusters` to populate curated metadata (display name, environment, owner, criticality) before the first tick. If skipped, the collector auto-creates a minimal record (name only) on first contact (ADR-0011).
 
 ## Uninstall
 

--- a/docs/adr/adr-0005-multi-cluster-collector.md
+++ b/docs/adr/adr-0005-multi-cluster-collector.md
@@ -51,7 +51,7 @@ This ADR decides how one or more Kubernetes clusters are polled into a single Ar
 ]
 ```
 
-- `name` is the cluster's CMDB name (same value the Cluster row carries); must already exist in the store.
+- `name` is the cluster's CMDB name (same value the Cluster row carries). The collector auto-creates the cluster record on first contact if it doesn't exist (ADR-0011); pre-registering via `POST /v1/clusters` is optional but recommended to populate curated metadata upfront.
 - `kubeconfig` is a filesystem path. An empty string means "use in-cluster config" (argosd's own ServiceAccount) — useful when argosd is deployed inside one of the target clusters.
 - Names must be unique within the list; `loadCollectorClusters` validates.
 
@@ -59,7 +59,7 @@ This ADR decides how one or more Kubernetes clusters are polled into a single Ar
 
 **Concurrency:** each cluster's `Collector.Run(ctx)` is its own goroutine. Failures in one cluster (unreachable API, transient timeout) log and continue; other clusters' ticks are unaffected. Per-tick operations inside a single cluster remain sequential (as today).
 
-**Cluster record lifecycle:** explicit. Operators `POST /v1/clusters` for each cluster before the collector can write to it. If the collector can't find a matching cluster row it logs `"cluster not registered; POST /v1/clusters first"` and skips that tick — unchanged from today. Auto-creation is explicitly rejected (see alternatives).
+**Cluster record lifecycle:** the collector auto-creates a minimal cluster record (name only) on first contact if the cluster doesn't exist in the CMDB (ADR-0011, reversing the original ALT-007/ALT-008 rejection below). Pre-registration via `POST /v1/clusters` is optional but recommended to populate curated metadata (display name, environment, owner, criticality) before the first tick.
 
 **Per-cluster reconciliation isolation:** already correct by construction. Every `Delete*NotIn` call is scoped to a `cluster_id` (for cluster-scoped kinds) or `namespace_id` (for namespace-scoped kinds). Two collectors writing in parallel never delete each other's rows.
 
@@ -103,7 +103,7 @@ This ADR decides how one or more Kubernetes clusters are polled into a single Ar
 ### Collector auto-registers the Cluster row
 
 - **ALT-007**: **Description**: If the collector can't find the cluster row at startup, it `POST`s one itself.
-- **ALT-008**: **Rejection Reason**: Collides with the CMDB's role as an authoritative inventory. Explicit registration forces the operator to commit metadata (display name, environment, region, labels) before the collector starts flooding rows in — data quality improves. Auto-registration is easy to add later if the friction becomes real.
+- **ALT-008**: **Originally rejected** — explicit registration was preferred for data quality. **Reversed by ADR-0011**: operational friction (boot-ordering, air-gap round-trips) outweighed the data-quality benefit. The collector now auto-creates a minimal record; operators can enrich metadata afterwards.
 
 ### Per-cluster interval / timeout overrides in v1
 

--- a/docs/adr/adr-0009-push-collector-for-airgapped-clusters.md
+++ b/docs/adr/adr-0009-push-collector-for-airgapped-clusters.md
@@ -195,8 +195,9 @@ the air-gapped cluster, with:
 - A `Secret` carrying `ARGOS_API_TOKEN`.
 - Egress network policy allowing HTTPS to the argosd endpoint only.
 
-The Cluster row must be pre-created in argosd (`POST /v1/clusters`)
-before the push collector starts — same requirement as the pull model.
+The push collector auto-creates the cluster record on first contact if
+it doesn't exist (ADR-0011). Pre-registering via `POST /v1/clusters` is
+optional but recommended to populate curated metadata upfront.
 
 ### Bulk push (future optimisation)
 

--- a/docs/adr/adr-0011-collector-auto-creates-cluster.md
+++ b/docs/adr/adr-0011-collector-auto-creates-cluster.md
@@ -1,0 +1,53 @@
+---
+title: "ADR-0011: Collector auto-creates cluster record on first contact"
+status: "Accepted"
+date: "2026-04-24"
+authors: "Steve ALBERT"
+tags: ["architecture", "decision", "collector", "cluster", "lifecycle"]
+supersedes: "ADR-0005 ALT-007/ALT-008 (partial)"
+superseded_by: ""
+---
+
+# ADR-0011: Collector auto-creates cluster record on first contact
+
+## Status
+
+Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+## Context
+
+ADR-0005 explicitly rejected collector auto-creation of cluster records (ALT-007/ALT-008). The rationale was that explicit `POST /v1/clusters` registration forces the operator to commit metadata (display name, environment, labels) before the collector floods rows in, improving data quality.
+
+In practice this created a boot-ordering problem: the collector cannot ingest anything until a human (or script) has registered the cluster via the API. For the common case — a fresh deployment where argosd runs inside the cluster it catalogues — this adds a mandatory manual step between `kubectl apply` and a working CMDB. Operators deploying via Helm or Kustomize expect the system to be functional after a single `apply`.
+
+The same friction applies to the push collector (ADR-0009): the air-gapped cluster's `argos-collector` cannot push until someone registers the cluster in the central argosd — which may itself require tunnelling through the air-gap boundary just to run a `curl`.
+
+## Decision
+
+**The collector auto-creates a minimal cluster record when `GetClusterByName` returns `ErrNotFound`.**
+
+The auto-created record carries only the `name` field (matching `ARGOS_CLUSTER_NAME` or the entry in `ARGOS_COLLECTOR_CLUSTERS`). All curated-metadata columns (`display_name`, `environment`, `owner`, `criticality`, `notes`, `runbook_url`, `annotations`) remain at their zero values. The collector then proceeds with its normal ingestion tick.
+
+This applies to both the pull collector (embedded in argosd) and the push collector (`argos-collector`), which calls `CreateCluster` through the API client.
+
+**Pre-registration via `POST /v1/clusters` remains supported and recommended** when the operator wants curated metadata populated before the first tick. If the cluster already exists, the collector uses it as-is — no fields are overwritten. The merge-patch semantics of `UpdateCluster` ensure that a later metadata edit is never clobbered by the collector.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Zero-touch bootstrap — a fresh `kubectl apply -k deploy/` produces a working CMDB without any manual API call.
+- **POS-002**: Push collectors in air-gapped clusters no longer require a round-trip to the central argosd just to register the cluster name.
+- **POS-003**: The `scripts/seed-demo.sh` workflow and integration tests that `POST /v1/clusters` continue to work unchanged — pre-creation is additive, not required.
+
+### Negative
+
+- **NEG-001**: Auto-created clusters have empty metadata until an operator fills it in. This is a data-quality trade-off: the CMDB has the cluster immediately, but without curated context. Mitigated by the UI surfacing empty fields as prompts ("No environment set — edit to add").
+- **NEG-002**: A typo in `ARGOS_CLUSTER_NAME` silently creates a new cluster row instead of failing. Operators must verify cluster names after first deployment.
+
+## References
+
+- **REF-001**: ADR-0005 — Multi-cluster collector topology (ALT-007/ALT-008: original rejection of auto-creation)
+- **REF-002**: ADR-0009 — Push-based collector for air-gapped clusters
+- **REF-003**: `internal/collector/collector.go` — `poll()` auto-creation path
+- **REF-004**: `internal/collector/collector_test.go` — `TestPollAutoCreatesClusterWhenMissing`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,7 +55,7 @@ The embedded pull-mode collector is disabled by default.
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `ARGOS_CLUSTER_NAME` | when single-cluster | -- | Name of the cluster to poll. Must match a cluster registered via `POST /v1/clusters`. When using in-cluster ServiceAccount credentials, no kubeconfig is needed. |
+| `ARGOS_CLUSTER_NAME` | when single-cluster | -- | Name of the cluster to poll. The collector auto-creates the cluster record if it doesn't exist (ADR-0011); pre-registering via `POST /v1/clusters` is optional but recommended to populate curated metadata. When using in-cluster ServiceAccount credentials, no kubeconfig is needed. |
 
 #### Multi-cluster mode
 
@@ -100,7 +100,7 @@ The standalone push-mode collector binary. It runs inside an air-gapped or netwo
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `ARGOS_CLUSTER_NAME` | yes | -- | Name of this cluster. Must match a cluster pre-registered in argosd via `POST /v1/clusters`. |
+| `ARGOS_CLUSTER_NAME` | yes | -- | Name of this cluster. The push collector auto-creates the record if it doesn't exist (ADR-0011); pre-registering via `POST /v1/clusters` is optional but recommended to populate curated metadata. |
 
 ### Collector behavior
 

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -74,13 +74,13 @@ helm install argos charts/argos \
 
 The chart creates a ClusterRole granting read-only `list` on the Kubernetes resources the collector ingests. The ServiceAccount is bound automatically.
 
-Remember to register the cluster in argosd first:
+The collector auto-creates the cluster record on first contact (ADR-0011). To populate curated metadata (display name, environment, owner) before the first tick, optionally pre-register:
 
 ```bash
 kubectl -n argos-system port-forward svc/argos 8080:8080 &
 curl -X POST http://localhost:8080/v1/clusters \
   -H 'Content-Type: application/json' \
-  -d '{"name":"my-cluster"}'
+  -d '{"name":"my-cluster","display_name":"My Cluster","environment":"prod"}'
 ```
 
 ## Enable OIDC

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -95,9 +95,11 @@ WARN  ========================================================================
 
 Capture this password immediately. The first login (via UI or API) requires a password change.
 
-## Register the cluster
+## Cluster registration
 
-The collector will not ingest data until the cluster is registered. Port-forward the service and register:
+The collector auto-creates a minimal cluster record (name only) on first contact (ADR-0011). No manual step is required — the CMDB starts populating on the next tick after deployment.
+
+**Optional: pre-register with curated metadata.** To populate display name, environment, or owner before the first tick:
 
 ```bash
 kubectl -n argos-system port-forward svc/argosd 8080:8080 &
@@ -107,7 +109,7 @@ curl -sS -c /tmp/argos.cookies -X POST http://localhost:8080/v1/auth/login \
   -H 'Content-Type: application/json' \
   -d '{"username":"admin","password":"<your rotated password>"}'
 
-# Register the cluster.
+# Pre-register the cluster with metadata.
 curl -sS -b /tmp/argos.cookies -X POST http://localhost:8080/v1/clusters \
   -H 'Content-Type: application/json' \
   -d '{"name":"in-cluster","display_name":"Self","environment":"production"}'

--- a/docs/deployment/push-collector.md
+++ b/docs/deployment/push-collector.md
@@ -98,7 +98,7 @@ Key variables for the push collector:
 |----------|----------|-------------|
 | `ARGOS_SERVER_URL` | yes | argosd base URL. |
 | `ARGOS_API_TOKEN` | yes | PAT with `write` scope. |
-| `ARGOS_CLUSTER_NAME` | yes | Must match a pre-registered cluster. |
+| `ARGOS_CLUSTER_NAME` | yes | Name of this cluster. Auto-created if it doesn't exist (ADR-0011). |
 | `ARGOS_COLLECTOR_INTERVAL` | no | Polling interval (default `5m`). |
 | `ARGOS_COLLECTOR_RECONCILE` | no | Delete stale rows (default `true`). |
 
@@ -188,9 +188,9 @@ No write access to Kubernetes. The collector is read-only.
 - The PAT is invalid, expired, or revoked. Check the argosd admin panel under Tokens.
 - The `Authorization: Bearer` header is malformed. Verify `ARGOS_API_TOKEN` starts with `argos_pat_`.
 
-### 404 cluster not found
+### 404 on upsert calls
 
-- The cluster name in `ARGOS_CLUSTER_NAME` does not match any cluster registered in argosd. Register it first with `POST /v1/clusters`.
+- The cluster auto-creation failed (e.g. a name conflict or a transient error). Check collector logs for `auto-create cluster failed` messages.
 
 ### 403 Forbidden
 
@@ -215,4 +215,4 @@ No write access to Kubernetes. The collector is read-only.
 
 - Wait for at least one full polling interval.
 - Check collector logs for upsert errors.
-- Verify the cluster name matches exactly between the collector and the registered cluster in argosd.
+- Verify `ARGOS_CLUSTER_NAME` is correct — a typo silently creates a new cluster record (ADR-0011 NEG-002).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -142,9 +142,11 @@ curl -sS -b /tmp/argos.cookies -X POST http://localhost:8080/v1/auth/change-pass
   -d '{"current_password":"changeme-on-first-login","new_password":"a-strong-passphrase"}'
 ```
 
-### Register a cluster
+### Cluster registration
 
-The CMDB requires explicit cluster registration before any collector can write data. Create a cluster:
+The collector auto-creates a minimal cluster record (name only) on first contact if the cluster doesn't exist (ADR-0011). No manual step is required to start ingesting.
+
+**Optional: pre-register with curated metadata.** To populate display name, environment, or owner before the first tick:
 
 ```bash
 curl -sS -b /tmp/argos.cookies -X POST http://localhost:8080/v1/clusters \


### PR DESCRIPTION
The collector has been auto-creating cluster records when they don't exist in the CMDB, but all documentation still referenced the old manual-registration-first requirement from ADR-0005 ALT-007/ALT-008.

Add ADR-0011 formalising the reversal and update all stale references across ADRs, deploy guides, configuration docs, and troubleshooting sections to reflect that pre-registration is optional (recommended for curated metadata, not required for ingestion).