### PR TITLE
fix(ui): keep wide tables inside the viewport and reclaim wasted left…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/sthalbert/longue-vue
 
 go 1.25.10
 
+toolchain go1.26.3
+
 tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
 
 require (

--- a/ui/src/components/resizable_columns.ts
+++ b/ui/src/components/resizable_columns.ts
@@ -22,6 +22,11 @@ import { useCallback, useEffect, useRef } from 'react';
 
 const STORAGE_PREFIX = 'lv.col-widths.';
 const MIN_WIDTH = 40;
+// Cap on the initial natural-width capture so that a single long unbroken
+// token in a tbody cell (think `ubuntu-22.04-amd64-very-long-image-name`)
+// can't seed a 1000px column that blows the table past its container.
+// Users can still drag a column wider — this only bounds the first paint.
+const INITIAL_MAX_WIDTH = 320;
 
 function loadWidths(key: string): number[] {
   try {
@@ -84,7 +89,8 @@ export function useResizableColumns(storageKey: string) {
       // appearance.
       const widths: number[] = ths.map((th, i) => {
         if (saved[i] && saved[i] > 0) return saved[i];
-        return Math.max(MIN_WIDTH, Math.round(th.getBoundingClientRect().width));
+        const natural = Math.round(th.getBoundingClientRect().width);
+        return Math.min(INITIAL_MAX_WIDTH, Math.max(MIN_WIDTH, natural));
       });
 
       // Build (or reuse) a colgroup. We mark our own with data-lv-resize

--- a/ui/src/pages/VirtualMachines.tsx
+++ b/ui/src/pages/VirtualMachines.tsx
@@ -473,7 +473,8 @@ export default function VirtualMachines() {
               {sorted.length === 0 ? (
                 <p className="muted empty">No virtual machines match these filters.</p>
               ) : (
-                <table className="entities" ref={tableRef}>
+                <div className="table-wrap">
+                  <table className="entities" ref={tableRef}>
                   <thead>
                     <tr>
                       <SortHeader
@@ -629,6 +630,7 @@ export default function VirtualMachines() {
                     })}
                   </tbody>
                 </table>
+                </div>
               )}
               {vms.next_cursor && (
                 <p className="muted" style={{ marginTop: '0.75rem' }}>

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -73,7 +73,7 @@
   --stroke: 1px;
   --stroke-thick: 2px;
   --stroke-accent: 3px;
-  --container-max: 1200px;
+  --container-max: 1600px;
 }
 
 * {
@@ -253,7 +253,11 @@ main {
   padding: 1.75rem 1.5rem;
   width: var(--container-max);
   max-width: 100%;
-  margin: 0 auto;
+  /* Left-aligned: previously `margin: 0 auto` which centered the content
+     in `.app-main`, leaving a multi-hundred-px gutter on the LEFT between
+     the sidebar and the content on wide screens. We sit flush against the
+     sidebar instead, like every modern sidebar-based app. */
+  margin: 0;
   box-sizing: border-box;
 }
 
@@ -620,6 +624,13 @@ h2 svg {
   line-height: 1.45;
 }
 
+/* Wraps a wide <table className="entities"> so it scrolls horizontally
+   instead of bleeding past `<main>` when columns can't be narrowed any
+   further (e.g. 11-column VM list with long image names). */
+.table-wrap {
+  overflow-x: auto;
+  max-width: 100%;
+}
 table.entities {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                     
  - Wrap the VM list `<table>` in `.table-wrap` (now defined in `styles.css` with `overflow-x: auto`) so long VM/image names scroll horizontally inside the panel instead of pushing the page wider than the viewport.
  - Cap the initial natural-width capture in `useResizableColumns` at 320 px (`INITIAL_MAX_WIDTH`) so a single long unbreakable token can't seed a 1000 px column on first paint. Users can still drag wider; persisted widths in localStorage   
  are untouched.                                                                                                                                                                                                                                 
  - Bump `--container-max` from 1200 px to 1600 px and left-align `<main>` (`margin: 0` instead of `0 auto`) to stop wasting ~590 px of left gutter on 2560 px+ screens.                                                                         
                                                                                                                                                                                                                                                 
  Closes #134                                            
                                                                                                                                                                                                                                                 
  ## Test plan                                           
  - [ ] `make ui-check` and `make ui-test`
  - [ ] Open `/ui/virtual-machines` with long VM names — table scrolls inside the panel, page does not overflow                                                                                                                                  
  - [ ] Verify at 1440 / 1920 / 2560 / 3440 viewport widths the content sits flush to the sidebar with no large left gutter                                                                                                                      
  - [ ] Drag a column wider, reload — width persists; double-click a handle resets to natural width 