### PR TITLE
fix(eol): match major-only cycles for products like postgresql

### DIFF
--- a/internal/eol/enricher.go
+++ b/internal/eol/enricher.go
@@ -344,8 +344,8 @@ func (e *Enricher) resolveVMApplicationAnnotation(ctx context.Context, product, 
 		return nil, fmt.Errorf("get product %s: %w", product, err)
 	}
 
-	cycleKey := extractMajorMinor(version)
-	if cycleKey == "" {
+	candidates := extractCycleCandidates(version)
+	if len(candidates) == 0 {
 		return &Annotation{
 			Product:   product,
 			Cycle:     strings.TrimSpace(version),
@@ -354,40 +354,46 @@ func (e *Enricher) resolveVMApplicationAnnotation(ctx context.Context, product, 
 		}, nil
 	}
 
-	cycle := FindCycle(cycles, cycleKey)
-	if cycle == nil {
-		return &Annotation{
-			Product:   product,
-			Cycle:     cycleKey,
-			EOLStatus: StatusUnknown,
-			CheckedAt: time.Now().UTC().Format(time.RFC3339),
-		}, nil
+	for _, cycleKey := range candidates {
+		if cycle := FindCycle(cycles, cycleKey); cycle != nil {
+			return e.buildAnnotation(MatchResult{Product: product, Cycle: cycleKey}, cycle, cycles), nil
+		}
 	}
 
-	return e.buildAnnotation(MatchResult{Product: product, Cycle: cycleKey}, cycle, cycles), nil
+	return &Annotation{
+		Product:   product,
+		Cycle:     candidates[0],
+		EOLStatus: StatusUnknown,
+		CheckedAt: time.Now().UTC().Format(time.RFC3339),
+	}, nil
 }
 
-// extractMajorMinor pulls a "X.Y" cycle string out of a free-form
-// operator-typed version. Strips a leading "v" and any "-suffix".
-// Returns "" when the input has no recognisable numeric major.minor.
-func extractMajorMinor(version string) string {
+// extractCycleCandidates derives endoflife.date cycle candidates from a
+// free-form operator-typed version, in priority order. Strips a leading
+// "v" and any "-suffix". Returns major.minor first when available, then
+// major alone — endoflife.date uses major.minor for some products
+// (vault: "1.15", kubernetes: "1.30") and major-only for others
+// (postgresql: "15", harbor: "2"), so we try the more specific match
+// first then fall back. Returns nil when the input has no recognisable
+// leading numeric component.
+func extractCycleCandidates(version string) []string {
 	v := strings.TrimSpace(version)
 	v = strings.TrimPrefix(v, "v")
 	v = strings.TrimPrefix(v, "V")
 	if v == "" {
-		return ""
+		return nil
 	}
 	if i := strings.IndexAny(v, "-+ "); i >= 0 {
 		v = v[:i]
 	}
 	parts := strings.Split(v, ".")
-	if len(parts) < 2 {
-		return ""
+	if len(parts) == 0 || !isNumeric(parts[0]) {
+		return nil
 	}
-	if !isNumeric(parts[0]) || !isNumeric(parts[1]) {
-		return ""
+	if len(parts) >= 2 && isNumeric(parts[1]) {
+		return []string{parts[0] + "." + parts[1], parts[0]}
 	}
-	return parts[0] + "." + parts[1]
+	return []string{parts[0]}
 }
 
 func isNumeric(s string) bool {

--- a/internal/eol/enricher_test.go
+++ b/internal/eol/enricher_test.go
@@ -444,6 +444,60 @@ func TestEnricherSkipsTerminatedVMs(t *testing.T) {
 	}
 }
 
+// TestEnricherMatchesMajorOnlyCycles covers products like postgresql
+// where endoflife.date publishes major-only cycles ("15", "16"). An
+// operator-declared version of "15" must match cycle "15" instead of
+// falling back to eol_status=unknown.
+func TestEnricherMatchesMajorOnlyCycles(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/postgresql.json" {
+			serveCycles(w, []Cycle{
+				{Cycle: "15", EOL: "2027-11-11", Latest: "15.10"},
+				{Cycle: "16", EOL: "2028-11-09", Latest: "16.6"},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	vmID := uuid.New()
+	store := &fakeStore{
+		eolEnabled: true,
+		vms: []api.VirtualMachine{
+			{
+				ID:   vmID,
+				Name: "pg-01",
+				Applications: []api.VMApplication{
+					{Product: "postgresql", Version: "15"},
+				},
+			},
+		},
+	}
+
+	enricher := NewEnricher(store, NewClient(srv.URL, 1*time.Hour, srv.Client()), 1*time.Hour, 90)
+	enricher.enrich(context.Background())
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	raw, ok := store.vms[0].Annotations["argos.io/eol.postgresql"]
+	if !ok {
+		t.Fatal("expected argos.io/eol.postgresql annotation")
+	}
+	var parsed Annotation
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed.Cycle != "15" {
+		t.Errorf("cycle = %q, want %q", parsed.Cycle, "15")
+	}
+	if parsed.EOLStatus == StatusUnknown {
+		t.Errorf("eol_status = unknown for major-only match; want a real status")
+	}
+}
+
 func TestMergeAnnotation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
extractMajorMinor required at least two numeric components, so a VM application declared as 'postgresql' version '15' fell through to eol_status=unknown even though endoflife.date exposes cycle '15'.

Replaced with extractCycleCandidates returning [major.minor, major] in priority order; the resolver now retries with the major-only candidate before stubbing the annotation.