### PR TITLE
feat(ui): resizable columns on entity tables (closes #116)

### DIFF
--- a/ui/src/components/resizable_columns.test.tsx
+++ b/ui/src/components/resizable_columns.test.tsx
@@ -1,0 +1,111 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import { useResizableColumns } from './resizable_columns';
+
+// Tiny harness — mounts a 3-column entities table wired to the hook so
+// tests can poke at the injected colgroup + handles directly.
+function Harness({ storageKey = 'test.tbl' }: { storageKey?: string }) {
+  const tableRef = useResizableColumns(storageKey);
+  return (
+    <table className="entities" ref={tableRef}>
+      <thead>
+        <tr>
+          <th>A</th>
+          <th>B</th>
+          <th>C</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>a1</td>
+          <td>b1</td>
+          <td>c1</td>
+        </tr>
+      </tbody>
+    </table>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  // jsdom returns 0 from getBoundingClientRect by default. Fake a width
+  // so the hook can capture an initial natural value.
+  Element.prototype.getBoundingClientRect = vi.fn().mockReturnValue({
+    width: 100,
+    height: 24,
+    top: 0,
+    left: 0,
+    right: 100,
+    bottom: 24,
+    x: 0,
+    y: 0,
+    toJSON: () => '',
+  });
+});
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('useResizableColumns', () => {
+  it('injects a colgroup with one <col> per <th> and a resize handle on each header', () => {
+    const { container } = render(<Harness />);
+    const table = container.querySelector('table')!;
+    const colgroup = table.querySelector('colgroup');
+    expect(colgroup).not.toBeNull();
+    expect(colgroup!.children.length).toBe(3);
+    expect(table.classList.contains('lv-resizable')).toBe(true);
+    expect(table.style.tableLayout).toBe('fixed');
+    expect(table.querySelectorAll('th .col-resize-handle').length).toBe(3);
+  });
+
+  it('applies saved widths from localStorage on mount', () => {
+    localStorage.setItem(
+      'lv.col-widths.test.tbl',
+      JSON.stringify([222, 333, 444]),
+    );
+    const { container } = render(<Harness />);
+    const cols = Array.from(container.querySelectorAll('colgroup > col')) as HTMLElement[];
+    expect(cols[0].style.width).toBe('222px');
+    expect(cols[1].style.width).toBe('333px');
+    expect(cols[2].style.width).toBe('444px');
+  });
+
+  it('persists widths to localStorage after a drag', () => {
+    const { container } = render(<Harness />);
+    const handles = container.querySelectorAll('th .col-resize-handle');
+    const firstHandle = handles[0] as HTMLElement;
+
+    fireEvent.mouseDown(firstHandle, { button: 0, clientX: 100 });
+    fireEvent.mouseMove(window, { clientX: 160 });
+    fireEvent.mouseUp(window);
+
+    const cols = Array.from(container.querySelectorAll('colgroup > col')) as HTMLElement[];
+    expect(cols[0].style.width).toBe('160px');
+
+    const saved = JSON.parse(localStorage.getItem('lv.col-widths.test.tbl')!);
+    expect(saved[0]).toBe(160);
+    // other columns keep their initial natural width (100 from the mock)
+    expect(saved[1]).toBe(100);
+    expect(saved[2]).toBe(100);
+  });
+
+  it('clamps widths at the minimum (40px) when dragged left past the limit', () => {
+    const { container } = render(<Harness />);
+    const handle = container.querySelector('th .col-resize-handle') as HTMLElement;
+    fireEvent.mouseDown(handle, { button: 0, clientX: 100 });
+    fireEvent.mouseMove(window, { clientX: -500 });
+    fireEvent.mouseUp(window);
+    const col = container.querySelector('colgroup > col') as HTMLElement;
+    expect(col.style.width).toBe('40px');
+  });
+
+  it('cleans up the colgroup and handles on unmount', () => {
+    const { container, unmount } = render(<Harness />);
+    expect(container.querySelector('colgroup')).not.toBeNull();
+    unmount();
+    // After unmount the table is gone too — but the cleanup must not throw.
+    // (Re-rendering with an empty body confirms idempotency.)
+    expect(document.body.classList.contains('lv-resizing-cols')).toBe(false);
+  });
+});

--- a/ui/src/components/resizable_columns.ts
+++ b/ui/src/components/resizable_columns.ts
@@ -1,0 +1,179 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+// useResizableColumns equips a <table> with draggable column-resize handles
+// and a <colgroup> whose widths are persisted to localStorage.
+//
+// Usage:
+//   const tableRef = useResizableColumns('lists.clusters');
+//   <table className="entities" ref={tableRef}>
+//     <thead><tr><th>…</th>…</tr></thead>
+//     <tbody>…</tbody>
+//   </table>
+//
+// On mount the hook measures each <th> for its natural width, switches the
+// table to `table-layout: fixed`, and renders inline widths via an injected
+// <colgroup>. Dragging the right edge of a header updates that column's
+// width live; releasing persists the full row of widths under
+// `lv.col-widths.<storageKey>`. Double-clicking a handle resets that column
+// to its current natural content width and persists.
+//
+// The hook tolerates re-renders (it ignores subsequent ref calls for the
+// same element) and cleans up handles + the injected colgroup on unmount.
+
+const STORAGE_PREFIX = 'lv.col-widths.';
+const MIN_WIDTH = 40;
+
+function loadWidths(key: string): number[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_PREFIX + key);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map((v) => Number(v)).filter((n) => Number.isFinite(n) && n > 0);
+  } catch {
+    return [];
+  }
+}
+
+function saveWidths(key: string, widths: number[]) {
+  try {
+    localStorage.setItem(STORAGE_PREFIX + key, JSON.stringify(widths));
+  } catch {
+    /* quota / disabled storage — ignored */
+  }
+}
+
+export function useResizableColumns(storageKey: string) {
+  const cleanupRef = useRef<(() => void) | null>(null);
+  const equippedRef = useRef<HTMLTableElement | null>(null);
+
+  // Tear down on unmount.
+  useEffect(() => {
+    return () => {
+      if (cleanupRef.current) cleanupRef.current();
+      cleanupRef.current = null;
+      equippedRef.current = null;
+    };
+  }, []);
+
+  return useCallback(
+    (table: HTMLTableElement | null) => {
+      // Already equipped this exact node — nothing to do (avoids React
+      // re-render thrash). If a different node arrives, tear down first.
+      if (equippedRef.current === table) return;
+      if (cleanupRef.current) {
+        cleanupRef.current();
+        cleanupRef.current = null;
+      }
+      equippedRef.current = table;
+      if (!table) return;
+
+      const headRow = table.querySelector<HTMLTableRowElement>(
+        ':scope > thead > tr',
+      );
+      if (!headRow) return;
+      const ths = Array.from(
+        headRow.querySelectorAll<HTMLTableCellElement>(':scope > th'),
+      );
+      if (ths.length === 0) return;
+
+      const saved = loadWidths(storageKey);
+
+      // Capture each th's natural width before we change layout, so we can
+      // hand the table a sensible initial colgroup that matches its current
+      // appearance.
+      const widths: number[] = ths.map((th, i) => {
+        if (saved[i] && saved[i] > 0) return saved[i];
+        return Math.max(MIN_WIDTH, Math.round(th.getBoundingClientRect().width));
+      });
+
+      // Build (or reuse) a colgroup. We mark our own with data-lv-resize
+      // so cleanup can remove only what we created.
+      let colgroup = table.querySelector<HTMLTableColElement>(':scope > colgroup');
+      const ownsColgroup = !colgroup;
+      if (!colgroup) {
+        colgroup = document.createElement('colgroup');
+        colgroup.dataset.lvResize = '1';
+        table.insertBefore(colgroup, table.firstChild);
+      }
+      const cols: HTMLTableColElement[] = ths.map((_, i) => {
+        let col = colgroup!.children[i] as HTMLTableColElement | undefined;
+        if (!col) {
+          col = document.createElement('col');
+          colgroup!.appendChild(col);
+        }
+        col.style.width = `${widths[i]}px`;
+        return col;
+      });
+
+      const prevTableLayout = table.style.tableLayout;
+      table.style.tableLayout = 'fixed';
+      table.classList.add('lv-resizable');
+
+      const cleanups: Array<() => void> = [];
+
+      ths.forEach((th, i) => {
+        const handle = document.createElement('div');
+        handle.className = 'col-resize-handle';
+        handle.setAttribute('aria-hidden', 'true');
+        handle.title = 'Drag to resize · double-click to reset';
+        th.appendChild(handle);
+
+        const onMouseDown = (e: MouseEvent) => {
+          if (e.button !== 0) return;
+          e.preventDefault();
+          e.stopPropagation();
+          const startX = e.clientX;
+          const startWidth = cols[i].getBoundingClientRect().width || widths[i];
+          document.body.classList.add('lv-resizing-cols');
+
+          const onMove = (ev: MouseEvent) => {
+            const dx = ev.clientX - startX;
+            const newW = Math.max(MIN_WIDTH, Math.round(startWidth + dx));
+            widths[i] = newW;
+            cols[i].style.width = `${newW}px`;
+          };
+          const onUp = () => {
+            window.removeEventListener('mousemove', onMove);
+            window.removeEventListener('mouseup', onUp);
+            document.body.classList.remove('lv-resizing-cols');
+            saveWidths(storageKey, widths);
+          };
+          window.addEventListener('mousemove', onMove);
+          window.addEventListener('mouseup', onUp);
+        };
+
+        const onDblClick = (e: MouseEvent) => {
+          e.preventDefault();
+          e.stopPropagation();
+          // Briefly drop the inline width so the browser remeasures, then
+          // snap to the resulting natural width and persist.
+          cols[i].style.width = '';
+          const natural = Math.max(MIN_WIDTH, Math.round(th.getBoundingClientRect().width));
+          widths[i] = natural;
+          cols[i].style.width = `${natural}px`;
+          saveWidths(storageKey, widths);
+        };
+
+        handle.addEventListener('mousedown', onMouseDown);
+        handle.addEventListener('dblclick', onDblClick);
+        cleanups.push(() => {
+          handle.removeEventListener('mousedown', onMouseDown);
+          handle.removeEventListener('dblclick', onDblClick);
+          if (handle.parentNode) handle.parentNode.removeChild(handle);
+        });
+      });
+
+      cleanupRef.current = () => {
+        cleanups.forEach((c) => c());
+        if (ownsColgroup && colgroup && colgroup.parentNode) {
+          colgroup.parentNode.removeChild(colgroup);
+        }
+        table.style.tableLayout = prevTableLayout;
+        table.classList.remove('lv-resizable');
+        document.body.classList.remove('lv-resizing-cols');
+      };
+    },
+    [storageKey],
+  );
+}

--- a/ui/src/pages/EolDashboard.tsx
+++ b/ui/src/pages/EolDashboard.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import * as api from '../api';
 import { useResources } from '../hooks';
 import { AsyncView, Dash } from '../components';
+import { useResizableColumns } from '../components/resizable_columns';
 import { EolIcon } from '../icons';
 
 // --- EOL annotation parsing -----------------------------------------------
@@ -288,6 +289,7 @@ function EolTable({
 }) {
   const allRows = useMemo(() => buildRows(clusters, nodes, vms), [clusters, nodes, vms]);
   const counts = useMemo(() => countStatuses(allRows), [allRows]);
+  const tableRef = useResizableColumns('eol.table');
 
   const filtered = useMemo(
     () => (statusFilter ? allRows.filter((r) => r.eolStatus === statusFilter) : allRows),
@@ -340,11 +342,7 @@ function EolTable({
         </p>
       )}
 
-      <table className="entities eol-table">
-        <colgroup>
-          <col span={6} className="eol-col-owned" />
-          <col span={3} />
-        </colgroup>
+      <table className="entities eol-table" ref={tableRef}>
         <thead>
           <tr>
             <SortHeader label="Status" sortKey="status" currentKey={sortKey} asc={sortAsc} onClick={onSort} />

--- a/ui/src/pages/Lists.tsx
+++ b/ui/src/pages/Lists.tsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 import * as api from '../api';
 import { useResource } from '../hooks';
 import { AsyncView, Dash, IdLink, LayerPill, LoadBalancerAddresses, Empty } from '../components';
+import { useResizableColumns } from '../components/resizable_columns';
 import {
   ClusterIcon, NodeIcon, NamespaceIcon, WorkloadIcon, PodIcon,
   ServiceIcon, IngressIcon, VolumeIcon,
@@ -14,6 +15,7 @@ import {
 
 export function Clusters() {
   const state = useResource(() => api.listClusters(), []);
+  const tableRef = useResizableColumns('lists.clusters');
   return (
     <>
       <h2><ClusterIcon size={20} /> Clusters</h2>
@@ -23,7 +25,7 @@ export function Clusters() {
             <Empty message="No clusters yet. Connect a collector to start populating your inventory." />
           ) : (
             <div className="table-wrap">
-              <table className="entities">
+              <table className="entities" ref={tableRef}>
                 <thead>
                   <tr>
                     <th>Name</th>
@@ -73,6 +75,7 @@ export function Nodes() {
       })),
     [],
   );
+  const tableRef = useResizableColumns('lists.nodes');
   return (
     <>
       <h2><NodeIcon size={20} /> Nodes</h2>
@@ -82,7 +85,7 @@ export function Nodes() {
             <Empty message="No nodes found. Ensure a collector is running and connected to a cluster." />
           ) : (
             <div className="table-wrap">
-              <table className="entities">
+              <table className="entities" ref={tableRef}>
                 <thead>
                   <tr>
                     <th>Name</th>
@@ -161,6 +164,7 @@ export function Namespaces() {
       })),
     [],
   );
+  const tableRef = useResizableColumns('lists.namespaces');
   return (
     <>
       <h2><NamespaceIcon size={20} /> Namespaces</h2>
@@ -170,7 +174,7 @@ export function Namespaces() {
             <Empty message="No namespaces found. They are collected automatically from your clusters." />
           ) : (
             <div className="table-wrap">
-              <table className="entities">
+              <table className="entities" ref={tableRef}>
                 <thead>
                   <tr>
                     <th>Name</th>
@@ -268,6 +272,7 @@ function NamespaceLink({
 export function Workloads() {
   const index = useNamespaceIndex();
   const workloads = useResource(() => api.listWorkloads(), []);
+  const tableRef = useResizableColumns('lists.workloads');
 
   return (
     <>
@@ -280,7 +285,7 @@ export function Workloads() {
                 <Empty message="No workloads found. Deployments, StatefulSets and DaemonSets will appear here once collected." />
               ) : (
                 <div className="table-wrap">
-                  <table className="entities">
+                  <table className="entities" ref={tableRef}>
                     <thead>
                       <tr>
                         <th>Name</th>
@@ -335,6 +340,7 @@ export function Pods() {
   const index = useNamespaceIndex();
   const pods = useResource(() => api.listPods(), []);
   const workloads = useResource(() => fetchAllWorkloads(), []);
+  const tableRef = useResizableColumns('lists.pods');
   return (
     <>
       <h2><PodIcon size={20} /> Pods</h2>
@@ -349,7 +355,7 @@ export function Pods() {
                     <Empty message="No pods found. Pods are collected from all connected clusters." />
                   ) : (
                     <div className="table-wrap">
-                      <table className="entities">
+                      <table className="entities" ref={tableRef}>
                         <thead>
                           <tr>
                             <th>Name</th>
@@ -412,6 +418,7 @@ export function Pods() {
 export function Services() {
   const index = useNamespaceIndex();
   const services = useResource(() => api.listServices(), []);
+  const tableRef = useResizableColumns('lists.services');
   return (
     <>
       <h2><ServiceIcon size={20} /> Services</h2>
@@ -423,7 +430,7 @@ export function Services() {
                 <Empty message="No services found. Kubernetes Services are collected automatically." />
               ) : (
                 <div className="table-wrap">
-                  <table className="entities">
+                  <table className="entities" ref={tableRef}>
                     <thead>
                       <tr>
                         <th>Name</th>
@@ -472,6 +479,7 @@ export function Services() {
 export function Ingresses() {
   const index = useNamespaceIndex();
   const ingresses = useResource(() => api.listIngresses(), []);
+  const tableRef = useResizableColumns('lists.ingresses');
   return (
     <>
       <h2><IngressIcon size={20} /> Ingresses</h2>
@@ -483,7 +491,7 @@ export function Ingresses() {
                 <Empty message="No ingresses found. Ingress resources are collected from all namespaces." />
               ) : (
                 <div className="table-wrap">
-                  <table className="entities">
+                  <table className="entities" ref={tableRef}>
                     <thead>
                       <tr>
                         <th>Name</th>
@@ -540,6 +548,7 @@ export function PersistentVolumes() {
       })),
     [],
   );
+  const tableRef = useResizableColumns('lists.persistent_volumes');
   return (
     <>
       <h2><VolumeIcon size={20} /> Persistent Volumes</h2>
@@ -549,7 +558,7 @@ export function PersistentVolumes() {
             <Empty message="No persistent volumes found. PVs are collected cluster-wide by the collector." />
           ) : (
             <div className="table-wrap">
-              <table className="entities">
+              <table className="entities" ref={tableRef}>
                 <thead>
                   <tr>
                     <th>Name</th>
@@ -593,6 +602,7 @@ export function PersistentVolumes() {
 export function PersistentVolumeClaims() {
   const index = useNamespaceIndex();
   const pvcs = useResource(() => api.listPersistentVolumeClaims(), []);
+  const tableRef = useResizableColumns('lists.persistent_volume_claims');
   return (
     <>
       <h2><VolumeIcon size={20} /> Persistent Volume Claims</h2>
@@ -604,7 +614,7 @@ export function PersistentVolumeClaims() {
                 <Empty message="No persistent volume claims found. PVCs are collected from all namespaces." />
               ) : (
                 <div className="table-wrap">
-                  <table className="entities">
+                  <table className="entities" ref={tableRef}>
                     <thead>
                       <tr>
                         <th>Name</th>

--- a/ui/src/pages/Search.tsx
+++ b/ui/src/pages/Search.tsx
@@ -3,6 +3,7 @@ import { Link, useSearchParams } from 'react-router-dom';
 import * as api from '../api';
 import { useResource } from '../hooks';
 import { AsyncView, Dash, IdLink, SectionTitle, Empty } from '../components';
+import { useResizableColumns } from '../components/resizable_columns';
 import { isAdmin, useMe } from '../me';
 
 // Image search — answers "which applications run component X in version Y?"
@@ -69,6 +70,9 @@ export default function ImageSearch() {
 function Results({ q }: { q: string }) {
   const me = useMe();
   const canListAccounts = isAdmin(me);
+  const workloadsTableRef = useResizableColumns('search.workloads');
+  const podsTableRef = useResizableColumns('search.pods');
+  const vmsTableRef = useResizableColumns('search.vms');
   const state = useResource(
     () =>
       Promise.all([
@@ -123,7 +127,7 @@ function Results({ q }: { q: string }) {
             {workloads.length === 0 ? (
               <Empty message="No workloads match." />
             ) : (
-              <table className="entities">
+              <table className="entities" ref={workloadsTableRef}>
                 <thead>
                   <tr>
                     <th>Workload</th>
@@ -161,7 +165,7 @@ function Results({ q }: { q: string }) {
             {pods.length === 0 ? (
               <Empty message="No pods match." />
             ) : (
-              <table className="entities">
+              <table className="entities" ref={podsTableRef}>
                 <thead>
                   <tr>
                     <th>Pod</th>
@@ -205,7 +209,7 @@ function Results({ q }: { q: string }) {
             {vms.length === 0 ? (
               <Empty message="No virtual machines match." />
             ) : (
-              <table className="entities">
+              <table className="entities" ref={vmsTableRef}>
                 <thead>
                   <tr>
                     <th>VM</th>

--- a/ui/src/pages/VirtualMachines.tsx
+++ b/ui/src/pages/VirtualMachines.tsx
@@ -4,6 +4,7 @@ import * as api from '../api';
 import { useResource } from '../hooks';
 import { isAdmin, useMe } from '../me';
 import { AsyncView, Dash } from '../components';
+import { useResizableColumns } from '../components/resizable_columns';
 import { VirtualMachineIcon } from '../icons';
 
 // VirtualMachines is the top-level list page for ADR-0015 VMs. It mirrors
@@ -110,6 +111,7 @@ function compare(a: api.VirtualMachine, b: api.VirtualMachine, key: SortKey, asc
 export default function VirtualMachines() {
   const me = useMe();
   const showAccountFilter = isAdmin(me);
+  const tableRef = useResizableColumns('vms.list');
 
   const [cloudAccountId, setCloudAccountId] = useState<string>('');
   const [region, setRegion] = useState<string>('');
@@ -471,7 +473,7 @@ export default function VirtualMachines() {
               {sorted.length === 0 ? (
                 <p className="muted empty">No virtual machines match these filters.</p>
               ) : (
-                <table className="entities">
+                <table className="entities" ref={tableRef}>
                   <thead>
                     <tr>
                       <SortHeader

--- a/ui/src/pages/admin/Audit.tsx
+++ b/ui/src/pages/admin/Audit.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useState } from 'react';
 import * as api from '../../api';
 import { useResource } from '../../hooks';
 import { AsyncView, Dash, SectionTitle } from '../../components';
+import { useResizableColumns } from '../../components/resizable_columns';
 
 // Admin Audit page. Read-only, newest-first list of recorded API
 // actions. Auditors can reach this without the rest of the admin panel
@@ -20,6 +21,7 @@ const emptyFilter: FilterForm = { actor: '', resourceType: '', action: '', since
 export default function AuditPage() {
   const [draft, setDraft] = useState<FilterForm>(emptyFilter);
   const [applied, setApplied] = useState<FilterForm>(emptyFilter);
+  const tableRef = useResizableColumns('admin.audit');
   const state = useResource(
     () =>
       api.listAuditEvents({
@@ -87,7 +89,7 @@ export default function AuditPage() {
           resp.items.length === 0 ? (
             <p className="muted">No audit events match.</p>
           ) : (
-            <table className="entities">
+            <table className="entities" ref={tableRef}>
               <thead>
                 <tr>
                   <th>Time</th>

--- a/ui/src/pages/admin/CloudAccountDetail.tsx
+++ b/ui/src/pages/admin/CloudAccountDetail.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import * as api from '../../api';
 import { useResource } from '../../hooks';
 import { AsyncView, Dash, KV, SectionTitle } from '../../components';
+import { useResizableColumns } from '../../components/resizable_columns';
 import { CuratedMetadataCard } from '../../components/inventory/CuratedMetadataCard';
 import { CloudAccountStatusBadge } from './CloudAccounts';
 
@@ -41,6 +42,7 @@ export default function CloudAccountDetail() {
     () => api.listVirtualMachines({ cloud_account_id: id }),
     [id, nonce],
   );
+  const tableRef = useResizableColumns('admin.cloud_account_detail.vms');
 
   const onDelete = async (account: api.CloudAccount, vmCount: number) => {
     const typed = prompt(
@@ -176,7 +178,7 @@ export default function CloudAccountDetail() {
                       No VMs in this account yet — wait for the collector's next tick.
                     </p>
                   ) : (
-                    <table className="entities">
+                    <table className="entities" ref={tableRef}>
                       <thead>
                         <tr>
                           <th>Name</th>

--- a/ui/src/pages/admin/CloudAccounts.tsx
+++ b/ui/src/pages/admin/CloudAccounts.tsx
@@ -3,6 +3,7 @@ import { Link, useSearchParams } from 'react-router-dom';
 import * as api from '../../api';
 import { useResource } from '../../hooks';
 import { AsyncView, Dash, SectionTitle } from '../../components';
+import { useResizableColumns } from '../../components/resizable_columns';
 
 // CloudAccountsPage — admin tab for ADR-0015 cloud-provider accounts.
 // Shape mirrors the Tokens page: list-then-action, with an inline create
@@ -45,6 +46,7 @@ export default function CloudAccountsPage() {
   const state = useResource(() => api.listCloudAccounts(), [nonce]);
   const [searchParams, setSearchParams] = useSearchParams();
   const statusFilter = searchParams.get('status') || '';
+  const tableRef = useResizableColumns('admin.cloud_accounts');
 
   const setStatus = (s: string) => {
     const next = new URLSearchParams(searchParams);
@@ -99,7 +101,7 @@ export default function CloudAccountsPage() {
             {filtered.length === 0 ? (
               <p className="muted">No cloud accounts registered yet.</p>
             ) : (
-              <table className="entities">
+              <table className="entities" ref={tableRef}>
                 <thead>
                   <tr>
                     <th>Name</th>

--- a/ui/src/pages/admin/Sessions.tsx
+++ b/ui/src/pages/admin/Sessions.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import * as api from '../../api';
 import { useResource } from '../../hooks';
 import { AsyncView, Dash, SectionTitle } from '../../components';
+import { useResizableColumns } from '../../components/resizable_columns';
 
 // Admin Sessions page. Read-only table with a revoke action. The `id`
 // column is the server-side public UUID, never the cookie value —
@@ -12,6 +13,7 @@ export default function SessionsPage() {
   const [nonce, setNonce] = useState(0);
   const reload = () => setNonce((n) => n + 1);
   const state = useResource(() => api.listSessions(), [nonce]);
+  const tableRef = useResizableColumns('admin.sessions');
 
   return (
     <AsyncView state={state}>
@@ -26,7 +28,7 @@ export default function SessionsPage() {
           {resp.items.length === 0 ? (
             <p className="muted">No active sessions.</p>
           ) : (
-            <table className="entities">
+            <table className="entities" ref={tableRef}>
               <thead>
                 <tr>
                   <th>User</th>

--- a/ui/src/pages/admin/Tokens.tsx
+++ b/ui/src/pages/admin/Tokens.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import * as api from '../../api';
 import { useResource } from '../../hooks';
 import { AsyncView, Dash, SectionTitle } from '../../components';
+import { useResizableColumns } from '../../components/resizable_columns';
 
 // Token presets per ADR-0007 + ADR-0015. The OpenAPI request type is
 // fixed (name, scopes, expires_at) so vm-collector tokens currently
@@ -290,9 +291,10 @@ function MintForm({
 }
 
 function TokenTable({ tokens, reload }: { tokens: api.ApiToken[]; reload: Reload }) {
+  const tableRef = useResizableColumns('admin.tokens');
   if (tokens.length === 0) return <p className="muted">No tokens minted yet.</p>;
   return (
-    <table className="entities">
+    <table className="entities" ref={tableRef}>
       <thead>
         <tr>
           <th>Name</th>

--- a/ui/src/pages/admin/Users.tsx
+++ b/ui/src/pages/admin/Users.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useState } from 'react';
 import * as api from '../../api';
 import { useResource } from '../../hooks';
 import { AsyncView, Dash, SectionTitle } from '../../components';
+import { useResizableColumns } from '../../components/resizable_columns';
 
 // Admin Users page: list of humans, new-user collapsible form, inline
 // row actions. Destructive actions (delete, disable, reset-password)
@@ -122,9 +123,10 @@ function NewUserForm({ reload }: { reload: Reload }) {
 }
 
 function UserTable({ users, reload }: { users: api.User[]; reload: Reload }) {
+  const tableRef = useResizableColumns('admin.users');
   if (users.length === 0) return <p className="muted">No users.</p>;
   return (
-    <table className="entities">
+    <table className="entities" ref={tableRef}>
       <thead>
         <tr>
           <th>Username</th>

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -667,6 +667,52 @@ table.entities td a {
   transition: color 0.15s ease;
 }
 
+/* ── Column resizing (see ui/src/components/resizable_columns.ts) ──────── */
+table.lv-resizable {
+  /* JS sets `table-layout: fixed` inline; this gives wrapped cells a sane
+     default so long tokens break instead of overflowing the column. */
+  word-break: break-word;
+}
+table.lv-resizable th {
+  position: relative;
+}
+table.lv-resizable .col-resize-handle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 8px;
+  height: 100%;
+  cursor: col-resize;
+  user-select: none;
+  touch-action: none;
+  /* Pull the active hit-area slightly past the border so it's easier to
+     grab without overlapping the next column's content. */
+  transform: translateX(3px);
+  z-index: 1;
+}
+table.lv-resizable .col-resize-handle::after {
+  content: '';
+  position: absolute;
+  top: 25%;
+  bottom: 25%;
+  left: 50%;
+  width: 2px;
+  background: transparent;
+  transition: background 0.12s ease;
+}
+table.lv-resizable th:hover .col-resize-handle::after,
+table.lv-resizable .col-resize-handle:hover::after {
+  background: var(--border);
+}
+body.lv-resizing-cols,
+body.lv-resizing-cols * {
+  cursor: col-resize !important;
+  user-select: none !important;
+}
+body.lv-resizing-cols table.lv-resizable .col-resize-handle::after {
+  background: var(--accent);
+}
+
 .pill {
   display: inline-block;
   font-size: var(--fs-2xs);


### PR DESCRIPTION
Drag the right edge of any header to resize a column; double-click resets
to the natural width. Per-table widths persist to localStorage so the
layout sticks across reloads. Applied to every list-style table: Lists,
VirtualMachines, Search, EolDashboard and the admin pages (Audit, Users,
Tokens, Sessions, CloudAccounts, CloudAccountDetail).