### PR TITLE
chore(charts): drop argos-named keys in helm values

### DIFF
--- a/charts/longue-vue-collector/templates/deployment.yaml
+++ b/charts/longue-vue-collector/templates/deployment.yaml
@@ -48,19 +48,19 @@ spec:
             - name: LONGUE_VUE_KUBECONFIG
               value: {{ .Values.kubeconfig.mountPath | quote }}
             {{- end }}
-            {{- if .Values.argosTLS.caSecret }}
+            {{- if .Values.serverTLS.caSecret }}
             - name: LONGUE_VUE_CA_CERT
-              value: /etc/longue-vue-collector/tls-ca/{{ .Values.argosTLS.caKey }}
+              value: /etc/longue-vue-collector/tls-ca/{{ .Values.serverTLS.caKey }}
             {{- end }}
-            {{- if .Values.argosTLS.existingSecret }}
+            {{- if .Values.serverTLS.existingSecret }}
             - name: LONGUE_VUE_CLIENT_CERT
               value: /etc/longue-vue-collector/tls/tls.crt
             - name: LONGUE_VUE_CLIENT_KEY
               value: /etc/longue-vue-collector/tls/tls.key
             {{- end }}
-            {{- if .Values.argosTLS.extraHeaders }}
+            {{- if .Values.serverTLS.extraHeaders }}
             - name: LONGUE_VUE_EXTRA_HEADERS
-              value: {{ .Values.argosTLS.extraHeaders | quote }}
+              value: {{ .Values.serverTLS.extraHeaders | quote }}
             {{- end }}
             {{- if .Values.proxy.httpsProxy }}
             - name: HTTPS_PROXY
@@ -87,12 +87,12 @@ spec:
               subPath: kubeconfig
               readOnly: true
             {{- end }}
-            {{- if .Values.argosTLS.existingSecret }}
+            {{- if .Values.serverTLS.existingSecret }}
             - name: lv-tls
               mountPath: /etc/longue-vue-collector/tls
               readOnly: true
             {{- end }}
-            {{- if .Values.argosTLS.caSecret }}
+            {{- if .Values.serverTLS.caSecret }}
             - name: lv-ca
               mountPath: /etc/longue-vue-collector/tls-ca
               readOnly: true
@@ -108,25 +108,25 @@ spec:
           secret:
             secretName: {{ required "kubeconfig.existingSecret is required when kubeconfig.mode=secret" .Values.kubeconfig.existingSecret | quote }}
         {{- end }}
-        {{- if .Values.argosTLS.existingSecret }}
+        {{- if .Values.serverTLS.existingSecret }}
         - name: lv-tls
           secret:
-            secretName: {{ .Values.argosTLS.existingSecret | quote }}
+            secretName: {{ .Values.serverTLS.existingSecret | quote }}
         {{- end }}
-        {{- if .Values.argosTLS.caSecret }}
+        {{- if .Values.serverTLS.caSecret }}
         - name: lv-ca
-          {{- if hasPrefix "configmap:" .Values.argosTLS.caSecret }}
+          {{- if hasPrefix "configmap:" .Values.serverTLS.caSecret }}
           configMap:
-            name: {{ trimPrefix "configmap:" .Values.argosTLS.caSecret | quote }}
+            name: {{ trimPrefix "configmap:" .Values.serverTLS.caSecret | quote }}
             items:
-              - key: {{ .Values.argosTLS.caKey }}
-                path: {{ .Values.argosTLS.caKey }}
+              - key: {{ .Values.serverTLS.caKey }}
+                path: {{ .Values.serverTLS.caKey }}
           {{- else }}
           secret:
-            secretName: {{ .Values.argosTLS.caSecret | quote }}
+            secretName: {{ .Values.serverTLS.caSecret | quote }}
             items:
-              - key: {{ .Values.argosTLS.caKey }}
-                path: {{ .Values.argosTLS.caKey }}
+              - key: {{ .Values.serverTLS.caKey }}
+                path: {{ .Values.serverTLS.caKey }}
           {{- end }}
         {{- end }}
         {{- with .Values.extraVolumes }}

--- a/charts/longue-vue-collector/values.yaml
+++ b/charts/longue-vue-collector/values.yaml
@@ -63,7 +63,7 @@ reconcile: true
 # Used together with serverURL pointing at the DMZ gateway (ADR-0016).
 # Leave existingSecret / caSecret empty to talk to longue-vue's public
 # listener over plain HTTPS.
-argosTLS:
+serverTLS:
   # Kubernetes TLS Secret (kubernetes.io/tls) carrying tls.crt + tls.key.
   existingSecret: ""
   # ConfigMap or Secret carrying ca.crt. Used to verify longue-vue's or the

--- a/charts/longue-vue-ingest-gw/templates/networkpolicy.yaml
+++ b/charts/longue-vue-ingest-gw/templates/networkpolicy.yaml
@@ -47,12 +47,12 @@ spec:
     - to:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ .Values.networkPolicy.argosdNamespace | quote }}
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.longueVueNamespace | quote }}
           podSelector:
-            {{- toYaml .Values.networkPolicy.argosdSelector | nindent 12 }}
+            {{- toYaml .Values.networkPolicy.longueVueSelector | nindent 12 }}
       ports:
         - protocol: TCP
-          port: {{ .Values.networkPolicy.argosdIngestPort }}
+          port: {{ .Values.networkPolicy.longueVueIngestPort }}
 
     {{- if and (eq .Values.mtls.mode "vault") .Values.networkPolicy.vaultEgress.enabled }}
     # Vault server — only allowed when mTLS mode is "vault" and the

--- a/charts/longue-vue-ingest-gw/values.yaml
+++ b/charts/longue-vue-ingest-gw/values.yaml
@@ -146,11 +146,11 @@ serviceAccount:
 # Disable only in environments without a NetworkPolicy CNI controller.
 networkPolicy:
   enabled: true
-  argosdSelector:
+  longueVueSelector:
     matchLabels:
       app.kubernetes.io/name: longue-vue
-  argosdNamespace: longue-vue
-  argosdIngestPort: 8443
+  longueVueNamespace: longue-vue
+  longueVueIngestPort: 8443
   vaultEgress:
     enabled: false                  # auto-set to true when mtls.mode=vault by the chart
     cidrs: []                       # operator fills in, e.g. ["10.0.5.10/32"]

--- a/charts/longue-vue-vm-collector/templates/deployment.yaml
+++ b/charts/longue-vue-vm-collector/templates/deployment.yaml
@@ -63,19 +63,19 @@ spec:
             - name: LONGUE_VUE_VM_COLLECTOR_METRICS_ADDR
               value: "0.0.0.0:{{ .Values.metrics.port }}"
             {{- end }}
-            {{- if .Values.argosTLS.caSecret }}
+            {{- if .Values.serverTLS.caSecret }}
             - name: LONGUE_VUE_CA_CERT
-              value: /etc/longue-vue-vm-collector/tls-ca/{{ .Values.argosTLS.caKey }}
+              value: /etc/longue-vue-vm-collector/tls-ca/{{ .Values.serverTLS.caKey }}
             {{- end }}
-            {{- if .Values.argosTLS.existingSecret }}
+            {{- if .Values.serverTLS.existingSecret }}
             - name: LONGUE_VUE_CLIENT_CERT
               value: /etc/longue-vue-vm-collector/tls/tls.crt
             - name: LONGUE_VUE_CLIENT_KEY
               value: /etc/longue-vue-vm-collector/tls/tls.key
             {{- end }}
-            {{- if .Values.argosTLS.extraHeaders }}
+            {{- if .Values.serverTLS.extraHeaders }}
             - name: LONGUE_VUE_EXTRA_HEADERS
-              value: {{ .Values.argosTLS.extraHeaders | quote }}
+              value: {{ .Values.serverTLS.extraHeaders | quote }}
             {{- end }}
             {{- if .Values.proxy.httpsProxy }}
             - name: HTTPS_PROXY
@@ -96,12 +96,12 @@ spec:
             - secretRef:
                 name: {{ required "tokenSecret.existingSecret is required" .Values.tokenSecret.existingSecret | quote }}
           volumeMounts:
-            {{- if .Values.argosTLS.existingSecret }}
+            {{- if .Values.serverTLS.existingSecret }}
             - name: lv-tls
               mountPath: /etc/longue-vue-vm-collector/tls
               readOnly: true
             {{- end }}
-            {{- if .Values.argosTLS.caSecret }}
+            {{- if .Values.serverTLS.caSecret }}
             - name: lv-ca
               mountPath: /etc/longue-vue-vm-collector/tls-ca
               readOnly: true
@@ -112,25 +112,25 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
-        {{- if .Values.argosTLS.existingSecret }}
+        {{- if .Values.serverTLS.existingSecret }}
         - name: lv-tls
           secret:
-            secretName: {{ .Values.argosTLS.existingSecret | quote }}
+            secretName: {{ .Values.serverTLS.existingSecret | quote }}
         {{- end }}
-        {{- if .Values.argosTLS.caSecret }}
+        {{- if .Values.serverTLS.caSecret }}
         - name: lv-ca
-          {{- if hasPrefix "configmap:" .Values.argosTLS.caSecret }}
+          {{- if hasPrefix "configmap:" .Values.serverTLS.caSecret }}
           configMap:
-            name: {{ trimPrefix "configmap:" .Values.argosTLS.caSecret | quote }}
+            name: {{ trimPrefix "configmap:" .Values.serverTLS.caSecret | quote }}
             items:
-              - key: {{ .Values.argosTLS.caKey }}
-                path: {{ .Values.argosTLS.caKey }}
+              - key: {{ .Values.serverTLS.caKey }}
+                path: {{ .Values.serverTLS.caKey }}
           {{- else }}
           secret:
-            secretName: {{ .Values.argosTLS.caSecret | quote }}
+            secretName: {{ .Values.serverTLS.caSecret | quote }}
             items:
-              - key: {{ .Values.argosTLS.caKey }}
-                path: {{ .Values.argosTLS.caKey }}
+              - key: {{ .Values.serverTLS.caKey }}
+                path: {{ .Values.serverTLS.caKey }}
           {{- end }}
         {{- end }}
         {{- with .Values.extraVolumes }}

--- a/charts/longue-vue-vm-collector/values.yaml
+++ b/charts/longue-vue-vm-collector/values.yaml
@@ -76,7 +76,7 @@ credentialRefresh: 1h
 # Used together with serverURL pointing at the DMZ gateway (ADR-0016).
 # Leave existingSecret / caSecret empty to talk to longue-vue's public
 # listener over plain HTTPS.
-argosTLS:
+serverTLS:
   # Kubernetes TLS Secret (kubernetes.io/tls) carrying tls.crt + tls.key.
   existingSecret: ""
   # ConfigMap or Secret carrying ca.crt. Used to verify longue-vue's or the

--- a/charts/longue-vue/templates/deployment.yaml
+++ b/charts/longue-vue/templates/deployment.yaml
@@ -49,24 +49,24 @@ spec:
             {{- end }}
           env:
             - name: LONGUE_VUE_ADDR
-              value: {{ .Values.argosd.addr | quote }}
+              value: {{ .Values.server.addr | quote }}
             - name: LONGUE_VUE_AUTO_MIGRATE
-              value: {{ .Values.argosd.autoMigrate | quote }}
+              value: {{ .Values.server.autoMigrate | quote }}
             - name: LONGUE_VUE_SHUTDOWN_TIMEOUT
-              value: {{ .Values.argosd.shutdownTimeout | quote }}
+              value: {{ .Values.server.shutdownTimeout | quote }}
             - name: LONGUE_VUE_SESSION_SECURE_COOKIE
-              value: {{ .Values.argosd.sessionSecureCookie | quote }}
-            {{- if .Values.argosd.tls.existingSecret }}
+              value: {{ .Values.server.sessionSecureCookie | quote }}
+            {{- if .Values.server.tls.existingSecret }}
             - name: LONGUE_VUE_PUBLIC_LISTEN_TLS_CERT
-              value: {{ printf "%s/tls.crt" .Values.argosd.tls.mountPath | quote }}
+              value: {{ printf "%s/tls.crt" .Values.server.tls.mountPath | quote }}
             - name: LONGUE_VUE_PUBLIC_LISTEN_TLS_KEY
-              value: {{ printf "%s/tls.key" .Values.argosd.tls.mountPath | quote }}
+              value: {{ printf "%s/tls.key" .Values.server.tls.mountPath | quote }}
             {{- end }}
-            {{- if .Values.argosd.trustedProxies }}
+            {{- if .Values.server.trustedProxies }}
             - name: LONGUE_VUE_TRUSTED_PROXIES
-              value: {{ .Values.argosd.trustedProxies | quote }}
+              value: {{ .Values.server.trustedProxies | quote }}
             {{- end }}
-            {{- if .Values.argosd.requireHTTPS }}
+            {{- if .Values.server.requireHTTPS }}
             - name: LONGUE_VUE_REQUIRE_HTTPS
               value: "true"
             {{- end }}
@@ -122,30 +122,30 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
-          {{- if or .Values.collector.kubeconfigSecret .Values.argosd.tls.existingSecret }}
+          {{- if or .Values.collector.kubeconfigSecret .Values.server.tls.existingSecret }}
           volumeMounts:
             {{- if .Values.collector.kubeconfigSecret }}
             - name: kubeconfigs
               mountPath: /etc/longue-vue/kubeconfigs
               readOnly: true
             {{- end }}
-            {{- if .Values.argosd.tls.existingSecret }}
+            {{- if .Values.server.tls.existingSecret }}
             - name: tls
-              mountPath: {{ .Values.argosd.tls.mountPath }}
+              mountPath: {{ .Values.server.tls.mountPath }}
               readOnly: true
             {{- end }}
           {{- end }}
-      {{- if or .Values.collector.kubeconfigSecret .Values.argosd.tls.existingSecret }}
+      {{- if or .Values.collector.kubeconfigSecret .Values.server.tls.existingSecret }}
       volumes:
         {{- if .Values.collector.kubeconfigSecret }}
         - name: kubeconfigs
           secret:
             secretName: {{ .Values.collector.kubeconfigSecret }}
         {{- end }}
-        {{- if .Values.argosd.tls.existingSecret }}
+        {{- if .Values.server.tls.existingSecret }}
         - name: tls
           secret:
-            secretName: {{ .Values.argosd.tls.existingSecret }}
+            secretName: {{ .Values.server.tls.existingSecret }}
         {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/charts/longue-vue/templates/secret.yaml
+++ b/charts/longue-vue/templates/secret.yaml
@@ -12,8 +12,8 @@ stringData:
   {{- if .Values.postgresql.enabled }}
   POSTGRES_PASSWORD: {{ .Values.postgresql.auth.password | quote }}
   {{- end }}
-  {{- if .Values.argosd.bootstrapAdminPassword }}
-  LONGUE_VUE_BOOTSTRAP_ADMIN_PASSWORD: {{ .Values.argosd.bootstrapAdminPassword | quote }}
+  {{- if .Values.server.bootstrapAdminPassword }}
+  LONGUE_VUE_BOOTSTRAP_ADMIN_PASSWORD: {{ .Values.server.bootstrapAdminPassword | quote }}
   {{- end }}
   {{- if .Values.oidc.enabled }}
   LONGUE_VUE_OIDC_ISSUER: {{ .Values.oidc.issuer | quote }}

--- a/charts/longue-vue/values.yaml
+++ b/charts/longue-vue/values.yaml
@@ -13,7 +13,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 # -- longue-vue server core configuration.
-argosd:
+server:
   # -- HTTP listen address inside the container.
   addr: ":8080"
   # -- Run embedded goose migrations on startup.


### PR DESCRIPTION
## Summary

Rename leftover Argos-era keys exposed in chart values, in lockstep with their templates:

- `charts/longue-vue`: `argosd` → `server` (used in `templates/deployment.yaml` and `templates/secret.yaml`)
- `charts/longue-vue-collector` and `charts/longue-vue-vm-collector`: `argosTLS` → `serverTLS` (the upstream-server mTLS block, used in both `templates/deployment.yaml`)
- `charts/longue-vue-ingest-gw`: `networkPolicy.argosd{Selector,Namespace,IngestPort}` → `networkPolicy.longueVue{Selector,Namespace,IngestPort}` — `longueVue*` rather than `server*` here because the ingest-gw is itself a server, so disambiguating by naming the upstream target reads better

After this PR, `grep -rin argos charts/` returns no matches.

## Breaking change

These keys are part of each chart's public values surface. Operators who set the old names in their own values files will need to rename them. Callsites:

| Old | New |
|---|---|
| `argosd.*` (longue-vue) | `server.*` |
| `argosTLS.*` (collectors) | `serverTLS.*` |
| `networkPolicy.argosd{Selector,Namespace,IngestPort}` (ingest-gw) | `networkPolicy.longueVue{Selector,Namespace,IngestPort}` |

The chart `version:` should be bumped and this change called out in the release notes.

## Test plan

- [ ] CI `helm lint` job passes for `charts/longue-vue` (default values + external-database posture)
- [ ] CI `helm template` renders cleanly for both postures
- [ ] Locally render the three other charts (`longue-vue-collector`, `longue-vue-vm-collector`, `longue-vue-ingest-gw`) — they aren't covered by CI today
- [ ] Confirm chart `version:` bump is in place before tagging a release

---
_Generated by [Claude Code](https://claude.ai/code/session_01FH1g3KXnGCpU2dHWBsAJ15)_