### PR TITLE
chore(security): silence gosec false positives from code scanning

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: securego/gosec@master
         with:
-          args: -fmt sarif -out gosec.sarif -no-fail ./...
+          args: -fmt sarif -out gosec.sarif -no-fail -exclude-generated ./...
       - uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: gosec.sarif

--- a/cmd/longue-vue-vm-collector/main.go
+++ b/cmd/longue-vue-vm-collector/main.go
@@ -182,6 +182,7 @@ func startMetricsServer(ctx context.Context, addr string) {
 			slog.Warn("longue-vue-vm-collector: metrics listener error", slog.Any("error", err))
 		}
 	}()
+	// #nosec G118 -- shutdown timeout intentionally uses a fresh ctx because the parent is already cancelled
 	go func() {
 		<-ctx.Done()
 		// Use a fresh context: the parent ctx is already cancelled, so we need

--- a/cmd/longue-vue/main.go
+++ b/cmd/longue-vue/main.go
@@ -669,7 +669,7 @@ func buildIngestServer(
 // Empty / missing files produce an explicit error so the operator sees
 // the misconfiguration at boot.
 func loadPEMCertPool(path string) (*x509.CertPool, error) {
-	data, err := os.ReadFile(path) //nolint:gosec // operator-supplied path; fail loud if missing
+	data, err := os.ReadFile(path) // #nosec G304 -- operator-supplied path; fail loud if missing
 	if err != nil {
 		return nil, fmt.Errorf("read %q: %w", path, err)
 	}

--- a/internal/api/settings_handlers.go
+++ b/internal/api/settings_handlers.go
@@ -26,6 +26,7 @@ func HandleGetSettings(store Store) http.HandlerFunc {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
+		// #nosec G104 -- response write to HTTP client; nothing to handle
 		json.NewEncoder(w).Encode(settings) //nolint:errcheck // response write to HTTP client; nothing to handle
 	}
 }
@@ -48,6 +49,7 @@ func HandleUpdateSettings(store Store) http.HandlerFunc {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
+		// #nosec G104 -- response write to HTTP client; nothing to handle
 		json.NewEncoder(w).Encode(settings) //nolint:errcheck // response write to HTTP client; nothing to handle
 	}
 }

--- a/internal/auth/passwords.go
+++ b/internal/auth/passwords.go
@@ -86,6 +86,7 @@ func VerifyPassword(plaintext, encoded string) error {
 		return ErrInvalidHashFormat
 	}
 
+	// #nosec G115 -- want is an argon2 hash decoded from base64 of a fixed-size field; len fits uint32 by construction
 	got := argon2.IDKey([]byte(plaintext), salt, time, memory, threads, uint32(len(want)))
 	if subtle.ConstantTimeCompare(got, want) != 1 {
 		return ErrPasswordMismatch

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -41,6 +41,7 @@ const (
 // gated through `trustedProxies` (see ADR-0017). The caller is
 // responsible for writing it to the response.
 func SessionCookie(id string, expires time.Time, r *http.Request, policy SecureCookiePolicy, trustedProxies []*net.IPNet) *http.Cookie {
+	// #nosec G124 -- Secure flag is derived from policy + trusted-proxy posture (ADR-0017); HttpOnly+SameSite=Strict set explicitly
 	return &http.Cookie{
 		Name:     SessionCookieName,
 		Value:    id,
@@ -64,6 +65,7 @@ func SetSessionCookie(w http.ResponseWriter, r *http.Request, id string, expires
 // empty value, MaxAge=-1 so the browser drops it. The caller writes
 // it to the response.
 func ClearSessionCookieValue(r *http.Request, policy SecureCookiePolicy, trustedProxies []*net.IPNet) *http.Cookie {
+	// #nosec G124 -- Secure flag is derived from policy + trusted-proxy posture (ADR-0017); HttpOnly+SameSite=Strict set explicitly
 	return &http.Cookie{
 		Name:     SessionCookieName,
 		Value:    "",

--- a/internal/auth/tokens.go
+++ b/internal/auth/tokens.go
@@ -27,8 +27,8 @@ import (
 //   - `<suffix>` is 32 URL-safe characters, random. Together with the
 //     prefix, argon2id-hashed at rest.
 const (
-	TokenScheme       = "longue_vue_pat_"
-	TokenSchemeLegacy = "argos_pat_"
+	TokenScheme       = "longue_vue_pat_" // #nosec G101 -- token scheme prefix (style ghp_), not a credential value
+	TokenSchemeLegacy = "argos_pat_"      // #nosec G101 -- legacy token scheme prefix, not a credential value
 	tokenPrefixLen    = 8
 	tokenSuffixBytes  = 24 // 24 raw → 32 chars base64-url-unpadded
 )

--- a/internal/impact/handler.go
+++ b/internal/impact/handler.go
@@ -63,6 +63,7 @@ func HandleImpact(store TraverserStore) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
+		// #nosec G104 -- response write to HTTP client; nothing to handle
 		json.NewEncoder(w).Encode(graph) //nolint:errcheck // response write to HTTP client
 	}
 }

--- a/internal/ingestgw/proxy.go
+++ b/internal/ingestgw/proxy.go
@@ -93,6 +93,7 @@ func (s *Server) proxyRequest( //nolint:gocyclo // central proxy dispatcher; fla
 	}
 
 	upStart := time.Now()
+	// #nosec G704 -- reverse proxy by design; upstream scheme/host fixed by operator config in buildUpstreamURL
 	resp, err := s.upstream.Do(upReq)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {

--- a/internal/store/pg_auth.go
+++ b/internal/store/pg_auth.go
@@ -825,6 +825,7 @@ func (p *PG) ListSessions(ctx context.Context, limit int, cursor string) ([]api.
 
 // --- api tokens ----------------------------------------------------------
 
+// #nosec G101 -- SQL column list, not a credential
 const apiTokenColumns = `id, name, prefix, scopes, created_by_user_id,
 	created_at, last_used_at, expires_at, revoked_at`
 


### PR DESCRIPTION
## Summary

Closes the 12 open gosec alerts on `main` (Security → Code scanning).

After audit, **none were vulnerabilities**:

- **G101 (×3)** — token scheme prefix `longue_vue_pat_`/`argos_pat_` and SQL column list, not credential values
- **G124 (×2)** — session cookies set `HttpOnly: true`, `SameSite: Strict`, `Secure` from the policy/trusted-proxy posture (ADR-0017); gosec doesn't follow the computed value
- **G704** — `s.upstream.Do(upReq)` in the ingest gateway is a reverse-proxy call by design; `buildUpstreamURL` keeps scheme/host from operator config
- **G118** — `context.Background()` in the metrics-server shutdown goroutine is intentional: the parent ctx is already cancelled
- **G304** — `os.ReadFile(certFile)` is an operator-supplied TLS path; was already annotated `//nolint:gosec` but gosec only honours its native `// #nosec`
- **G115** — `uint32(len(want))` over an argon2 hash; bounded by the base64 of a fixed-size field
- **G104 (×3)** — `json.NewEncoder(w).Encode(...)` writes to the HTTP client; nothing to handle. Lines were annotated `//nolint:errcheck` (errcheck linter), but gosec G104 needs its own directive

Changes:
- `.github/workflows/security.yml` adds `-exclude-generated` so gosec skips `internal/api/api.gen.go` (oapi-codegen output) → resolves the G101 alert there with no in-code annotation
- 11 in-code `// #nosec G<rule> -- <justification>` annotations on the remaining call sites; existing `//nolint:errcheck` comments stay so errcheck/gocritic remain happy

## Test plan

- [x] `go vet ./...` clean
- [x] `golangci-lint run` — 0 issues
- [x] `gosec -exclude-generated ./...` — `Nosec: 12, Issues: 0` on the affected rules
- [x] `go test -race -cover ./...` — all packages pass
- [x] `npm test` (UI) — 217/217 pass
- [x] After merge, next `security.yml` run should auto-resolve all 12 code-scanning alerts