### PR TITLE
chore(charts): align sibling charts on appVersion 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 — the REST and database contracts may still change incompatibly before
 `v1.0.0`.
 
-## [0.12.1] — 2026-04-29
+## [0.12.1] — 2026-04-30
 
-Helm chart 0.15.1 / appVersion 0.12.1. UI hotfix for the VM applications
-editor introduced in 0.12.0.
+Helm charts realigned on `appVersion 0.12.1` across the family
+(`argos` 0.15.1, `argos-collector` 0.1.1, `argos-ingest-gw` 0.1.2,
+`argos-vm-collector` 0.1.1). UI hotfix for the VM applications editor
+introduced in 0.12.0; the collector binaries are unchanged but their
+charts bump in lockstep so `helm list` shows a single coherent
+appVersion across an Argos deployment.
 
 ### Fixed
 

--- a/charts/argos-collector/Chart.yaml
+++ b/charts/argos-collector/Chart.yaml
@@ -7,8 +7,8 @@ description: >-
   independently of the umbrella `argos` chart so the source-cluster release
   contains only what belongs in that cluster.
 type: application
-version: 0.1.0
-appVersion: "0.11.1"
+version: 0.1.1
+appVersion: "0.12.1"
 home: https://github.com/sthalbert/Argos
 sources:
   - https://github.com/sthalbert/Argos

--- a/charts/argos-ingest-gw/Chart.yaml
+++ b/charts/argos-ingest-gw/Chart.yaml
@@ -8,8 +8,8 @@ description: >-
   trusted zone. Ships independently of the umbrella `argos` chart so the
   DMZ release contains only what should be in the DMZ.
 type: application
-version: 0.1.1
-appVersion: "0.11.1"
+version: 0.1.2
+appVersion: "0.12.1"
 home: https://github.com/sthalbert/Argos
 sources:
   - https://github.com/sthalbert/Argos

--- a/charts/argos-vm-collector/Chart.yaml
+++ b/charts/argos-vm-collector/Chart.yaml
@@ -7,8 +7,8 @@ description: >-
   independently of the umbrella `argos` chart so cloud-account collector
   releases stay decoupled from the central control-plane release.
 type: application
-version: 0.1.0
-appVersion: "0.11.1"
+version: 0.1.1
+appVersion: "0.12.1"
 home: https://github.com/sthalbert/Argos
 sources:
   - https://github.com/sthalbert/Argos


### PR DESCRIPTION
`charts/argos-collector`, `charts/argos-ingest-gw`, and `charts/argos-vm-collector` were still pinned at appVersion 0.11.1 while `charts/argos` had moved to 0.12.1. Bump each sibling chart by one patch and align their appVersion so `helm list` shows a single coherent appVersion across an Argos deployment.

The collector binaries are unchanged; only the chart metadata moves.