### PR TITLE
fix(vm-applications): omit empty added_at/added_by on new rows in UI …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 — the REST and database contracts may still change incompatibly before
 `v1.0.0`.
 
+## [0.12.1] — 2026-04-29
+
+Helm chart 0.15.1 / appVersion 0.12.1. UI hotfix for the VM applications
+editor introduced in 0.12.0.
+
+### Fixed
+
+- **`PATCH /v1/virtual-machines/{id}` returned `400 invalid JSON body` when
+  adding a new application row from the UI.** The `ApplicationsCard` editor
+  was sending `added_at: ""` and `added_by: ""` for fresh rows; the server
+  decodes `added_at` into `time.Time`, which cannot parse the empty string,
+  so the entire request was rejected before reaching the diff logic that
+  would have stamped the missing values. The form now omits those fields
+  entirely on new rows (and only re-sends them for rows that already carry
+  server-stamped values), letting the server take its existing
+  preserve-or-stamp path. No schema or API change — only the UI payload
+  shape is fixed.
+
 ## [0.12.0] — 2026-04-29
 
 Helm chart 0.15.0 / appVersion 0.12.0. Adds VM application inventory and EOL

--- a/charts/argos/Chart.yaml
+++ b/charts/argos/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   A CMDB for Kubernetes environments aligned with the ANSSI SecNumCloud
   qualification framework. Polls clusters and exposes a REST API and web UI.
 type: application
-version: 0.15.0
-appVersion: "0.12.0"
+version: 0.15.1
+appVersion: "0.12.1"
 home: https://github.com/sthalbert/Argos
 sources:
   - https://github.com/sthalbert/Argos

--- a/ui/src/components/inventory/ApplicationsCard.tsx
+++ b/ui/src/components/inventory/ApplicationsCard.tsx
@@ -170,17 +170,17 @@ function ApplicationsForm({
         return;
       }
     }
-    const payload: api.VMApplication[] = cleaned.map((d) => ({
+    // The server stamps added_at / added_by for new rows and preserves
+    // them for matching (product, version, name) keys; on input these are
+    // omitted entirely when empty (Go time.Time can't decode "").
+    const payload = cleaned.map((d) => ({
       product: d.product,
       version: d.version,
-      name: d.name || undefined,
-      notes: d.notes || undefined,
-      // The server overwrites added_at / added_by for new rows and
-      // preserves them for matching (product, version, name) keys, so
-      // sending back the values the read returned is safe.
-      added_at: d.added_at ?? '',
-      added_by: d.added_by ?? '',
-    }));
+      ...(d.name ? { name: d.name } : {}),
+      ...(d.notes ? { notes: d.notes } : {}),
+      ...(d.added_at ? { added_at: d.added_at } : {}),
+      ...(d.added_by ? { added_by: d.added_by } : {}),
+    })) as api.VMApplication[];
     setBusy(true);
     try {
       await onSave(payload);


### PR DESCRIPTION
…editor

The ApplicationsCard editor sent `added_at: ""` and `added_by: ""` for freshly-added rows, which made `PATCH /v1/virtual-machines/{id}` fail with `400 invalid JSON body` because Go's `time.Time` cannot decode an empty string. The server's diff path was already designed to stamp those fields server-side when absent, so the fix is to omit them entirely (and `name` / `notes` too) when the draft holds no value.

Bumps Helm chart to 0.15.1 / appVersion 0.12.1.