### PR TITLE
feat(helm): expose MCP SSE port in Service and Deployment

### DIFF
--- a/charts/argos/templates/deployment.yaml
+++ b/charts/argos/templates/deployment.yaml
@@ -42,6 +42,11 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            {{- if and .Values.mcp.enabled (eq .Values.mcp.transport "sse") }}
+            - name: mcp
+              containerPort: {{ trimPrefix ":" .Values.mcp.addr | default "8090" }}
+              protocol: TCP
+            {{- end }}
           env:
             - name: ARGOS_ADDR
               value: {{ .Values.argosd.addr | quote }}
@@ -66,6 +71,18 @@ spec:
             {{- else }}
             - name: ARGOS_CLUSTER_NAME
               value: {{ .Values.collector.clusterName | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.mcp.enabled }}
+            - name: ARGOS_MCP_ENABLED
+              value: "true"
+            - name: ARGOS_MCP_TRANSPORT
+              value: {{ .Values.mcp.transport | quote }}
+            - name: ARGOS_MCP_ADDR
+              value: {{ .Values.mcp.addr | quote }}
+            {{- if .Values.mcp.token }}
+            - name: ARGOS_MCP_TOKEN
+              value: {{ .Values.mcp.token | quote }}
             {{- end }}
             {{- end }}
           envFrom:

--- a/charts/argos/templates/service.yaml
+++ b/charts/argos/templates/service.yaml
@@ -16,3 +16,9 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
+    {{- if and .Values.mcp.enabled (eq .Values.mcp.transport "sse") }}
+    - name: mcp
+      port: {{ .Values.service.mcpPort }}
+      targetPort: mcp
+      protocol: TCP
+    {{- end }}

--- a/charts/argos/values.yaml
+++ b/charts/argos/values.yaml
@@ -101,10 +101,23 @@ externalDatabase:
 # The Secret must contain ARGOS_DATABASE_URL (and optionally other ARGOS_* keys).
 existingSecret: ""
 
+# -- MCP server (Model Context Protocol for AI agents).
+mcp:
+  # -- Enable the MCP server (seeds mcp_enabled DB setting on startup).
+  enabled: false
+  # -- Transport: "sse" (HTTP, remote agents) or "stdio" (local agents).
+  transport: "sse"
+  # -- Listen address for SSE transport.
+  addr: ":8090"
+  # -- PAT for stdio transport auth (not needed for SSE — uses bearer header).
+  token: ""
+
 # -- Kubernetes Service.
 service:
   type: ClusterIP
   port: 8080
+  # -- MCP SSE port (only exposed when mcp.enabled and mcp.transport=sse).
+  mcpPort: 8090
 
 # -- ServiceAccount.
 serviceAccount:


### PR DESCRIPTION
When mcp.enabled=true and mcp.transport=sse, the Helm chart now:
- Adds containerPort 8090 (mcp) to the Deployment
- Adds port 8090 (mcp) to the Service
- Sets ARGOS_MCP_ENABLED, ARGOS_MCP_TRANSPORT, ARGOS_MCP_ADDR env vars

Disabled by default — no change to existing deployments.