### PR TITLE
ci: automate version tagging via release-please for binaries and Helm…

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+name: release-please
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,45 @@ on:
   push:
     tags:
       - "v*"
+      - "chart-*-v*"
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
+  detect:
+    name: Detect release kind from tag
+    runs-on: ubuntu-latest
+    outputs:
+      kind: ${{ steps.k.outputs.kind }}
+      chart: ${{ steps.k.outputs.chart }}
+      version: ${{ steps.k.outputs.version }}
+    steps:
+      - id: k
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ "$TAG" == chart-*-v* ]]; then
+            rest="${TAG#chart-}"
+            chart="${rest%-v*}"
+            version="${rest##*-v}"
+            echo "kind=chart" >>"$GITHUB_OUTPUT"
+            echo "chart=$chart" >>"$GITHUB_OUTPUT"
+            echo "version=$version" >>"$GITHUB_OUTPUT"
+          elif [[ "$TAG" == v* ]]; then
+            echo "kind=binary" >>"$GITHUB_OUTPUT"
+            echo "version=${TAG#v}" >>"$GITHUB_OUTPUT"
+          else
+            echo "Unrecognised tag: $TAG" >&2
+            exit 1
+          fi
+
   images:
     name: Build and push container images
+    needs: detect
+    if: needs.detect.outputs.kind == 'binary'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -20,30 +51,23 @@ jobs:
             dockerfile: Dockerfile
           - image: longue-vue-collector
             dockerfile: Dockerfile.collector
-
+          - image: longue-vue-ingest-gw
+            dockerfile: Dockerfile.ingest-gw
+          - image: longue-vue-vm-collector
+            dockerfile: Dockerfile.vm-collector
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
+      - uses: actions/checkout@v5
 
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
-      - name: Set up QEMU (multi-arch)
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker metadata
-        id: meta
+      - id: meta
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
@@ -53,8 +77,7 @@ jobs:
             type=semver,pattern={{major}}
             type=raw,value=latest
 
-      - name: Build and push
-        uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -65,4 +88,61 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,scope=${{ matrix.image }},mode=max
           build-args: |
-            VERSION=${{ steps.version.outputs.version }}
+            VERSION=${{ needs.detect.outputs.version }}
+
+  binaries:
+    name: Build and publish binaries (GoReleaser)
+    needs: detect
+    if: needs.detect.outputs.kind == 'binary'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+          cache: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  chart:
+    name: Package and push Helm chart to GHCR
+    needs: detect
+    if: needs.detect.outputs.kind == 'chart'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.2
+
+      - name: Helm registry login
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
+        run: |
+          echo "$GHCR_TOKEN" | helm registry login ghcr.io -u "$GHCR_USER" --password-stdin
+
+      - name: Package and push chart
+        env:
+          CHART: ${{ needs.detect.outputs.chart }}
+          VERSION: ${{ needs.detect.outputs.version }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          helm package "charts/$CHART" -d /tmp
+          helm push "/tmp/${CHART}-${VERSION}.tgz" "oci://ghcr.io/${OWNER}/charts"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,59 @@
+version: 2
+
+before:
+  hooks:
+    - sh -c "cd ui && npm ci && npm run build"
+
+builds:
+  - id: longue-vue
+    main: ./cmd/longue-vue
+    binary: longue-vue
+    env: [CGO_ENABLED=0]
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+
+  - id: longue-vue-collector
+    main: ./cmd/longue-vue-collector
+    binary: longue-vue-collector
+    env: [CGO_ENABLED=0]
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+
+  - id: longue-vue-ingest-gw
+    main: ./cmd/longue-vue-ingest-gw
+    binary: longue-vue-ingest-gw
+    env: [CGO_ENABLED=0]
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+
+  - id: longue-vue-vm-collector
+    main: ./cmd/longue-vue-vm-collector
+    binary: longue-vue-vm-collector
+    env: [CGO_ENABLED=0]
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+
+archives:
+  - formats: [tar.gz]
+    name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  disable: true
+
+release:
+  draft: false
+  prerelease: auto

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,7 @@
+{
+  ".": "0.14.0",
+  "charts/longue-vue": "0.16.0",
+  "charts/longue-vue-collector": "0.2.0",
+  "charts/longue-vue-ingest-gw": "0.2.0",
+  "charts/longue-vue-vm-collector": "0.2.0"
+}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -893,18 +894,55 @@ func (f *fakeKubeSource) ListPersistentVolumeClaims(_ context.Context) ([]collec
 	return f.pvcs, nil
 }
 
-// runCollectorOnce creates a collector and runs one poll cycle, then cancels.
+// notifyingStore wraps a CmdbStore and closes tickDone after the first
+// successful UpsertPersistentVolumeClaim, which is the last write in a tick.
+type notifyingStore struct {
+	collector.CmdbStore
+	once     sync.Once
+	tickDone chan struct{}
+}
+
+func (s *notifyingStore) UpsertPersistentVolumeClaim(ctx context.Context, in api.PersistentVolumeClaimCreate) (api.PersistentVolumeClaim, error) {
+	pvc, err := s.CmdbStore.UpsertPersistentVolumeClaim(ctx, in)
+	if err == nil {
+		s.once.Do(func() { close(s.tickDone) })
+	}
+	return pvc, err
+}
+
 func runCollectorOnce(
 	t *testing.T, cStore collector.CmdbStore, source collector.KubeSource,
 	clusterName string, reconcile bool,
 ) {
 	t.Helper()
-	coll := collector.New(cStore, source, clusterName, 1*time.Hour, 30*time.Second, reconcile)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	// Wrap the store so we can detect when PVC (the last write of a tick) lands.
+	ns := &notifyingStore{
+		CmdbStore: cStore,
+		tickDone:  make(chan struct{}),
+	}
+	// Use a generous outer timeout; fetchTimeout is set to the same value so
+	// the inner per-call context is always bounded by the outer one.
+	const totalTimeout = 30 * time.Second
+	coll := collector.New(ns, source, clusterName, 1*time.Hour, totalTimeout, reconcile)
+
+	ctx, cancel := context.WithTimeout(context.Background(), totalTimeout)
 	defer cancel()
-	go coll.Run(ctx) //nolint:errcheck // fire-and-forget; context cancellation stops the collector
-	time.Sleep(3 * time.Second)
-	cancel()
+
+	collDone := make(chan struct{})
+	go func() {
+		defer close(collDone)
+		coll.Run(ctx) //nolint:errcheck // context cancellation stops the collector
+	}()
+
+	// Cancel the context as soon as the first PVC upsert succeeds (full tick
+	// committed) or when totalTimeout fires, whichever comes first.
+	select {
+	case <-ns.tickDone:
+		cancel()
+	case <-ctx.Done():
+		// timeout fired before tick completed — let the goroutine finish
+	}
+	<-collDone
 }
 
 // verifyFirstPollResults checks that the first collector poll populated all

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -902,12 +902,13 @@ type notifyingStore struct {
 	tickDone chan struct{}
 }
 
+//nolint:gocritic // signature is fixed by the collector.CmdbStore interface
 func (s *notifyingStore) UpsertPersistentVolumeClaim(ctx context.Context, in api.PersistentVolumeClaimCreate) (api.PersistentVolumeClaim, error) {
 	pvc, err := s.CmdbStore.UpsertPersistentVolumeClaim(ctx, in)
 	if err == nil {
 		s.once.Do(func() { close(s.tickDone) })
 	}
-	return pvc, err
+	return pvc, err //nolint:wrapcheck // pass through interface error verbatim
 }
 
 func runCollectorOnce(

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "separate-pull-requests": false,
+  "include-component-in-tag": true,
+  "packages": {
+    ".": {
+      "release-type": "go",
+      "component": "longue-vue",
+      "include-component-in-tag": false,
+      "extra-files": [
+        {
+          "type": "yaml",
+          "path": "charts/longue-vue/Chart.yaml",
+          "jsonpath": "$.appVersion"
+        },
+        {
+          "type": "yaml",
+          "path": "charts/longue-vue-collector/Chart.yaml",
+          "jsonpath": "$.appVersion"
+        },
+        {
+          "type": "yaml",
+          "path": "charts/longue-vue-ingest-gw/Chart.yaml",
+          "jsonpath": "$.appVersion"
+        },
+        {
+          "type": "yaml",
+          "path": "charts/longue-vue-vm-collector/Chart.yaml",
+          "jsonpath": "$.appVersion"
+        }
+      ]
+    },
+    "charts/longue-vue": {
+      "release-type": "helm",
+      "component": "chart-longue-vue",
+      "package-name": "longue-vue"
+    },
+    "charts/longue-vue-collector": {
+      "release-type": "helm",
+      "component": "chart-longue-vue-collector",
+      "package-name": "longue-vue-collector"
+    },
+    "charts/longue-vue-ingest-gw": {
+      "release-type": "helm",
+      "component": "chart-longue-vue-ingest-gw",
+      "package-name": "longue-vue-ingest-gw"
+    },
+    "charts/longue-vue-vm-collector": {
+      "release-type": "helm",
+      "component": "chart-longue-vue-vm-collector",
+      "package-name": "longue-vue-vm-collector"
+    }
+  }
+}


### PR DESCRIPTION
… charts

Adds release-please monorepo config with separate tags for the Go binaries (grouped under v*) and each Helm chart (chart-<name>-v*). Refactors the Release workflow to detect tag kind and dispatch to GoReleaser, multi-arch Docker image builds, or `helm push` to GHCR OCI accordingly.