### PR TITLE
feat(ui): resizable + per-column-value filters on entity tables

### DIFF
--- a/ui/src/components/column_filters.test.tsx
+++ b/ui/src/components/column_filters.test.tsx
@@ -1,0 +1,163 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import { useColumnFilters } from './column_filters';
+
+// 3-column test table with three rows. Phase has two distinct values
+// (running / pending), Cluster has three (a / b / c).
+function Harness({ storageKey = 'test.cf' }: { storageKey?: string }) {
+  const tableRef = useColumnFilters(storageKey);
+  return (
+    <table ref={tableRef}>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Phase</th>
+          <th>Cluster</th>
+          <th style={{ textAlign: 'right' }}>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr data-testid="r1">
+          <td>alpha</td>
+          <td>running</td>
+          <td>a</td>
+          <td>
+            <button>edit</button>
+          </td>
+        </tr>
+        <tr data-testid="r2">
+          <td>beta</td>
+          <td>pending</td>
+          <td>b</td>
+          <td>
+            <button>edit</button>
+          </td>
+        </tr>
+        <tr data-testid="r3">
+          <td>gamma</td>
+          <td>running</td>
+          <td>c</td>
+          <td>
+            <button>edit</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+afterEach(() => {
+  cleanup();
+  // Any leftover popover should be removed automatically by hook cleanup;
+  // belt and braces in case a test fails mid-way.
+  document
+    .querySelectorAll('.col-filter-popover')
+    .forEach((el) => el.remove());
+  vi.restoreAllMocks();
+});
+
+function getRow(container: HTMLElement, id: string) {
+  return container.querySelector<HTMLTableRowElement>(
+    `[data-testid="${id}"]`,
+  )!;
+}
+
+describe('useColumnFilters', () => {
+  it('adds a filter button to every non-action header', () => {
+    const { container } = render(<Harness />);
+    const ths = container.querySelectorAll('thead > tr > th');
+    expect(ths[0].querySelector('.col-filter-btn')).not.toBeNull();
+    expect(ths[1].querySelector('.col-filter-btn')).not.toBeNull();
+    expect(ths[2].querySelector('.col-filter-btn')).not.toBeNull();
+    // Right-aligned action column is skipped.
+    expect(ths[3].querySelector('.col-filter-btn')).toBeNull();
+  });
+
+  it('opens a popover with the column\'s distinct values when the funnel is clicked', () => {
+    const { container } = render(<Harness />);
+    const phaseBtn = container
+      .querySelectorAll('thead > tr > th')[1]
+      .querySelector('.col-filter-btn') as HTMLElement;
+    fireEvent.click(phaseBtn);
+    const pop = document.querySelector('.col-filter-popover')!;
+    const labels = Array.from(
+      pop.querySelectorAll<HTMLElement>('.col-filter-popover-label'),
+    ).map((el) => el.textContent);
+    expect(labels.sort()).toEqual(['pending', 'running']);
+  });
+
+  it('hides rows whose value is unchecked and persists the selection', () => {
+    const { container } = render(<Harness />);
+    const phaseBtn = container
+      .querySelectorAll('thead > tr > th')[1]
+      .querySelector('.col-filter-btn') as HTMLElement;
+    fireEvent.click(phaseBtn);
+    const pop = document.querySelector('.col-filter-popover')!;
+    const checkboxes = Array.from(
+      pop.querySelectorAll<HTMLInputElement>('input[type=checkbox]'),
+    );
+    // Find the "pending" checkbox (sibling label text)
+    const pendingCb = checkboxes.find(
+      (cb) =>
+        cb.parentElement?.querySelector('.col-filter-popover-label')
+          ?.textContent === 'pending',
+    )!;
+    fireEvent.click(pendingCb);
+
+    expect(getRow(container, 'r1').style.display).toBe('');
+    expect(getRow(container, 'r2').style.display).toBe('none');
+    expect(getRow(container, 'r3').style.display).toBe('');
+
+    const saved = JSON.parse(localStorage.getItem('lv.col-filters.test.cf')!);
+    expect(saved['1']).toEqual(['running']);
+
+    // Funnel button now shows active state.
+    expect(phaseBtn.classList.contains('col-filter-active')).toBe(true);
+  });
+
+  it('restores hidden rows on mount when a stored filter exists', () => {
+    localStorage.setItem(
+      'lv.col-filters.test.cf',
+      JSON.stringify({ '2': ['a'] }),
+    );
+    const { container } = render(<Harness />);
+    expect(getRow(container, 'r1').style.display).toBe('');
+    expect(getRow(container, 'r2').style.display).toBe('none');
+    expect(getRow(container, 'r3').style.display).toBe('none');
+  });
+
+  it('"All" reverts to no filter and unhides every row', () => {
+    localStorage.setItem(
+      'lv.col-filters.test.cf',
+      JSON.stringify({ '1': ['running'] }),
+    );
+    const { container } = render(<Harness />);
+    expect(getRow(container, 'r2').style.display).toBe('none');
+    const phaseBtn = container
+      .querySelectorAll('thead > tr > th')[1]
+      .querySelector('.col-filter-btn') as HTMLElement;
+    fireEvent.click(phaseBtn);
+    const allBtn = document.querySelector(
+      '.col-filter-popover-actions .link-btn',
+    ) as HTMLButtonElement;
+    fireEvent.click(allBtn);
+    expect(getRow(container, 'r1').style.display).toBe('');
+    expect(getRow(container, 'r2').style.display).toBe('');
+    expect(getRow(container, 'r3').style.display).toBe('');
+    expect(localStorage.getItem('lv.col-filters.test.cf')).toBeNull();
+  });
+
+  it('cleans up popover on unmount and restores all row visibility', () => {
+    const { container, unmount } = render(<Harness />);
+    const phaseBtn = container
+      .querySelectorAll('thead > tr > th')[1]
+      .querySelector('.col-filter-btn') as HTMLElement;
+    fireEvent.click(phaseBtn);
+    expect(document.querySelector('.col-filter-popover')).not.toBeNull();
+    unmount();
+    expect(document.querySelector('.col-filter-popover')).toBeNull();
+  });
+});

--- a/ui/src/components/column_filters.ts
+++ b/ui/src/components/column_filters.ts
@@ -1,0 +1,379 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useResizableColumns as useResizableColumnsImpl } from './resizable_columns';
+
+// useColumnFilters equips a <table> with per-column "filter values" pickers.
+//
+// Usage:
+//   const filterRef = useColumnFilters('lists.clusters');
+//   <table className="entities" ref={filterRef}> … </table>
+//
+// On mount the hook walks the header row and appends a small funnel button
+// to each <th> (skipping right-aligned action columns and any th carrying
+// `data-no-filter`). Clicking the button opens a popover that lists the
+// distinct trimmed text values currently rendered in that column's cells;
+// each value is a checkbox. Toggling a value hides every row whose cell
+// text in that column does not match the surviving set. Multiple columns
+// AND together. Selections persist under `lv.col-filters.<storageKey>`.
+//
+// The hook re-applies its filter whenever React swaps rows under <tbody>
+// (via a MutationObserver), so refetches and sort changes don't lose the
+// active filter. Plays nicely alongside useResizableColumns — the funnel
+// sits inline in the header, the resize handle hugs the right edge.
+
+const STORAGE_PREFIX = 'lv.col-filters.';
+const FILTER_ICON_SVG =
+  '<svg viewBox="0 0 16 16" width="11" height="11" fill="currentColor" aria-hidden="true">' +
+  '<path d="M1.5 2.5a.5.5 0 0 1 .5-.5h12a.5.5 0 0 1 .4.8L10 9.1V13a.5.5 0 0 1-.8.4l-2-1.4a.5.5 0 0 1-.2-.4V9.1L1.6 3.3A.5.5 0 0 1 1.5 2.5z"/>' +
+  '</svg>';
+
+type FilterMap = Record<string, string[]>;
+
+function loadFilters(key: string): FilterMap {
+  try {
+    const raw = localStorage.getItem(STORAGE_PREFIX + key);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const out: FilterMap = {};
+      for (const [k, v] of Object.entries(parsed)) {
+        if (Array.isArray(v)) out[k] = v.map(String);
+      }
+      return out;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+function saveFilters(key: string, filters: FilterMap) {
+  try {
+    if (Object.keys(filters).length === 0) {
+      localStorage.removeItem(STORAGE_PREFIX + key);
+    } else {
+      localStorage.setItem(STORAGE_PREFIX + key, JSON.stringify(filters));
+    }
+  } catch {
+    /* quota / disabled storage — ignored */
+  }
+}
+
+function cellText(cell: Element | null | undefined): string {
+  return ((cell?.textContent) || '').trim().replace(/\s+/g, ' ');
+}
+
+function applyFilters(table: HTMLTableElement, filters: FilterMap) {
+  const tbody = table.querySelector<HTMLTableSectionElement>(':scope > tbody');
+  if (!tbody) return;
+  const rows = Array.from(tbody.querySelectorAll<HTMLTableRowElement>(':scope > tr'));
+  const activeIdx = Object.keys(filters)
+    .map(Number)
+    .filter((i) => Number.isInteger(i) && Array.isArray(filters[String(i)]));
+  if (activeIdx.length === 0) {
+    rows.forEach((r) => {
+      r.style.display = '';
+    });
+    return;
+  }
+  rows.forEach((r) => {
+    let show = true;
+    for (const i of activeIdx) {
+      const allowed = filters[String(i)];
+      const text = cellText(r.children[i]);
+      if (!allowed.includes(text)) {
+        show = false;
+        break;
+      }
+    }
+    r.style.display = show ? '' : 'none';
+  });
+}
+
+let openPopover: { el: HTMLDivElement; cleanup: () => void } | null = null;
+
+function closePopover() {
+  if (openPopover) {
+    openPopover.cleanup();
+    openPopover.el.remove();
+    openPopover = null;
+  }
+}
+
+function buildPopover(
+  table: HTMLTableElement,
+  colIdx: number,
+  anchor: HTMLElement,
+  filters: FilterMap,
+  storageKey: string,
+  onAfterChange: () => void,
+) {
+  // Distinct text values currently in this column.
+  const tbody = table.querySelector<HTMLTableSectionElement>(':scope > tbody');
+  const valueSet = new Set<string>();
+  if (tbody) {
+    tbody.querySelectorAll<HTMLTableRowElement>(':scope > tr').forEach((r) => {
+      valueSet.add(cellText(r.children[colIdx]));
+    });
+  }
+  const values = Array.from(valueSet).sort((a, b) => a.localeCompare(b));
+
+  const stored = filters[String(colIdx)];
+  // Working set tracks which values are currently kept. If no filter was
+  // saved, treat that as "all kept" so toggling a checkbox reveals an
+  // explicit selection (everything-but-this).
+  const kept = new Set<string>(stored ?? values);
+
+  const pop = document.createElement('div');
+  pop.className = 'col-filter-popover';
+  pop.setAttribute('role', 'dialog');
+  pop.addEventListener('mousedown', (e) => e.stopPropagation());
+
+  const head = document.createElement('div');
+  head.className = 'col-filter-popover-head';
+  const title = document.createElement('span');
+  title.className = 'col-filter-popover-title';
+  title.textContent = `Filter · ${values.length} value${values.length === 1 ? '' : 's'}`;
+  const actions = document.createElement('div');
+  actions.className = 'col-filter-popover-actions';
+  const allBtn = document.createElement('button');
+  allBtn.type = 'button';
+  allBtn.className = 'link-btn';
+  allBtn.textContent = 'All';
+  const noneBtn = document.createElement('button');
+  noneBtn.type = 'button';
+  noneBtn.className = 'link-btn';
+  noneBtn.textContent = 'None';
+  actions.appendChild(allBtn);
+  actions.appendChild(noneBtn);
+  head.appendChild(title);
+  head.appendChild(actions);
+  pop.appendChild(head);
+
+  const list = document.createElement('div');
+  list.className = 'col-filter-popover-list';
+  pop.appendChild(list);
+
+  const persist = () => {
+    if (kept.size === values.length) {
+      delete filters[String(colIdx)];
+    } else {
+      filters[String(colIdx)] = Array.from(kept);
+    }
+    saveFilters(storageKey, filters);
+    onAfterChange();
+  };
+
+  const renderRows = () => {
+    list.replaceChildren();
+    if (values.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'col-filter-popover-empty';
+      empty.textContent = 'No values to filter.';
+      list.appendChild(empty);
+      return;
+    }
+    values.forEach((val) => {
+      const row = document.createElement('label');
+      row.className = 'col-filter-popover-item';
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.checked = kept.has(val);
+      cb.addEventListener('change', () => {
+        if (cb.checked) kept.add(val);
+        else kept.delete(val);
+        persist();
+      });
+      const txt = document.createElement('span');
+      txt.className = 'col-filter-popover-label';
+      txt.textContent = val === '' ? '(empty)' : val;
+      txt.title = val;
+      row.appendChild(cb);
+      row.appendChild(txt);
+      list.appendChild(row);
+    });
+  };
+  renderRows();
+
+  allBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    kept.clear();
+    values.forEach((v) => kept.add(v));
+    persist();
+    list
+      .querySelectorAll<HTMLInputElement>('input[type=checkbox]')
+      .forEach((cb) => {
+        cb.checked = true;
+      });
+  });
+  noneBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    kept.clear();
+    persist();
+    list
+      .querySelectorAll<HTMLInputElement>('input[type=checkbox]')
+      .forEach((cb) => {
+        cb.checked = false;
+      });
+  });
+
+  // Position via fixed coords next to the anchor. If the popover would
+  // overflow the right edge, anchor it to the right side of the button
+  // instead.
+  document.body.appendChild(pop);
+  const rect = anchor.getBoundingClientRect();
+  const popWidth = pop.offsetWidth || 220;
+  let left = rect.left;
+  if (left + popWidth + 8 > window.innerWidth) {
+    left = Math.max(8, window.innerWidth - popWidth - 8);
+  }
+  pop.style.position = 'fixed';
+  pop.style.top = `${rect.bottom + 4}px`;
+  pop.style.left = `${left}px`;
+
+  const onDocDown = (e: MouseEvent) => {
+    if (pop.contains(e.target as Node) || anchor.contains(e.target as Node)) return;
+    closePopover();
+  };
+  const onKey = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') closePopover();
+  };
+  document.addEventListener('mousedown', onDocDown);
+  document.addEventListener('keydown', onKey);
+
+  openPopover = {
+    el: pop,
+    cleanup: () => {
+      document.removeEventListener('mousedown', onDocDown);
+      document.removeEventListener('keydown', onKey);
+    },
+  };
+}
+
+// useEntityTable bundles the two table enhancements (column resizing +
+// per-column value filters) behind a single ref so a page only has to
+// thread one ref onto its <table>. Both behaviors persist under the
+// same storage key (different prefixes internally).
+export function useEntityTable(storageKey: string) {
+  // Imported lazily to keep the hook order trivial — both children obey
+  // the rules-of-hooks because they're called unconditionally below.
+  /* eslint-disable react-hooks/rules-of-hooks */
+  const resizeRef = useResizableColumnsImpl(storageKey);
+  const filterRef = useColumnFilters(storageKey);
+  /* eslint-enable react-hooks/rules-of-hooks */
+  return useCallback(
+    (el: HTMLTableElement | null) => {
+      resizeRef(el);
+      filterRef(el);
+    },
+    [resizeRef, filterRef],
+  );
+}
+
+export function useColumnFilters(storageKey: string) {
+  const cleanupRef = useRef<(() => void) | null>(null);
+  const equippedRef = useRef<HTMLTableElement | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (cleanupRef.current) cleanupRef.current();
+      cleanupRef.current = null;
+      equippedRef.current = null;
+      closePopover();
+    };
+  }, []);
+
+  return useCallback(
+    (table: HTMLTableElement | null) => {
+      if (equippedRef.current === table) return;
+      if (cleanupRef.current) {
+        cleanupRef.current();
+        cleanupRef.current = null;
+      }
+      equippedRef.current = table;
+      if (!table) return;
+
+      const headRow = table.querySelector<HTMLTableRowElement>(
+        ':scope > thead > tr',
+      );
+      if (!headRow) return;
+      const ths = Array.from(
+        headRow.querySelectorAll<HTMLTableCellElement>(':scope > th'),
+      );
+      if (ths.length === 0) return;
+
+      const filters = loadFilters(storageKey);
+      const cleanups: Array<() => void> = [];
+      const updaters: Array<() => void> = [];
+
+      ths.forEach((th, idx) => {
+        // Skip right-aligned (action) columns and explicit opt-outs.
+        const skip =
+          th.style.textAlign === 'right' ||
+          th.hasAttribute('data-no-filter');
+        if (skip) return;
+
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'col-filter-btn';
+        btn.innerHTML = FILTER_ICON_SVG;
+        btn.setAttribute('aria-label', 'Filter values');
+        btn.title = 'Filter values';
+        th.appendChild(btn);
+
+        const updateActive = () => {
+          const has = Array.isArray(filters[String(idx)]);
+          btn.classList.toggle('col-filter-active', has);
+        };
+        updateActive();
+        updaters.push(updateActive);
+
+        const onClick = (e: MouseEvent) => {
+          e.preventDefault();
+          e.stopPropagation();
+          // Re-clicking the funnel while its popover is open closes it.
+          if (openPopover && openPopover.el.dataset.colIdx === String(idx)) {
+            closePopover();
+            return;
+          }
+          closePopover();
+          buildPopover(table, idx, btn, filters, storageKey, () => {
+            applyFilters(table, filters);
+            updaters.forEach((u) => u());
+          });
+          if (openPopover) openPopover.el.dataset.colIdx = String(idx);
+        };
+        btn.addEventListener('click', onClick);
+        cleanups.push(() => {
+          btn.removeEventListener('click', onClick);
+          if (btn.parentNode) btn.parentNode.removeChild(btn);
+        });
+      });
+
+      // Apply persisted filters straight away so reloads land on the same
+      // visible subset the user left behind.
+      applyFilters(table, filters);
+
+      // Re-apply when React swaps rows (refetch, resort, paginate).
+      const tbody = table.querySelector<HTMLTableSectionElement>(':scope > tbody');
+      let observer: MutationObserver | null = null;
+      if (tbody && typeof MutationObserver !== 'undefined') {
+        observer = new MutationObserver(() => applyFilters(table, filters));
+        observer.observe(tbody, { childList: true });
+      }
+
+      cleanupRef.current = () => {
+        if (observer) observer.disconnect();
+        cleanups.forEach((c) => c());
+        // Restore visibility — our display:none is otherwise sticky.
+        const rows = table.querySelectorAll<HTMLTableRowElement>(
+          ':scope > tbody > tr',
+        );
+        rows.forEach((r) => {
+          r.style.display = '';
+        });
+        closePopover();
+      };
+    },
+    [storageKey],
+  );
+}

--- a/ui/src/pages/EolDashboard.tsx
+++ b/ui/src/pages/EolDashboard.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import * as api from '../api';
 import { useResources } from '../hooks';
 import { AsyncView, Dash } from '../components';
-import { useResizableColumns } from '../components/resizable_columns';
+import { useEntityTable } from '../components/column_filters';
 import { EolIcon } from '../icons';
 
 // --- EOL annotation parsing -----------------------------------------------
@@ -289,7 +289,7 @@ function EolTable({
 }) {
   const allRows = useMemo(() => buildRows(clusters, nodes, vms), [clusters, nodes, vms]);
   const counts = useMemo(() => countStatuses(allRows), [allRows]);
-  const tableRef = useResizableColumns('eol.table');
+  const tableRef = useEntityTable('eol.table');
 
   const filtered = useMemo(
     () => (statusFilter ? allRows.filter((r) => r.eolStatus === statusFilter) : allRows),

--- a/ui/src/pages/Lists.tsx
+++ b/ui/src/pages/Lists.tsx
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom';
 import * as api from '../api';
 import { useResource } from '../hooks';
 import { AsyncView, Dash, IdLink, LayerPill, LoadBalancerAddresses, Empty } from '../components';
-import { useResizableColumns } from '../components/resizable_columns';
+import { useEntityTable } from '../components/column_filters';
 import {
   ClusterIcon, NodeIcon, NamespaceIcon, WorkloadIcon, PodIcon,
   ServiceIcon, IngressIcon, VolumeIcon,
@@ -15,7 +15,7 @@ import {
 
 export function Clusters() {
   const state = useResource(() => api.listClusters(), []);
-  const tableRef = useResizableColumns('lists.clusters');
+  const tableRef = useEntityTable('lists.clusters');
   return (
     <>
       <h2><ClusterIcon size={20} /> Clusters</h2>
@@ -75,7 +75,7 @@ export function Nodes() {
       })),
     [],
   );
-  const tableRef = useResizableColumns('lists.nodes');
+  const tableRef = useEntityTable('lists.nodes');
   return (
     <>
       <h2><NodeIcon size={20} /> Nodes</h2>
@@ -164,7 +164,7 @@ export function Namespaces() {
       })),
     [],
   );
-  const tableRef = useResizableColumns('lists.namespaces');
+  const tableRef = useEntityTable('lists.namespaces');
   return (
     <>
       <h2><NamespaceIcon size={20} /> Namespaces</h2>
@@ -272,7 +272,7 @@ function NamespaceLink({
 export function Workloads() {
   const index = useNamespaceIndex();
   const workloads = useResource(() => api.listWorkloads(), []);
-  const tableRef = useResizableColumns('lists.workloads');
+  const tableRef = useEntityTable('lists.workloads');
 
   return (
     <>
@@ -340,7 +340,7 @@ export function Pods() {
   const index = useNamespaceIndex();
   const pods = useResource(() => api.listPods(), []);
   const workloads = useResource(() => fetchAllWorkloads(), []);
-  const tableRef = useResizableColumns('lists.pods');
+  const tableRef = useEntityTable('lists.pods');
   return (
     <>
       <h2><PodIcon size={20} /> Pods</h2>
@@ -418,7 +418,7 @@ export function Pods() {
 export function Services() {
   const index = useNamespaceIndex();
   const services = useResource(() => api.listServices(), []);
-  const tableRef = useResizableColumns('lists.services');
+  const tableRef = useEntityTable('lists.services');
   return (
     <>
       <h2><ServiceIcon size={20} /> Services</h2>
@@ -479,7 +479,7 @@ export function Services() {
 export function Ingresses() {
   const index = useNamespaceIndex();
   const ingresses = useResource(() => api.listIngresses(), []);
-  const tableRef = useResizableColumns('lists.ingresses');
+  const tableRef = useEntityTable('lists.ingresses');
   return (
     <>
       <h2><IngressIcon size={20} /> Ingresses</h2>
@@ -548,7 +548,7 @@ export function PersistentVolumes() {
       })),
     [],
   );
-  const tableRef = useResizableColumns('lists.persistent_volumes');
+  const tableRef = useEntityTable('lists.persistent_volumes');
   return (
     <>
       <h2><VolumeIcon size={20} /> Persistent Volumes</h2>
@@ -602,7 +602,7 @@ export function PersistentVolumes() {
 export function PersistentVolumeClaims() {
   const index = useNamespaceIndex();
   const pvcs = useResource(() => api.listPersistentVolumeClaims(), []);
-  const tableRef = useResizableColumns('lists.persistent_volume_claims');
+  const tableRef = useEntityTable('lists.persistent_volume_claims');
   return (
     <>
       <h2><VolumeIcon size={20} /> Persistent Volume Claims</h2>

--- a/ui/src/pages/Search.tsx
+++ b/ui/src/pages/Search.tsx
@@ -3,7 +3,7 @@ import { Link, useSearchParams } from 'react-router-dom';
 import * as api from '../api';
 import { useResource } from '../hooks';
 import { AsyncView, Dash, IdLink, SectionTitle, Empty } from '../components';
-import { useResizableColumns } from '../components/resizable_columns';
+import { useEntityTable } from '../components/column_filters';
 import { isAdmin, useMe } from '../me';
 
 // Image search — answers "which applications run component X in version Y?"
@@ -70,9 +70,9 @@ export default function ImageSearch() {
 function Results({ q }: { q: string }) {
   const me = useMe();
   const canListAccounts = isAdmin(me);
-  const workloadsTableRef = useResizableColumns('search.workloads');
-  const podsTableRef = useResizableColumns('search.pods');
-  const vmsTableRef = useResizableColumns('search.vms');
+  const workloadsTableRef = useEntityTable('search.workloads');
+  const podsTableRef = useEntityTable('search.pods');
+  const vmsTableRef = useEntityTable('search.vms');
   const state = useResource(
     () =>
       Promise.all([

--- a/ui/src/pages/VirtualMachines.tsx
+++ b/ui/src/pages/VirtualMachines.tsx
@@ -4,7 +4,7 @@ import * as api from '../api';
 import { useResource } from '../hooks';
 import { isAdmin, useMe } from '../me';
 import { AsyncView, Dash } from '../components';
-import { useResizableColumns } from '../components/resizable_columns';
+import { useEntityTable } from '../components/column_filters';
 import { VirtualMachineIcon } from '../icons';
 
 // VirtualMachines is the top-level list page for ADR-0015 VMs. It mirrors
@@ -111,7 +111,7 @@ function compare(a: api.VirtualMachine, b: api.VirtualMachine, key: SortKey, asc
 export default function VirtualMachines() {
   const me = useMe();
   const showAccountFilter = isAdmin(me);
-  const tableRef = useResizableColumns('vms.list');
+  const tableRef = useEntityTable('vms.list');
 
   const [cloudAccountId, setCloudAccountId] = useState<string>('');
   const [region, setRegion] = useState<string>('');

--- a/ui/src/pages/admin/Audit.tsx
+++ b/ui/src/pages/admin/Audit.tsx
@@ -2,7 +2,7 @@ import { FormEvent, useState } from 'react';
 import * as api from '../../api';
 import { useResource } from '../../hooks';
 import { AsyncView, Dash, SectionTitle } from '../../components';
-import { useResizableColumns } from '../../components/resizable_columns';
+import { useEntityTable } from '../../components/column_filters';
 
 // Admin Audit page. Read-only, newest-first list of recorded API
 // actions. Auditors can reach this without the rest of the admin panel
@@ -21,7 +21,7 @@ const emptyFilter: FilterForm = { actor: '', resourceType: '', action: '', since
 export default function AuditPage() {
   const [draft, setDraft] = useState<FilterForm>(emptyFilter);
   const [applied, setApplied] = useState<FilterForm>(emptyFilter);
-  const tableRef = useResizableColumns('admin.audit');
+  const tableRef = useEntityTable('admin.audit');
   const state = useResource(
     () =>
       api.listAuditEvents({

--- a/ui/src/pages/admin/CloudAccountDetail.tsx
+++ b/ui/src/pages/admin/CloudAccountDetail.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import * as api from '../../api';
 import { useResource } from '../../hooks';
 import { AsyncView, Dash, KV, SectionTitle } from '../../components';
-import { useResizableColumns } from '../../components/resizable_columns';
+import { useEntityTable } from '../../components/column_filters';
 import { CuratedMetadataCard } from '../../components/inventory/CuratedMetadataCard';
 import { CloudAccountStatusBadge } from './CloudAccounts';
 
@@ -42,7 +42,7 @@ export default function CloudAccountDetail() {
     () => api.listVirtualMachines({ cloud_account_id: id }),
     [id, nonce],
   );
-  const tableRef = useResizableColumns('admin.cloud_account_detail.vms');
+  const tableRef = useEntityTable('admin.cloud_account_detail.vms');
 
   const onDelete = async (account: api.CloudAccount, vmCount: number) => {
     const typed = prompt(

--- a/ui/src/pages/admin/CloudAccounts.tsx
+++ b/ui/src/pages/admin/CloudAccounts.tsx
@@ -3,7 +3,7 @@ import { Link, useSearchParams } from 'react-router-dom';
 import * as api from '../../api';
 import { useResource } from '../../hooks';
 import { AsyncView, Dash, SectionTitle } from '../../components';
-import { useResizableColumns } from '../../components/resizable_columns';
+import { useEntityTable } from '../../components/column_filters';
 
 // CloudAccountsPage — admin tab for ADR-0015 cloud-provider accounts.
 // Shape mirrors the Tokens page: list-then-action, with an inline create
@@ -46,7 +46,7 @@ export default function CloudAccountsPage() {
   const state = useResource(() => api.listCloudAccounts(), [nonce]);
   const [searchParams, setSearchParams] = useSearchParams();
   const statusFilter = searchParams.get('status') || '';
-  const tableRef = useResizableColumns('admin.cloud_accounts');
+  const tableRef = useEntityTable('admin.cloud_accounts');
 
   const setStatus = (s: string) => {
     const next = new URLSearchParams(searchParams);

--- a/ui/src/pages/admin/Sessions.tsx
+++ b/ui/src/pages/admin/Sessions.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import * as api from '../../api';
 import { useResource } from '../../hooks';
 import { AsyncView, Dash, SectionTitle } from '../../components';
-import { useResizableColumns } from '../../components/resizable_columns';
+import { useEntityTable } from '../../components/column_filters';
 
 // Admin Sessions page. Read-only table with a revoke action. The `id`
 // column is the server-side public UUID, never the cookie value —
@@ -13,7 +13,7 @@ export default function SessionsPage() {
   const [nonce, setNonce] = useState(0);
   const reload = () => setNonce((n) => n + 1);
   const state = useResource(() => api.listSessions(), [nonce]);
-  const tableRef = useResizableColumns('admin.sessions');
+  const tableRef = useEntityTable('admin.sessions');
 
   return (
     <AsyncView state={state}>

--- a/ui/src/pages/admin/Tokens.tsx
+++ b/ui/src/pages/admin/Tokens.tsx
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import * as api from '../../api';
 import { useResource } from '../../hooks';
 import { AsyncView, Dash, SectionTitle } from '../../components';
-import { useResizableColumns } from '../../components/resizable_columns';
+import { useEntityTable } from '../../components/column_filters';
 
 // Token presets per ADR-0007 + ADR-0015. The OpenAPI request type is
 // fixed (name, scopes, expires_at) so vm-collector tokens currently
@@ -291,7 +291,7 @@ function MintForm({
 }
 
 function TokenTable({ tokens, reload }: { tokens: api.ApiToken[]; reload: Reload }) {
-  const tableRef = useResizableColumns('admin.tokens');
+  const tableRef = useEntityTable('admin.tokens');
   if (tokens.length === 0) return <p className="muted">No tokens minted yet.</p>;
   return (
     <table className="entities" ref={tableRef}>

--- a/ui/src/pages/admin/Users.tsx
+++ b/ui/src/pages/admin/Users.tsx
@@ -2,7 +2,7 @@ import { FormEvent, useState } from 'react';
 import * as api from '../../api';
 import { useResource } from '../../hooks';
 import { AsyncView, Dash, SectionTitle } from '../../components';
-import { useResizableColumns } from '../../components/resizable_columns';
+import { useEntityTable } from '../../components/column_filters';
 
 // Admin Users page: list of humans, new-user collapsible form, inline
 // row actions. Destructive actions (delete, disable, reset-password)
@@ -123,7 +123,7 @@ function NewUserForm({ reload }: { reload: Reload }) {
 }
 
 function UserTable({ users, reload }: { users: api.User[]; reload: Reload }) {
-  const tableRef = useResizableColumns('admin.users');
+  const tableRef = useEntityTable('admin.users');
   if (users.length === 0) return <p className="muted">No users.</p>;
   return (
     <table className="entities" ref={tableRef}>

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -714,7 +714,10 @@ body.lv-resizing-cols table.lv-resizable .col-resize-handle::after {
 }
 
 /* ── Per-column value filter (see ui/src/components/column_filters.ts) ── */
-.col-filter-btn {
+/* All selectors are scoped under `.entities` to outrank the generic
+   `table.entities button { padding: 0.25rem 0.55rem }` rule lower in this
+   file — without it the funnel SVG ends up with ~0px of usable width. */
+.entities .col-filter-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -728,15 +731,15 @@ body.lv-resizing-cols table.lv-resizable .col-resize-handle::after {
   color: var(--fg-muted);
   cursor: pointer;
   vertical-align: middle;
-  opacity: 0.55;
+  opacity: 0.7;
   transition: opacity 0.12s ease, background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
 }
-.col-filter-btn:hover {
+.entities .col-filter-btn:hover {
   opacity: 1;
   background: var(--bg-hover);
   color: var(--fg-1);
 }
-.col-filter-btn.col-filter-active {
+.entities .col-filter-btn.col-filter-active {
   opacity: 1;
   color: var(--accent);
   border-color: var(--accent);

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -713,6 +713,101 @@ body.lv-resizing-cols table.lv-resizable .col-resize-handle::after {
   background: var(--accent);
 }
 
+/* ── Per-column value filter (see ui/src/components/column_filters.ts) ── */
+.col-filter-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  margin-left: 0.35rem;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm, 4px);
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+  vertical-align: middle;
+  opacity: 0.55;
+  transition: opacity 0.12s ease, background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.col-filter-btn:hover {
+  opacity: 1;
+  background: var(--bg-hover);
+  color: var(--fg-1);
+}
+.col-filter-btn.col-filter-active {
+  opacity: 1;
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--bg-hover);
+}
+.col-filter-popover {
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+  min-width: 200px;
+  max-width: 320px;
+  font-size: var(--fs-sm);
+  color: var(--fg-1);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.col-filter-popover-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.65rem;
+  background: var(--bg-2);
+  border-bottom: 1px solid var(--border);
+}
+.col-filter-popover-title {
+  color: var(--fg-muted);
+  font-size: var(--fs-2xs);
+  text-transform: uppercase;
+  letter-spacing: var(--ls-caps);
+}
+.col-filter-popover-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+.col-filter-popover-actions .link-btn {
+  font-size: var(--fs-2xs);
+}
+.col-filter-popover-list {
+  max-height: 280px;
+  overflow-y: auto;
+  padding: 0.25rem 0;
+}
+.col-filter-popover-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0.65rem;
+  cursor: pointer;
+  user-select: none;
+}
+.col-filter-popover-item:hover {
+  background: var(--bg-hover);
+}
+.col-filter-popover-item input[type='checkbox'] {
+  flex-shrink: 0;
+  margin: 0;
+}
+.col-filter-popover-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+}
+.col-filter-popover-empty {
+  padding: 0.65rem;
+  color: var(--fg-muted);
+  font-style: italic;
+}
+
 .pill {
   display: inline-block;
   font-size: var(--fs-2xs);


### PR DESCRIPTION
## Summary

Two UX improvements asked for in the open issue queue, sharing infrastructure on the same set of tables.

- **Closes #116** — drag the right edge of any header to resize a column; double-click to reset. Per-table widths persist to localStorage.
- **Closes #117** — funnel button on every non-action header opens a popover that lists the column's distinct text values; checkboxes pick which ones to keep. Filters AND across columns and persist to localStorage.

Both behaviors are bundled behind a single `useEntityTable(storageKey)` hook so each page only threads one ref onto its `<table>`. A `MutationObserver` keeps filters applied across React re-renders (refetch / sort / paginate). Resize handles hug the right edge; the funnel sits inline in the header — they coexist cleanly.

Applied to every list-style table:

- `Lists.tsx` × 9 (Clusters, Nodes, Namespaces, Workloads, Pods, Services, Ingresses, PVs, PVCs)
- `VirtualMachines.tsx`, `Search.tsx` × 3, `EolDashboard.tsx`
- Admin: Audit, CloudAccounts, CloudAccountDetail, Users, Tokens, Sessions

New files:

- `ui/src/components/resizable_columns.ts` (+ test)
- `ui/src/components/column_filters.ts` (+ test) — also exports `useEntityTable`
- New CSS in `ui/src/styles.css` for the resize handle, funnel button, and popover.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Vitest: 216/216 (incl. 5 resize + 6 filter unit tests)
- [x] `make ui-build` succeeds (CSS warning at `<stdin>:449` is pre-existing on `main`)
- [x] Manual smoke: drag a column on `/clusters`, reload — width sticks
- [x] Manual smoke: filter `/pods` by Phase; resort the table — filter stays applied
- [x] Manual smoke: open + close popovers via Escape and outside-click
- [x] Manual smoke: confirm action-column funnel is correctly skipped on Users / Tokens / CloudAccounts

---
_Generated by [Claude Code](https://claude.ai/code/session_016NLNxtGpkNxzMEyZJKcH9D)_