### PR TITLE
ci(release-please): use GitHub App token so PRs trigger CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,15 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
PRs opened by github-actions[bot] with the default GITHUB_TOKEN do not trigger pull_request workflow events (GitHub safety against recursive runs). That left release-please PRs sitting with no required checks and unmergeable under branch protection.

Mint a token from a dedicated GitHub App via actions/create-github-app-token and pass it to release-please-action so the PR is opened by the App identity, which does fire pull_request events.

Requires repo secrets RELEASE_PLEASE_APP_ID and RELEASE_PLEASE_APP_PRIVATE_KEY.