### PR TITLE
chore(charts): bump charts to next patch and align appVersion 0.12.2

### DIFF
--- a/charts/argos-collector/Chart.yaml
+++ b/charts/argos-collector/Chart.yaml
@@ -7,8 +7,8 @@ description: >-
   independently of the umbrella `argos` chart so the source-cluster release
   contains only what belongs in that cluster.
 type: application
-version: 0.1.1
-appVersion: "0.12.1"
+version: 0.1.2
+appVersion: "0.12.2"
 home: https://github.com/sthalbert/Argos
 sources:
   - https://github.com/sthalbert/Argos

--- a/charts/argos-ingest-gw/Chart.yaml
+++ b/charts/argos-ingest-gw/Chart.yaml
@@ -8,8 +8,8 @@ description: >-
   trusted zone. Ships independently of the umbrella `argos` chart so the
   DMZ release contains only what should be in the DMZ.
 type: application
-version: 0.1.2
-appVersion: "0.12.1"
+version: 0.1.3
+appVersion: "0.12.2"
 home: https://github.com/sthalbert/Argos
 sources:
   - https://github.com/sthalbert/Argos

--- a/charts/argos-vm-collector/Chart.yaml
+++ b/charts/argos-vm-collector/Chart.yaml
@@ -7,8 +7,8 @@ description: >-
   independently of the umbrella `argos` chart so cloud-account collector
   releases stay decoupled from the central control-plane release.
 type: application
-version: 0.1.1
-appVersion: "0.12.1"
+version: 0.1.2
+appVersion: "0.12.2"
 home: https://github.com/sthalbert/Argos
 sources:
   - https://github.com/sthalbert/Argos

--- a/charts/argos/Chart.yaml
+++ b/charts/argos/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   A CMDB for Kubernetes environments aligned with the ANSSI SecNumCloud
   qualification framework. Polls clusters and exposes a REST API and web UI.
 type: application
-version: 0.15.1
-appVersion: "0.12.1"
+version: 0.15.2
+appVersion: "0.12.2"
 home: https://github.com/sthalbert/Argos
 sources:
   - https://github.com/sthalbert/Argos


### PR DESCRIPTION
- argos: 0.15.1 -> 0.15.2
- argos-collector: 0.1.1 -> 0.1.2
- argos-ingest-gw: 0.1.2 -> 0.1.3
- argos-vm-collector: 0.1.1 -> 0.1.2
- appVersion: 0.12.1 -> 0.12.2 (carries the eol major-only-cycle fix)