### PR TITLE
feat(audit): drop no-op CMDB writes from audit log (ADR-0024)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ ui/debug-*.mjs
 # Local-only forbidden-words pre-commit scanner
 /.forbidden-words
 /scripts/check-forbidden-words.sh
+
+# Isolated worktrees for subagent-driven development
+/.worktrees/

--- a/docs/adr/adr-0008-secnumcloud-chapter-8-asset-management.md
+++ b/docs/adr/adr-0008-secnumcloud-chapter-8-asset-management.md
@@ -286,9 +286,12 @@ and implemented as a follow-up PR series:
 
 - **IMP-005**: **Audit trail**: changes to classification fields land
   in `audit_events` automatically — the audit middleware (ADR-0007
-  follow-up) already records every PATCH with a scrubbed body. The
-  body diff will include the before/after DICT values, which is
-  exactly what an SNC assessor needs to verify §8.3 traceability.
+  follow-up) records every **state-changing** write (ADR-0024
+  refinement: idempotent no-op upserts are filtered, but any PATCH
+  that mutates a classification field necessarily changes business
+  state and is therefore recorded with a scrubbed body). The body diff
+  will include the before/after DICT values, which is exactly what an
+  SNC assessor needs to verify §8.3 traceability.
 
 - **IMP-006**: **Dependency-Track integration for §8.1.c**: document
   in `docs/compliance/snc-chapter-8.md` that the CMDB's role is to

--- a/docs/adr/adr-0010-admin-only-cluster-deletion-with-audit.md
+++ b/docs/adr/adr-0010-admin-only-cluster-deletion-with-audit.md
@@ -25,7 +25,9 @@ Deleting a cluster is the single most destructive operation in longue-vue. The `
 Today the `DELETE /v1/clusters/{id}` endpoint is gated on the `delete` scope, which per ADR-0007 is granted exclusively to the `admin` role. That satisfies the "only admins can do it" requirement at the scope level. However, two gaps remain:
 
 1. **No explicit confirmation safeguard.** A single `DELETE` call — whether from the UI, a script, or an accidental `curl` — immediately drops the cluster and all its children. There is no "are you sure?" at the API level and no soft-delete window.
-2. **Audit coverage is implicit.** The `AuditMiddleware` already captures every non-GET request including `DELETE /v1/clusters/{id}`, recording the actor, timestamp, HTTP method/path, response status, and scrubbed body. But the audit record does not capture _what_ was lost — no count of cascaded children, no cluster name snapshot. If the cluster row is gone, the audit event's `resource_id` (a UUID) becomes an opaque string with no human context.
+2. **Audit coverage is implicit.** The `AuditMiddleware` already captures every non-GET request[^noop] including `DELETE /v1/clusters/{id}`, recording the actor, timestamp, HTTP method/path, response status, and scrubbed body. But the audit record does not capture _what_ was lost — no count of cascaded children, no cluster name snapshot. If the cluster row is gone, the audit event's `resource_id` (a UUID) becomes an opaque string with no human context.
+
+[^noop]: ADR-0024 refined this criterion from "every non-GET request" to "every state-changing write": idempotent no-op upserts and empty reconciles are filtered out. Cluster deletions are never no-op (they always remove at least the `clusters` row), so the conclusions of this ADR stand unchanged.
 
 ANSSI SecNumCloud chapter 8 (asset management) requires that the CMDB maintain an accurate, auditable inventory. Deleting an entire cluster's worth of assets is a significant event that must be traceable to a named human actor with enough context to answer "what happened and what was lost."
 

--- a/docs/adr/adr-0024-audit-no-op-write-filtering.md
+++ b/docs/adr/adr-0024-audit-no-op-write-filtering.md
@@ -1,0 +1,270 @@
+---
+title: "ADR-0024: Audit no-op write filtering for SecNumCloud trail compactness"
+status: "Accepted"
+date: "2026-05-13"
+authors: "Steve ALBERT"
+tags: ["architecture", "audit", "secnumcloud", "performance"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0024: Audit no-op write filtering for SecNumCloud trail compactness
+
+## Status
+
+Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-05-13
+- **Supersedes:** none
+- **Superseded by:** none
+
+## Context
+
+The `audit_events` table grows by ~500k rows/day on the production CMDB
+instance. The 2026-05-12 snapshot measured **6.7 GB / 6.4M rows over 16
+days**. The dominant write volume comes from K8s collector ticks (POST
+`/v1/pods`, `/v1/services`, `/v1/virtual-machines`, …): every tick
+re-upserts every resource even when nothing changed, and the audit
+middleware records every non-GET request — so each tick produces one
+audit row per resource regardless of state change.
+
+The growth has two operational consequences:
+
+1. Insert pressure cascades. `context canceled` errors were observed on
+   `/v1/services/reconcile` under collector load.
+2. ANSSI SecNumCloud retention (≥30 days) extrapolates to ~15 GB of
+   mostly-redundant rows — pure cost without forensic value.
+
+The audit middleware (ADR-0007 §IMP-005, ADR-0008 §8.3, ADR-0010) was
+written before push collectors existed; its rule "audit every non-GET
+request" was correct for a human-only API but is wrong for a system
+where 95%+ of writes are idempotent collector re-ticks.
+
+## Decision
+
+**Audit = state change, not request method.**
+
+A write is auditable when it produces an observable change in CMDB
+state. A re-upsert that touches only clock fields (`last_seen`,
+`updated_at`) is **not** a state change and is not audited. The audit
+middleware remains the sole writer of `audit_events`; the change is
+purely a filter applied to its insert path.
+
+### State-change definition
+
+- **Upsert (POST `/v1/<resource>`)**: any business field changes
+  (`INSERT`, or `UPDATE` where the CTE detects at least one column
+  changed). Clock-field-only updates → no audit row.
+- **Reconcile (POST `/v1/<resource>/reconcile`)**: at least one row
+  was deleted/tombstoned (`Delete*NotIn` returned `> 0`,
+  `ReconcileVirtualMachines` tombstoned `> 0`). Empty reconcile → no
+  audit row.
+- **Everything else stays audited** — see compliance invariants below.
+
+### Mechanism
+
+A new `UpsertOutcome` enum is returned by every `Upsert*` store
+function:
+
+```go
+type UpsertOutcome int
+
+const (
+    OutcomeInserted        UpsertOutcome = iota // new row
+    OutcomeBusinessChanged                      // UPDATE: ≥1 business field changed
+    OutcomeNoChange                             // UPDATE: only clock fields touched
+)
+```
+
+The PG implementation uses a CTE that compares each business column
+with `IS DISTINCT FROM` (NULL-safe) in a single round-trip:
+
+```sql
+WITH old AS (SELECT <business cols> FROM <table> WHERE …),
+     upserted AS (
+       INSERT … ON CONFLICT … DO UPDATE SET … RETURNING id, xmax, <business cols>
+     )
+SELECT u.id,
+       (u.xmax = 0) AS inserted,
+       (u.xmax <> 0 AND (o.col_a IS DISTINCT FROM u.col_a OR …)) AS business_changed
+FROM upserted u LEFT JOIN old o ON true;
+```
+
+Handlers consume the outcome and call `api.SetAuditSkip(ctx)` when it
+is `OutcomeNoChange`. Reconcile handlers call `SetAuditSkip` (and
+`SetAuditSkipReason(ctx, "reconcile_empty")`) when the store returned
+`0`. The audit middleware reads the bag after the handler returns and
+decides whether to insert.
+
+### Forensic bypass
+
+Even when `SetAuditSkip` was called, the middleware **always inserts**
+when any of the following holds:
+
+- HTTP status ≥ 400 (any error path — forensic value).
+- Path matches an auth-always set: `/v1/auth/login`, `/v1/auth/logout`,
+  `/v1/auth/change-password`, `/v1/auth/oidc/authorize`,
+  `/v1/auth/oidc/callback`.
+
+`shouldAudit()` itself is unchanged: it still passes admin GETs
+(`/v1/admin/*`) and the credentials-fetch path
+(`/v1/cloud-accounts/.../credentials`) into the audit pipeline. The
+skip flag is only ever set by upsert + reconcile handlers, never by
+admin or auth handlers.
+
+## Compliance invariants
+
+| Category | Before | After | Reason |
+|---|---|---|---|
+| Admin GET `/v1/admin/*` | audited | **audited** | `shouldAudit()` unchanged |
+| Credentials fetch GET | audited | **audited** | `shouldAudit()` unchanged (ADR-0015 §5) |
+| Auth (login, logout, change-pwd, OIDC) | audited | **audited** | explicit skip bypass on auth-always paths |
+| Error 4xx/5xx on write | audited | **audited** | explicit skip bypass when status ≥ 400 |
+| Admin create/update/delete | audited | **audited** | admin handlers do not call `SetAuditSkip` |
+| User self-service (change-password) | audited | **audited** | auth bypass |
+| Collector INSERT | audited | **audited** | `Outcome=Inserted` |
+| Collector UPDATE business | audited | **audited** | `Outcome=BusinessChanged` |
+| Collector reconcile with deletes | audited | **audited** | `count > 0` |
+| **Collector UPDATE no-op (clock only)** | audited | **dropped** | `Outcome=NoChange` |
+| **Collector reconcile empty** | audited | **dropped** | `count == 0` |
+
+The trade-off is that we lose the ability to assert from the audit
+table alone "this collector token called the API at 15:32:14". That
+behavioural signal moves to the Prometheus counter below — `audit_events`
+remains the forensic record of state changes only.
+
+## Observability
+
+A new Prometheus counter replaces the "collector heartbeat via audit
+row" signal:
+
+```
+longue_vue_audit_events_skipped_total{actor_kind, resource_type, reason}
+```
+
+- `actor_kind`: `user|token|anonymous`
+- `resource_type`: `pod|service|workload|node|namespace|ingress|persistentvolume|persistentvolumeclaim|virtual_machine|<resource>`
+- `reason`: `no_change` (upsert no-op) | `reconcile_empty` (reconcile no-op)
+
+The ratio `skipped / (skipped + inserted)` measures filter efficiency.
+Targeted dashboard panel "Audit write rate" gets two series — inserted
+vs skipped.
+
+No new application logs: skipped events stay silent. Detection errors
+(unexpected `UpsertOutcome` value) log at WARN.
+
+## Consequences
+
+### Positive
+
+- ~95% reduction in `audit_events` insert volume on collector traffic
+  (3 identical upserts → 1 row, validated by the integration test).
+- SecNumCloud 30-day window shrinks from ~15 GB to ~750 MB on the
+  production traffic mix.
+- Insert pressure relieved → `context canceled` cascades on hot
+  reconciles disappear.
+- Forensic value preserved: every state change, every error, every
+  auth event still lands in `audit_events`.
+
+### Negative
+
+- Per-upsert SQL grows from a single `INSERT … ON CONFLICT …` to a CTE
+  with `IS DISTINCT FROM` against the old row. Benchmark `UpsertPod`
+  (hottest path) before merge; if regression > 15% the CTE is reverted
+  and a different detection strategy (e.g. application-side hash) is
+  evaluated.
+- Each `Upsert*` carries a hand-maintained list of business columns.
+  Adding a new business column without updating that list silently
+  drops audits for changes to it. Mitigations: `// AUDIT_BUSINESS_FIELDS`
+  marker comment on every list, PR review checklist line, and a
+  table-driven test asserting `Outcome=BusinessChanged` when each
+  business field is touched individually.
+- Behavioural observability ("how often does this collector tick?")
+  moves out of `audit_events` and into the Prom counter. Dashboards
+  that previously scraped `audit_events` for collector activity must
+  migrate.
+
+### Neutral
+
+- No schema change on `audit_events`. Existing rows are preserved;
+  future rows just contain less collector noise.
+- No feature flag. The change is non-recoverable — a missed audit
+  event cannot be backfilled — so a graduated flag would only defer
+  the risk, not mitigate it. Mitigation lives in tests, not in a
+  runtime toggle. Rollback is a code revert: middleware ignores `skip`
+  and audit becomes verbose again.
+
+## Alternatives considered
+
+### Asynchronous audit insertion (queue + worker)
+
+Move audit inserts off the request path entirely into a background
+worker. Rejected: doesn't reduce row count, only smooths latency.
+Same 6.4M rows / 16 days, same retention cost.
+
+### Audit-events partitioning
+
+PostgreSQL declarative range partitioning on `occurred_at`. Solves the
+storage-management problem (drop old partitions instead of `DELETE`)
+but **does not** reduce row volume. Tracked separately as a follow-up
+structural fix; complementary to this ADR.
+
+### Application-side hash comparison
+
+Compute a `SHA-256` of the row's business columns in Go, compare to
+the previous hash stored in the DB. Rejected: doubles the storage
+overhead on every row, requires a schema migration, and risks
+divergence between the in-Go hash and the actual SQL semantics.
+
+### Audit-everything-as-now, just batch the writes
+
+Buffer audit writes in-memory and flush every N seconds. Rejected:
+loses durability on crash, complicates the forensic chain (gap windows
+between flush and crash), and still costs the row volume.
+
+### Per-collector heartbeat suppression
+
+Drop audits from a specific token-id allowlist. Rejected: brittle (new
+collector deployment forgotten in the allowlist would re-flood
+audits), and it preserves audits for handwritten Postman/curl traffic
+that nobody asked for.
+
+## Implementation status
+
+- Migration: none. No `audit_events` schema change.
+- Store: `Upsert*` signature returns `UpsertOutcome`; PG impl uses CTE
+  with `IS DISTINCT FROM`; memStore fake mirrors via snapshot +
+  `reflect.DeepEqual`.
+- Middleware: `SetAuditSkip(ctx)`, `SetAuditSkipReason(ctx, reason)`,
+  bypass when `status ≥ 400` or path ∈ auth-always set.
+- Handlers wired: 8 K8s upserts + VM upsert + 8 K8s reconciles + VM
+  reconcile.
+- Metrics: `longue_vue_audit_events_skipped_total{actor_kind,resource_type,reason}`.
+- Tests: per-upsert handler tests (mock store outcome → assert skip),
+  reconcile tests (`n == 0` → skip with reason `reconcile_empty`),
+  middleware matrix (status ≥ 400 → never skip, auth-always → never
+  skip), integration test (3 identical pod upserts → 1 row + counter
+  delta = 2).
+
+## Related ADRs
+
+- ADR-0007 — Auth & RBAC — **unchanged**, concept preserved.
+- ADR-0008 — SecNumCloud Ch.8 asset management — **amendment** to
+  IMP-005: criterion changes from "every non-GET" to "every state
+  change"; PATCH classification fields always change state, so §8.3
+  traceability is preserved.
+- ADR-0010 — Admin-only cluster deletion with audit trail —
+  **amendment**: the "AuditMiddleware captures every non-GET request"
+  line is footnoted; cluster deletes are never no-op (always remove
+  rows), so the ADR's conclusions stand.
+- ADR-0015 — VM collector — credentials fetch GET stays audited (the
+  `shouldAudit()` path is unchanged).
+
+## References
+
+- Design doc: `docs/superpowers/specs/2026-05-13-audit-noop-filter-design.md`
+- Implementation plan: `docs/superpowers/plans/2026-05-13-audit-noop-filter.md`
+- Code: `internal/api/audit.go`, `internal/api/outcome.go`, `internal/api/server.go`,
+  `internal/api/virtual_machine_handlers.go`, `internal/store/pg_*.go`,
+  `internal/metrics/metrics.go`.
+- CLAUDE.md — "Audit log" section.

--- a/internal/api/audit.go
+++ b/internal/api/audit.go
@@ -116,6 +116,8 @@ var authAlwaysAuditPaths = map[string]struct{}{ //nolint:gochecknoglobals // rea
 // the audit row. Pass nil to ignore XFF unconditionally — the secure
 // default and what tests should use unless they're specifically
 // exercising proxy-trust behavior.
+//
+//nolint:gocyclo // skip-decision branches each carry distinct compliance semantics
 func AuditMiddleware(recorder AuditRecorder, source string, trustedProxies []*net.IPNet) MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/audit.go
+++ b/internal/api/audit.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/sthalbert/longue-vue/internal/auth"
 	"github.com/sthalbert/longue-vue/internal/httputil"
+	"github.com/sthalbert/longue-vue/internal/metrics"
 )
 
 // AuditRecorder is the narrow slice of Store the middleware needs.
@@ -39,7 +40,9 @@ type AuditRecorder interface {
 // derived context that cannot propagate values back to the middleware's
 // original request context.
 type auditBag struct {
-	details map[string]any
+	details     map[string]any
+	skip        bool
+	skipReason_ string // set via SetAuditSkipReason; defaults to "no_change"
 }
 
 type ctxKeyAuditBag struct{}
@@ -58,6 +61,41 @@ func SetAuditDetails(ctx context.Context, details map[string]any) {
 	if bag, ok := ctx.Value(ctxKeyAuditBag{}).(*auditBag); ok && bag != nil {
 		bag.details = details
 	}
+}
+
+// SetAuditSkip marks the current request as droppable by the audit
+// middleware. Handlers call this when the request did not change any
+// business state (e.g., a collector upsert that touched only clock
+// fields, or a reconcile that deleted zero rows). The middleware honors
+// the flag unless the response status is >= 400 (forensic) or the path
+// is on the auth-endpoint allowlist. See ADR-0024.
+//
+// Safe to call when no bag is present (no-op).
+func SetAuditSkip(ctx context.Context) {
+	if bag, ok := ctx.Value(ctxKeyAuditBag{}).(*auditBag); ok && bag != nil {
+		bag.skip = true
+	}
+}
+
+// SetAuditSkipReason overrides the default "no_change" reason label on
+// the Prometheus skipped counter. Call from reconcile handlers that
+// dropped zero rows with reason="reconcile_empty".
+func SetAuditSkipReason(ctx context.Context, reason string) {
+	if bag, ok := ctx.Value(ctxKeyAuditBag{}).(*auditBag); ok && bag != nil {
+		bag.skipReason_ = reason
+	}
+}
+
+// authAlwaysAuditPaths is the small set of auth endpoints where every
+// call must produce an audit row, even when a handler set the skip
+// flag. Login attempts, logout, password changes and OIDC handshakes
+// must remain visible regardless of state-change semantics.
+var authAlwaysAuditPaths = map[string]struct{}{ //nolint:gochecknoglobals // read-only lookup
+	"/v1/auth/login":           {},
+	"/v1/auth/logout":          {},
+	"/v1/auth/change-password": {},
+	"/v1/auth/oidc/authorize":  {},
+	"/v1/auth/oidc/callback":   {},
 }
 
 // AuditMiddleware wraps the generated router and records every call
@@ -103,6 +141,13 @@ func AuditMiddleware(recorder AuditRecorder, source string, trustedProxies []*ne
 
 			rw := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 			next.ServeHTTP(rw, r)
+
+			if bag.skip && rw.status < 400 {
+				if _, alwaysAudit := authAlwaysAuditPaths[r.URL.Path]; !alwaysAudit {
+					metrics.ObserveAuditSkipped(auditActorKind(r), auditResourceType(r), bag.skipReason())
+					return
+				}
+			}
 
 			ev := buildAuditEvent(r, rw.status, bodySnap, trustedProxies)
 			ev.Source = source
@@ -326,6 +371,39 @@ func scrubSecrets(raw []byte) any {
 		}
 	}
 	return obj
+}
+
+// auditActorKind mirrors buildAuditEvent's actor classification but
+// returns just the kind label used by Prometheus.
+func auditActorKind(r *http.Request) string {
+	if c := auth.CallerFromContext(r.Context()); c != nil {
+		switch c.Kind {
+		case auth.CallerKindUser:
+			return "user"
+		case auth.CallerKindToken:
+			return "token"
+		}
+	}
+	return "anonymous"
+}
+
+// auditResourceType returns the resource label for the skipped counter.
+// Falls back to "unknown" when the URL does not match a known shape.
+func auditResourceType(r *http.Request) string {
+	t, _ := deriveResource(r)
+	if t == "" {
+		return "unknown"
+	}
+	return t
+}
+
+// skipReason returns the Prom-label reason value. Defaults to
+// "no_change"; reconcile handlers override via SetAuditSkipReason.
+func (b *auditBag) skipReason() string {
+	if b.skipReason_ == "" {
+		return "no_change"
+	}
+	return b.skipReason_
 }
 
 // statusRecorder is the tiniest http.ResponseWriter wrapper that

--- a/internal/api/audit_export_test.go
+++ b/internal/api/audit_export_test.go
@@ -1,0 +1,19 @@
+package api
+
+import "context"
+
+// WithAuditBagForTest exposes withAuditBag to the api_test package so
+// handler tests can pre-seed a bag and inspect SetAuditSkip behavior
+// without spinning up the full AuditMiddleware.
+func WithAuditBagForTest(ctx context.Context) (context.Context, *AuditBagTestView) {
+	c, bag := withAuditBag(ctx)
+	return c, &AuditBagTestView{bag: bag}
+}
+
+// AuditBagTestView is a narrow read-only window into the audit bag for
+// _test packages. Production code reads/writes the bag indirectly via
+// SetAuditSkip / SetAuditDetails / SetAuditSkipReason.
+type AuditBagTestView struct{ bag *auditBag }
+
+func (v *AuditBagTestView) SkipForTest() bool         { return v.bag.skip }
+func (v *AuditBagTestView) SkipReasonForTest() string { return v.bag.skipReason() }

--- a/internal/api/audit_test.go
+++ b/internal/api/audit_test.go
@@ -226,8 +226,22 @@ func TestListAuditEventsHandler(t *testing.T) {
 	}
 }
 
+// postEmptyJSON POSTs an empty JSON body to url with context bound to the
+// test deadline. Wrapper exists so callers don't trip the noctx linter
+// on http.Post; tests in this file only ever send `{}`.
+func postEmptyJSON(t *testing.T, url string) (*http.Response, error) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, url, strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return http.DefaultClient.Do(req) //nolint:wrapcheck // pass-through helper for tests
+}
+
 type recorderStub struct{ inserts atomic.Int32 }
 
+//nolint:gocritic // hugeParam: AuditRecorder interface mandates value param
 func (r *recorderStub) InsertAuditEvent(_ context.Context, _ AuditEventInsert) error {
 	r.inserts.Add(1)
 	return nil
@@ -244,7 +258,7 @@ func TestAuditMiddleware_SkipRespected(t *testing.T) {
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
-	resp, err := http.Post(srv.URL+"/v1/pods", "application/json", strings.NewReader(`{}`))
+	resp, err := postEmptyJSON(t, srv.URL+"/v1/pods")
 	if err != nil {
 		t.Fatalf("post: %v", err)
 	}
@@ -266,7 +280,7 @@ func TestAuditMiddleware_SkipBypassedOnError(t *testing.T) {
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
-	resp, err := http.Post(srv.URL+"/v1/pods", "application/json", strings.NewReader(`{}`))
+	resp, err := postEmptyJSON(t, srv.URL+"/v1/pods")
 	if err != nil {
 		t.Fatalf("post: %v", err)
 	}
@@ -284,7 +298,6 @@ func TestAuditMiddleware_SkipBypassedOnAuthPath(t *testing.T) {
 		"/v1/auth/oidc/authorize", "/v1/auth/oidc/callback",
 	}
 	for _, p := range authPaths {
-		p := p
 		t.Run(p, func(t *testing.T) {
 			t.Parallel()
 			rec := &recorderStub{}
@@ -296,7 +309,7 @@ func TestAuditMiddleware_SkipBypassedOnAuthPath(t *testing.T) {
 			srv := httptest.NewServer(h)
 			defer srv.Close()
 
-			resp, err := http.Post(srv.URL+p, "application/json", strings.NewReader(`{}`))
+			resp, err := postEmptyJSON(t, srv.URL+p)
 			if err != nil {
 				t.Fatalf("post: %v", err)
 			}
@@ -319,7 +332,7 @@ func TestAuditMiddleware_NoSkipKeepsExistingBehaviour(t *testing.T) {
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
-	resp, err := http.Post(srv.URL+"/v1/pods", "application/json", strings.NewReader(`{}`))
+	resp, err := postEmptyJSON(t, srv.URL+"/v1/pods")
 	if err != nil {
 		t.Fatalf("post: %v", err)
 	}

--- a/internal/api/audit_test.go
+++ b/internal/api/audit_test.go
@@ -11,6 +11,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/uuid"
@@ -221,5 +223,109 @@ func TestListAuditEventsHandler(t *testing.T) {
 	}
 	if len(got.Items) != 3 {
 		t.Errorf("expected 3 items, got %d", len(got.Items))
+	}
+}
+
+type recorderStub struct{ inserts atomic.Int32 }
+
+func (r *recorderStub) InsertAuditEvent(_ context.Context, _ AuditEventInsert) error {
+	r.inserts.Add(1)
+	return nil
+}
+
+func TestAuditMiddleware_SkipRespected(t *testing.T) {
+	t.Parallel()
+	rec := &recorderStub{}
+	mw := AuditMiddleware(rec, "api", nil)
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		SetAuditSkip(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/v1/pods", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	resp.Body.Close()
+
+	if got := rec.inserts.Load(); got != 0 {
+		t.Errorf("SetAuditSkip + 2xx should drop insert; got %d inserts", got)
+	}
+}
+
+func TestAuditMiddleware_SkipBypassedOnError(t *testing.T) {
+	t.Parallel()
+	rec := &recorderStub{}
+	mw := AuditMiddleware(rec, "api", nil)
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		SetAuditSkip(r.Context())
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/v1/pods", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	resp.Body.Close()
+
+	if got := rec.inserts.Load(); got != 1 {
+		t.Errorf("status >= 400 must bypass skip; got %d inserts", got)
+	}
+}
+
+func TestAuditMiddleware_SkipBypassedOnAuthPath(t *testing.T) {
+	t.Parallel()
+	authPaths := []string{
+		"/v1/auth/login", "/v1/auth/logout", "/v1/auth/change-password",
+		"/v1/auth/oidc/authorize", "/v1/auth/oidc/callback",
+	}
+	for _, p := range authPaths {
+		p := p
+		t.Run(p, func(t *testing.T) {
+			t.Parallel()
+			rec := &recorderStub{}
+			mw := AuditMiddleware(rec, "api", nil)
+			h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				SetAuditSkip(r.Context())
+				w.WriteHeader(http.StatusOK)
+			}))
+			srv := httptest.NewServer(h)
+			defer srv.Close()
+
+			resp, err := http.Post(srv.URL+p, "application/json", strings.NewReader(`{}`))
+			if err != nil {
+				t.Fatalf("post: %v", err)
+			}
+			resp.Body.Close()
+
+			if got := rec.inserts.Load(); got != 1 {
+				t.Errorf("auth path must bypass skip; got %d inserts on %s", got, p)
+			}
+		})
+	}
+}
+
+func TestAuditMiddleware_NoSkipKeepsExistingBehaviour(t *testing.T) {
+	t.Parallel()
+	rec := &recorderStub{}
+	mw := AuditMiddleware(rec, "api", nil)
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/v1/pods", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	resp.Body.Close()
+
+	if got := rec.inserts.Load(); got != 1 {
+		t.Errorf("no skip + 2xx should insert; got %d inserts", got)
 	}
 }

--- a/internal/api/audit_test.go
+++ b/internal/api/audit_test.go
@@ -226,17 +226,19 @@ func TestListAuditEventsHandler(t *testing.T) {
 	}
 }
 
-// postEmptyJSON POSTs an empty JSON body to url with context bound to the
-// test deadline. Wrapper exists so callers don't trip the noctx linter
-// on http.Post; tests in this file only ever send `{}`.
-func postEmptyJSON(t *testing.T, url string) (*http.Response, error) {
+// postEmptyJSON POSTs an empty JSON body to srv with context bound to the
+// test deadline. Uses srv.Client() instead of http.DefaultClient so parallel
+// subtests don't race on httptest.Server.Close(), which calls
+// CloseIdleConnections on http.DefaultTransport and can rip a connection
+// out from under a sibling subtest's in-flight request.
+func postEmptyJSON(t *testing.T, srv *httptest.Server, path string) (*http.Response, error) {
 	t.Helper()
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, url, strings.NewReader(`{}`))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+path, strings.NewReader(`{}`))
 	if err != nil {
 		t.Fatalf("build request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	return http.DefaultClient.Do(req) //nolint:wrapcheck // pass-through helper for tests
+	return srv.Client().Do(req) //nolint:wrapcheck // pass-through helper for tests
 }
 
 type recorderStub struct{ inserts atomic.Int32 }
@@ -258,7 +260,7 @@ func TestAuditMiddleware_SkipRespected(t *testing.T) {
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
-	resp, err := postEmptyJSON(t, srv.URL+"/v1/pods")
+	resp, err := postEmptyJSON(t, srv, "/v1/pods")
 	if err != nil {
 		t.Fatalf("post: %v", err)
 	}
@@ -280,7 +282,7 @@ func TestAuditMiddleware_SkipBypassedOnError(t *testing.T) {
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
-	resp, err := postEmptyJSON(t, srv.URL+"/v1/pods")
+	resp, err := postEmptyJSON(t, srv, "/v1/pods")
 	if err != nil {
 		t.Fatalf("post: %v", err)
 	}
@@ -309,7 +311,7 @@ func TestAuditMiddleware_SkipBypassedOnAuthPath(t *testing.T) {
 			srv := httptest.NewServer(h)
 			defer srv.Close()
 
-			resp, err := postEmptyJSON(t, srv.URL+p)
+			resp, err := postEmptyJSON(t, srv, p)
 			if err != nil {
 				t.Fatalf("post: %v", err)
 			}
@@ -332,7 +334,7 @@ func TestAuditMiddleware_NoSkipKeepsExistingBehaviour(t *testing.T) {
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
-	resp, err := postEmptyJSON(t, srv.URL+"/v1/pods")
+	resp, err := postEmptyJSON(t, srv, "/v1/pods")
 	if err != nil {
 		t.Fatalf("post: %v", err)
 	}

--- a/internal/api/outcome.go
+++ b/internal/api/outcome.go
@@ -1,0 +1,35 @@
+package api
+
+// UpsertOutcome classifies the result of an Upsert* operation so the
+// audit middleware can decide whether to record a row. A tick that only
+// refreshes clock fields (last_seen / updated_at) returns OutcomeNoChange
+// and is filtered out; everything else is recorded as before.
+//
+// The enum lives in internal/api (not internal/store) to avoid an
+// import cycle: internal/store imports internal/api for entity types,
+// so the Store interface — which lives here — must reference a type
+// declared here. See ADR-0024.
+type UpsertOutcome int
+
+const (
+	// OutcomeInserted — the row did not exist; INSERT path was taken.
+	OutcomeInserted UpsertOutcome = iota
+	// OutcomeBusinessChanged — the row existed and ≥1 business field changed.
+	OutcomeBusinessChanged
+	// OutcomeNoChange — the row existed and only clock fields were touched.
+	OutcomeNoChange
+)
+
+// String returns a stable lowercase token suitable for a Prometheus label.
+func (o UpsertOutcome) String() string {
+	switch o {
+	case OutcomeInserted:
+		return "inserted"
+	case OutcomeBusinessChanged:
+		return "business_changed"
+	case OutcomeNoChange:
+		return "no_change"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/api/outcome_test.go
+++ b/internal/api/outcome_test.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestUpsertOutcome_String(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		o    UpsertOutcome
+		want string
+	}{
+		{OutcomeInserted, "inserted"},
+		{OutcomeBusinessChanged, "business_changed"},
+		{OutcomeNoChange, "no_change"},
+		{UpsertOutcome(99), "unknown"},
+	}
+	for _, tc := range cases {
+		if got := tc.o.String(); got != tc.want {
+			t.Errorf("UpsertOutcome(%d).String() = %q, want %q", tc.o, got, tc.want)
+		}
+	}
+}

--- a/internal/api/pods_handlers_test.go
+++ b/internal/api/pods_handlers_test.go
@@ -13,6 +13,8 @@ import (
 // wiring: a brand-new POST must NOT mark the audit bag skip, while an
 // identical replay (same business fields, store classifies NoChange)
 // MUST flip skip=true so AuditMiddleware drops the row.
+//
+//nolint:gocyclo // sequenced three-phase scenario keeps fresh/identical/mutated checks contiguous
 func TestCreatePod_NoOpCallsSetAuditSkip(t *testing.T) {
 	t.Parallel()
 	store := newMemStore()
@@ -39,7 +41,7 @@ func TestCreatePod_NoOpCallsSetAuditSkip(t *testing.T) {
 	podBody := fmt.Sprintf(`{"namespace_id":%q,"name":"pod-a","phase":"Running"}`, ns.Id.String())
 
 	// First POST: new pod, must NOT skip.
-	r1 := httptest.NewRequest(http.MethodPost, "/v1/pods", strings.NewReader(podBody))
+	r1 := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/pods", strings.NewReader(podBody))
 	r1.Header.Set("Content-Type", "application/json")
 	ctx1, bag1 := WithAuditBagForTest(r1.Context())
 	w1 := httptest.NewRecorder()
@@ -53,7 +55,7 @@ func TestCreatePod_NoOpCallsSetAuditSkip(t *testing.T) {
 
 	// Second POST: identical body, store classifies NoChange, handler
 	// MUST mark skip.
-	r2 := httptest.NewRequest(http.MethodPost, "/v1/pods", strings.NewReader(podBody))
+	r2 := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/pods", strings.NewReader(podBody))
 	r2.Header.Set("Content-Type", "application/json")
 	ctx2, bag2 := WithAuditBagForTest(r2.Context())
 	w2 := httptest.NewRecorder()
@@ -67,7 +69,7 @@ func TestCreatePod_NoOpCallsSetAuditSkip(t *testing.T) {
 
 	// Third POST: change phase → BusinessChanged, must NOT skip.
 	changedBody := fmt.Sprintf(`{"namespace_id":%q,"name":"pod-a","phase":"Succeeded"}`, ns.Id.String())
-	r3 := httptest.NewRequest(http.MethodPost, "/v1/pods", strings.NewReader(changedBody))
+	r3 := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/pods", strings.NewReader(changedBody))
 	r3.Header.Set("Content-Type", "application/json")
 	ctx3, bag3 := WithAuditBagForTest(r3.Context())
 	w3 := httptest.NewRecorder()

--- a/internal/api/pods_handlers_test.go
+++ b/internal/api/pods_handlers_test.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestCreatePod_NoOpCallsSetAuditSkip exercises the audit no-op filter
+// wiring: a brand-new POST must NOT mark the audit bag skip, while an
+// identical replay (same business fields, store classifies NoChange)
+// MUST flip skip=true so AuditMiddleware drops the row.
+func TestCreatePod_NoOpCallsSetAuditSkip(t *testing.T) {
+	t.Parallel()
+	store := newMemStore()
+	h := newTestHandler(t, store)
+
+	clusterResp := do(h, http.MethodPost, "/v1/clusters", `{"name":"prod-pod-skip"}`)
+	if clusterResp.Code != http.StatusCreated {
+		t.Fatalf("create cluster: %d %q", clusterResp.Code, clusterResp.Body.String())
+	}
+	var cluster Cluster
+	if err := json.Unmarshal(clusterResp.Body.Bytes(), &cluster); err != nil {
+		t.Fatalf("decode cluster: %v", err)
+	}
+
+	nsResp := do(h, http.MethodPost, "/v1/namespaces", fmt.Sprintf(`{"cluster_id":%q,"name":"apps"}`, cluster.Id.String()))
+	if nsResp.Code != http.StatusCreated {
+		t.Fatalf("create namespace: %d %q", nsResp.Code, nsResp.Body.String())
+	}
+	var ns Namespace
+	if err := json.Unmarshal(nsResp.Body.Bytes(), &ns); err != nil {
+		t.Fatalf("decode namespace: %v", err)
+	}
+
+	podBody := fmt.Sprintf(`{"namespace_id":%q,"name":"pod-a","phase":"Running"}`, ns.Id.String())
+
+	// First POST: new pod, must NOT skip.
+	r1 := httptest.NewRequest(http.MethodPost, "/v1/pods", strings.NewReader(podBody))
+	r1.Header.Set("Content-Type", "application/json")
+	ctx1, bag1 := WithAuditBagForTest(r1.Context())
+	w1 := httptest.NewRecorder()
+	h.ServeHTTP(w1, r1.WithContext(ctx1))
+	if w1.Code != http.StatusCreated {
+		t.Fatalf("first POST: %d %q", w1.Code, w1.Body.String())
+	}
+	if bag1.SkipForTest() {
+		t.Fatalf("first POST should NOT skip audit (outcome=Inserted)")
+	}
+
+	// Second POST: identical body, store classifies NoChange, handler
+	// MUST mark skip.
+	r2 := httptest.NewRequest(http.MethodPost, "/v1/pods", strings.NewReader(podBody))
+	r2.Header.Set("Content-Type", "application/json")
+	ctx2, bag2 := WithAuditBagForTest(r2.Context())
+	w2 := httptest.NewRecorder()
+	h.ServeHTTP(w2, r2.WithContext(ctx2))
+	if w2.Code != http.StatusCreated {
+		t.Fatalf("second POST: %d %q", w2.Code, w2.Body.String())
+	}
+	if !bag2.SkipForTest() {
+		t.Fatalf("identical second POST SHOULD skip audit (outcome=NoChange)")
+	}
+
+	// Third POST: change phase → BusinessChanged, must NOT skip.
+	changedBody := fmt.Sprintf(`{"namespace_id":%q,"name":"pod-a","phase":"Succeeded"}`, ns.Id.String())
+	r3 := httptest.NewRequest(http.MethodPost, "/v1/pods", strings.NewReader(changedBody))
+	r3.Header.Set("Content-Type", "application/json")
+	ctx3, bag3 := WithAuditBagForTest(r3.Context())
+	w3 := httptest.NewRecorder()
+	h.ServeHTTP(w3, r3.WithContext(ctx3))
+	if w3.Code != http.StatusCreated {
+		t.Fatalf("third POST: %d %q", w3.Code, w3.Body.String())
+	}
+	if bag3.SkipForTest() {
+		t.Fatalf("changed phase should NOT skip audit (outcome=BusinessChanged)")
+	}
+}

--- a/internal/api/reconcile_handlers_audit_skip_test.go
+++ b/internal/api/reconcile_handlers_audit_skip_test.go
@@ -21,7 +21,7 @@ func runReconcileEmptyAuditSkip(t *testing.T, h http.Handler, path, emptyBody, d
 
 	post := func(label, body string) *AuditBagTestView {
 		t.Helper()
-		r := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, path, strings.NewReader(body))
 		r.Header.Set("Content-Type", "application/json")
 		ctx, bag := WithAuditBagForTest(r.Context())
 		w := httptest.NewRecorder()
@@ -181,4 +181,3 @@ func TestReconcilePersistentVolumeClaims_EmptyCallsSetAuditSkip(t *testing.T) {
 	deleteBody := fmt.Sprintf(`{"namespace_id":%q,"keep_names":[]}`, nsID)
 	runReconcileEmptyAuditSkip(t, h, "/v1/persistentvolumeclaims/reconcile", emptyBody, deleteBody)
 }
-

--- a/internal/api/reconcile_handlers_audit_skip_test.go
+++ b/internal/api/reconcile_handlers_audit_skip_test.go
@@ -1,0 +1,184 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// runReconcileEmptyAuditSkip POSTs an empty-store reconcile (n == 0 path)
+// and asserts that the audit bag was flipped to skip with reason
+// "reconcile_empty". Then POSTs a reconcile that DOES delete (n > 0) and
+// asserts the bag is NOT flipped.
+//
+// path is the reconcile endpoint, emptyBody is a JSON body that hits the
+// handler with no rows to delete, and deleteBody is a JSON body that
+// triggers a delete (so n > 0).
+func runReconcileEmptyAuditSkip(t *testing.T, h http.Handler, path, emptyBody, deleteBody string) {
+	t.Helper()
+
+	post := func(label, body string) *AuditBagTestView {
+		t.Helper()
+		r := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+		ctx, bag := WithAuditBagForTest(r.Context())
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r.WithContext(ctx))
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s POST %s: %d %q", label, path, w.Code, w.Body.String())
+		}
+		return bag
+	}
+
+	bagEmpty := post("empty", emptyBody)
+	if !bagEmpty.SkipForTest() {
+		t.Fatalf("%s: empty reconcile (n==0) SHOULD skip", path)
+	}
+	if got := bagEmpty.SkipReasonForTest(); got != "reconcile_empty" {
+		t.Fatalf("%s: empty reconcile reason = %q, want %q", path, got, "reconcile_empty")
+	}
+	if deleteBody == "" {
+		return
+	}
+	bagDel := post("delete", deleteBody)
+	if bagDel.SkipForTest() {
+		t.Fatalf("%s: delete reconcile (n>0) should NOT skip", path)
+	}
+}
+
+func seedPod(t *testing.T, h http.Handler, namespaceID, name string) {
+	t.Helper()
+	body := fmt.Sprintf(`{"namespace_id":%q,"name":%q,"phase":"Running"}`, namespaceID, name)
+	rr := do(h, http.MethodPost, "/v1/pods", body)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed pod: %d %q", rr.Code, rr.Body.String())
+	}
+}
+
+func seedWorkload(t *testing.T, h http.Handler, namespaceID, kind, name string) {
+	t.Helper()
+	body := fmt.Sprintf(`{"namespace_id":%q,"kind":%q,"name":%q,"replicas":1}`, namespaceID, kind, name)
+	rr := do(h, http.MethodPost, "/v1/workloads", body)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed workload: %d %q", rr.Code, rr.Body.String())
+	}
+}
+
+func seedService(t *testing.T, h http.Handler, namespaceID, name string) {
+	t.Helper()
+	body := fmt.Sprintf(`{"namespace_id":%q,"name":%q,"type":"ClusterIP","cluster_ip":"10.0.0.5"}`, namespaceID, name)
+	rr := do(h, http.MethodPost, "/v1/services", body)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed service: %d %q", rr.Code, rr.Body.String())
+	}
+}
+
+func seedIngress(t *testing.T, h http.Handler, namespaceID, name string) {
+	t.Helper()
+	body := fmt.Sprintf(`{"namespace_id":%q,"name":%q,"ingress_class_name":"nginx"}`, namespaceID, name)
+	rr := do(h, http.MethodPost, "/v1/ingresses", body)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed ingress: %d %q", rr.Code, rr.Body.String())
+	}
+}
+
+func seedPV(t *testing.T, h http.Handler, clusterID, name string) {
+	t.Helper()
+	body := fmt.Sprintf(`{"cluster_id":%q,"name":%q,"capacity":"10Gi","phase":"Available"}`, clusterID, name)
+	rr := do(h, http.MethodPost, "/v1/persistentvolumes", body)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed pv: %d %q", rr.Code, rr.Body.String())
+	}
+}
+
+func seedPVC(t *testing.T, h http.Handler, namespaceID, name string) {
+	t.Helper()
+	body := fmt.Sprintf(`{"namespace_id":%q,"name":%q,"phase":"Pending","requested_storage":"5Gi"}`, namespaceID, name)
+	rr := do(h, http.MethodPost, "/v1/persistentvolumeclaims", body)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed pvc: %d %q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestReconcileNodes_EmptyCallsSetAuditSkip(t *testing.T) {
+	t.Parallel()
+	h, cluster, _ := newSkipTestEnv(t)
+	clusterID := cluster.Id.String()
+	_ = seedNode(t, h, clusterID, "node-keep")
+	emptyBody := fmt.Sprintf(`{"cluster_id":%q,"keep_names":["node-keep"]}`, clusterID)
+	deleteBody := fmt.Sprintf(`{"cluster_id":%q,"keep_names":[]}`, clusterID)
+	runReconcileEmptyAuditSkip(t, h, "/v1/nodes/reconcile", emptyBody, deleteBody)
+}
+
+func TestReconcileNamespaces_EmptyCallsSetAuditSkip(t *testing.T) {
+	t.Parallel()
+	h, cluster, _ := newSkipTestEnv(t)
+	clusterID := cluster.Id.String()
+	_ = seedNamespace(t, h, clusterID, "ns-keep")
+	emptyBody := fmt.Sprintf(`{"cluster_id":%q,"keep_names":["apps","ns-keep"]}`, clusterID)
+	deleteBody := fmt.Sprintf(`{"cluster_id":%q,"keep_names":["apps"]}`, clusterID)
+	runReconcileEmptyAuditSkip(t, h, "/v1/namespaces/reconcile", emptyBody, deleteBody)
+}
+
+func TestReconcilePods_EmptyCallsSetAuditSkip(t *testing.T) {
+	t.Parallel()
+	h, _, ns := newSkipTestEnv(t)
+	nsID := ns.Id.String()
+	seedPod(t, h, nsID, "pod-keep")
+	emptyBody := fmt.Sprintf(`{"namespace_id":%q,"keep_names":["pod-keep"]}`, nsID)
+	deleteBody := fmt.Sprintf(`{"namespace_id":%q,"keep_names":[]}`, nsID)
+	runReconcileEmptyAuditSkip(t, h, "/v1/pods/reconcile", emptyBody, deleteBody)
+}
+
+func TestReconcileWorkloads_EmptyCallsSetAuditSkip(t *testing.T) {
+	t.Parallel()
+	h, _, ns := newSkipTestEnv(t)
+	nsID := ns.Id.String()
+	seedWorkload(t, h, nsID, "Deployment", "wl-keep")
+	emptyBody := fmt.Sprintf(`{"namespace_id":%q,"keep_kinds":["Deployment"],"keep_names":["wl-keep"]}`, nsID)
+	deleteBody := fmt.Sprintf(`{"namespace_id":%q,"keep_kinds":[],"keep_names":[]}`, nsID)
+	runReconcileEmptyAuditSkip(t, h, "/v1/workloads/reconcile", emptyBody, deleteBody)
+}
+
+func TestReconcileServices_EmptyCallsSetAuditSkip(t *testing.T) {
+	t.Parallel()
+	h, _, ns := newSkipTestEnv(t)
+	nsID := ns.Id.String()
+	seedService(t, h, nsID, "svc-keep")
+	emptyBody := fmt.Sprintf(`{"namespace_id":%q,"keep_names":["svc-keep"]}`, nsID)
+	deleteBody := fmt.Sprintf(`{"namespace_id":%q,"keep_names":[]}`, nsID)
+	runReconcileEmptyAuditSkip(t, h, "/v1/services/reconcile", emptyBody, deleteBody)
+}
+
+func TestReconcileIngresses_EmptyCallsSetAuditSkip(t *testing.T) {
+	t.Parallel()
+	h, _, ns := newSkipTestEnv(t)
+	nsID := ns.Id.String()
+	seedIngress(t, h, nsID, "ing-keep")
+	emptyBody := fmt.Sprintf(`{"namespace_id":%q,"keep_names":["ing-keep"]}`, nsID)
+	deleteBody := fmt.Sprintf(`{"namespace_id":%q,"keep_names":[]}`, nsID)
+	runReconcileEmptyAuditSkip(t, h, "/v1/ingresses/reconcile", emptyBody, deleteBody)
+}
+
+func TestReconcilePersistentVolumes_EmptyCallsSetAuditSkip(t *testing.T) {
+	t.Parallel()
+	h, cluster, _ := newSkipTestEnv(t)
+	clusterID := cluster.Id.String()
+	seedPV(t, h, clusterID, "pv-keep")
+	emptyBody := fmt.Sprintf(`{"cluster_id":%q,"keep_names":["pv-keep"]}`, clusterID)
+	deleteBody := fmt.Sprintf(`{"cluster_id":%q,"keep_names":[]}`, clusterID)
+	runReconcileEmptyAuditSkip(t, h, "/v1/persistentvolumes/reconcile", emptyBody, deleteBody)
+}
+
+func TestReconcilePersistentVolumeClaims_EmptyCallsSetAuditSkip(t *testing.T) {
+	t.Parallel()
+	h, _, ns := newSkipTestEnv(t)
+	nsID := ns.Id.String()
+	seedPVC(t, h, nsID, "pvc-keep")
+	emptyBody := fmt.Sprintf(`{"namespace_id":%q,"keep_names":["pvc-keep"]}`, nsID)
+	deleteBody := fmt.Sprintf(`{"namespace_id":%q,"keep_names":[]}`, nsID)
+	runReconcileEmptyAuditSkip(t, h, "/v1/persistentvolumeclaims/reconcile", emptyBody, deleteBody)
+}
+

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -395,7 +395,7 @@ func (s *Server) CreateNode(ctx context.Context, req CreateNodeRequestObject) (C
 		}, nil
 	}
 
-	n, _, err := s.store.UpsertNode(ctx, body)
+	n, outcome, err := s.store.UpsertNode(ctx, body)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return CreateNode404ApplicationProblemPlusJSONResponse{
@@ -408,6 +408,9 @@ func (s *Server) CreateNode(ctx context.Context, req CreateNodeRequestObject) (C
 			}, nil
 		}
 		return nil, fmt.Errorf("store: %w", err)
+	}
+	if outcome == OutcomeNoChange {
+		SetAuditSkip(ctx)
 	}
 	n = withNodeLayer(n)
 
@@ -519,7 +522,7 @@ func (s *Server) CreateNamespace(ctx context.Context, req CreateNamespaceRequest
 		}, nil
 	}
 
-	n, _, err := s.store.UpsertNamespace(ctx, body)
+	n, outcome, err := s.store.UpsertNamespace(ctx, body)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return CreateNamespace404ApplicationProblemPlusJSONResponse{
@@ -532,6 +535,9 @@ func (s *Server) CreateNamespace(ctx context.Context, req CreateNamespaceRequest
 			}, nil
 		}
 		return nil, fmt.Errorf("store: %w", err)
+	}
+	if outcome == OutcomeNoChange {
+		SetAuditSkip(ctx)
 	}
 	n = withNamespaceLayer(n)
 
@@ -785,7 +791,7 @@ func (s *Server) CreateWorkload(ctx context.Context, req CreateWorkloadRequestOb
 		}, nil
 	}
 
-	wl, _, err := s.store.UpsertWorkload(ctx, body)
+	wl, outcome, err := s.store.UpsertWorkload(ctx, body)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return CreateWorkload404ApplicationProblemPlusJSONResponse{
@@ -798,6 +804,9 @@ func (s *Server) CreateWorkload(ctx context.Context, req CreateWorkloadRequestOb
 			}, nil
 		}
 		return nil, fmt.Errorf("store: %w", err)
+	}
+	if outcome == OutcomeNoChange {
+		SetAuditSkip(ctx)
 	}
 	wl = withWorkloadLayer(wl)
 
@@ -909,7 +918,7 @@ func (s *Server) CreateService(ctx context.Context, req CreateServiceRequestObje
 		}, nil
 	}
 
-	svc, _, err := s.store.UpsertService(ctx, body)
+	svc, outcome, err := s.store.UpsertService(ctx, body)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return CreateService404ApplicationProblemPlusJSONResponse{
@@ -922,6 +931,9 @@ func (s *Server) CreateService(ctx context.Context, req CreateServiceRequestObje
 			}, nil
 		}
 		return nil, fmt.Errorf("store: %w", err)
+	}
+	if outcome == OutcomeNoChange {
+		SetAuditSkip(ctx)
 	}
 	svc = withServiceLayer(svc)
 
@@ -1026,7 +1038,7 @@ func (s *Server) CreateIngress(ctx context.Context, req CreateIngressRequestObje
 		}, nil
 	}
 
-	ing, _, err := s.store.UpsertIngress(ctx, body)
+	ing, outcome, err := s.store.UpsertIngress(ctx, body)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return CreateIngress404ApplicationProblemPlusJSONResponse{
@@ -1039,6 +1051,9 @@ func (s *Server) CreateIngress(ctx context.Context, req CreateIngressRequestObje
 			}, nil
 		}
 		return nil, fmt.Errorf("store: %w", err)
+	}
+	if outcome == OutcomeNoChange {
+		SetAuditSkip(ctx)
 	}
 	ing = withIngressLayer(ing)
 
@@ -1143,7 +1158,7 @@ func (s *Server) CreatePersistentVolume(ctx context.Context, req CreatePersisten
 		}, nil
 	}
 
-	pv, _, err := s.store.UpsertPersistentVolume(ctx, body)
+	pv, outcome, err := s.store.UpsertPersistentVolume(ctx, body)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return CreatePersistentVolume404ApplicationProblemPlusJSONResponse{
@@ -1156,6 +1171,9 @@ func (s *Server) CreatePersistentVolume(ctx context.Context, req CreatePersisten
 			}, nil
 		}
 		return nil, fmt.Errorf("store: %w", err)
+	}
+	if outcome == OutcomeNoChange {
+		SetAuditSkip(ctx)
 	}
 	pv = withPersistentVolumeLayer(pv)
 
@@ -1256,7 +1274,7 @@ func (s *Server) CreatePersistentVolumeClaim(
 		}, nil
 	}
 
-	pvc, _, err := s.store.UpsertPersistentVolumeClaim(ctx, body)
+	pvc, outcome, err := s.store.UpsertPersistentVolumeClaim(ctx, body)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return CreatePersistentVolumeClaim404ApplicationProblemPlusJSONResponse{
@@ -1269,6 +1287,9 @@ func (s *Server) CreatePersistentVolumeClaim(
 			}, nil
 		}
 		return nil, fmt.Errorf("store: %w", err)
+	}
+	if outcome == OutcomeNoChange {
+		SetAuditSkip(ctx)
 	}
 	pvc = withPersistentVolumeClaimLayer(pvc)
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -640,7 +640,7 @@ func (s *Server) CreatePod(ctx context.Context, req CreatePodRequestObject) (Cre
 		}, nil
 	}
 
-	p, _, err := s.store.UpsertPod(ctx, body)
+	p, outcome, err := s.store.UpsertPod(ctx, body)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return CreatePod404ApplicationProblemPlusJSONResponse{
@@ -653,6 +653,9 @@ func (s *Server) CreatePod(ctx context.Context, req CreatePodRequestObject) (Cre
 			}, nil
 		}
 		return nil, fmt.Errorf("store: %w", err)
+	}
+	if outcome == OutcomeNoChange {
+		SetAuditSkip(ctx)
 	}
 	p = withPodLayer(p)
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -395,7 +395,7 @@ func (s *Server) CreateNode(ctx context.Context, req CreateNodeRequestObject) (C
 		}, nil
 	}
 
-	n, err := s.store.UpsertNode(ctx, body)
+	n, _, err := s.store.UpsertNode(ctx, body)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return CreateNode404ApplicationProblemPlusJSONResponse{
@@ -519,7 +519,7 @@ func (s *Server) CreateNamespace(ctx context.Context, req CreateNamespaceRequest
 		}, nil
 	}
 
-	n, err := s.store.UpsertNamespace(ctx, body)
+	n, _, err := s.store.UpsertNamespace(ctx, body)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return CreateNamespace404ApplicationProblemPlusJSONResponse{
@@ -640,7 +640,7 @@ func (s *Server) CreatePod(ctx context.Context, req CreatePodRequestObject) (Cre
 		}, nil
 	}
 
-	p, err := s.store.UpsertPod(ctx, body)
+	p, _, err := s.store.UpsertPod(ctx, body)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return CreatePod404ApplicationProblemPlusJSONResponse{
@@ -782,7 +782,7 @@ func (s *Server) CreateWorkload(ctx context.Context, req CreateWorkloadRequestOb
 		}, nil
 	}
 
-	wl, err := s.store.UpsertWorkload(ctx, body)
+	wl, _, err := s.store.UpsertWorkload(ctx, body)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return CreateWorkload404ApplicationProblemPlusJSONResponse{
@@ -906,7 +906,7 @@ func (s *Server) CreateService(ctx context.Context, req CreateServiceRequestObje
 		}, nil
 	}
 
-	svc, err := s.store.UpsertService(ctx, body)
+	svc, _, err := s.store.UpsertService(ctx, body)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return CreateService404ApplicationProblemPlusJSONResponse{
@@ -1023,7 +1023,7 @@ func (s *Server) CreateIngress(ctx context.Context, req CreateIngressRequestObje
 		}, nil
 	}
 
-	ing, err := s.store.UpsertIngress(ctx, body)
+	ing, _, err := s.store.UpsertIngress(ctx, body)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return CreateIngress404ApplicationProblemPlusJSONResponse{
@@ -1140,7 +1140,7 @@ func (s *Server) CreatePersistentVolume(ctx context.Context, req CreatePersisten
 		}, nil
 	}
 
-	pv, err := s.store.UpsertPersistentVolume(ctx, body)
+	pv, _, err := s.store.UpsertPersistentVolume(ctx, body)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return CreatePersistentVolume404ApplicationProblemPlusJSONResponse{
@@ -1253,7 +1253,7 @@ func (s *Server) CreatePersistentVolumeClaim(
 		}, nil
 	}
 
-	pvc, err := s.store.UpsertPersistentVolumeClaim(ctx, body)
+	pvc, _, err := s.store.UpsertPersistentVolumeClaim(ctx, body)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return CreatePersistentVolumeClaim404ApplicationProblemPlusJSONResponse{

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1365,6 +1365,10 @@ func (s *Server) ReconcileNodes(ctx context.Context, req ReconcileNodesRequestOb
 	if err != nil {
 		return nil, fmt.Errorf("store: %w", err)
 	}
+	if n == 0 {
+		SetAuditSkipReason(ctx, "reconcile_empty")
+		SetAuditSkip(ctx)
+	}
 	return ReconcileNodes200JSONResponse(ReconcileResult{Deleted: n}), nil
 }
 
@@ -1380,6 +1384,10 @@ func (s *Server) ReconcileNamespaces(ctx context.Context, req ReconcileNamespace
 	n, err := s.store.DeleteNamespacesNotIn(ctx, body.ClusterId, body.KeepNames)
 	if err != nil {
 		return nil, fmt.Errorf("store: %w", err)
+	}
+	if n == 0 {
+		SetAuditSkipReason(ctx, "reconcile_empty")
+		SetAuditSkip(ctx)
 	}
 	return ReconcileNamespaces200JSONResponse(ReconcileResult{Deleted: n}), nil
 }
@@ -1399,6 +1407,10 @@ func (s *Server) ReconcilePersistentVolumes(
 	if err != nil {
 		return nil, fmt.Errorf("store: %w", err)
 	}
+	if n == 0 {
+		SetAuditSkipReason(ctx, "reconcile_empty")
+		SetAuditSkip(ctx)
+	}
 	return ReconcilePersistentVolumes200JSONResponse(ReconcileResult{Deleted: n}), nil
 }
 
@@ -1414,6 +1426,10 @@ func (s *Server) ReconcilePods(ctx context.Context, req ReconcilePodsRequestObje
 	n, err := s.store.DeletePodsNotIn(ctx, body.NamespaceId, body.KeepNames)
 	if err != nil {
 		return nil, fmt.Errorf("store: %w", err)
+	}
+	if n == 0 {
+		SetAuditSkipReason(ctx, "reconcile_empty")
+		SetAuditSkip(ctx)
 	}
 	return ReconcilePods200JSONResponse(ReconcileResult{Deleted: n}), nil
 }
@@ -1438,6 +1454,10 @@ func (s *Server) ReconcileWorkloads(ctx context.Context, req ReconcileWorkloadsR
 	if err != nil {
 		return nil, fmt.Errorf("store: %w", err)
 	}
+	if n == 0 {
+		SetAuditSkipReason(ctx, "reconcile_empty")
+		SetAuditSkip(ctx)
+	}
 	return ReconcileWorkloads200JSONResponse(ReconcileResult{Deleted: n}), nil
 }
 
@@ -1454,6 +1474,10 @@ func (s *Server) ReconcileServices(ctx context.Context, req ReconcileServicesReq
 	if err != nil {
 		return nil, fmt.Errorf("store: %w", err)
 	}
+	if n == 0 {
+		SetAuditSkipReason(ctx, "reconcile_empty")
+		SetAuditSkip(ctx)
+	}
 	return ReconcileServices200JSONResponse(ReconcileResult{Deleted: n}), nil
 }
 
@@ -1469,6 +1493,10 @@ func (s *Server) ReconcileIngresses(ctx context.Context, req ReconcileIngressesR
 	n, err := s.store.DeleteIngressesNotIn(ctx, body.NamespaceId, body.KeepNames)
 	if err != nil {
 		return nil, fmt.Errorf("store: %w", err)
+	}
+	if n == 0 {
+		SetAuditSkipReason(ctx, "reconcile_empty")
+		SetAuditSkip(ctx)
 	}
 	return ReconcileIngresses200JSONResponse(ReconcileResult{Deleted: n}), nil
 }
@@ -1487,6 +1515,10 @@ func (s *Server) ReconcilePersistentVolumeClaims(
 	n, err := s.store.DeletePersistentVolumeClaimsNotIn(ctx, body.NamespaceId, body.KeepNames)
 	if err != nil {
 		return nil, fmt.Errorf("store: %w", err)
+	}
+	if n == 0 {
+		SetAuditSkipReason(ctx, "reconcile_empty")
+		SetAuditSkip(ctx)
 	}
 	return ReconcilePersistentVolumeClaims200JSONResponse(ReconcileResult{Deleted: n}), nil
 }

--- a/internal/api/server_cloud_fake_test.go
+++ b/internal/api/server_cloud_fake_test.go
@@ -6,6 +6,7 @@ package api
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -311,18 +312,27 @@ func (m *memStore) UpsertVirtualMachine(_ context.Context, in VirtualMachineUpse
 	// Check provider_vm_id conflict — simulate the nodes.provider_id dedup
 	// by also checking for a conflict marker tag.
 	if v, ok := in.Tags["argos.test.is_kube"]; ok && v == "true" {
-		return VirtualMachine{}, OutcomeBusinessChanged, ErrConflict
+		return VirtualMachine{}, OutcomeNoChange, ErrConflict
 	}
 	for vmID, vm := range cloudFake.vms {
 		if vm.CloudAccountID == in.CloudAccountID && vm.ProviderVMID == in.ProviderVMID {
+			before := vm
 			vm.Name = in.Name
 			vm.PowerState = in.PowerState
 			vm.Ready = in.Ready
-			vm.UpdatedAt = time.Now().UTC()
-			vm.LastSeenAt = vm.UpdatedAt
 			vm.TerminatedAt = nil
+			businessChanged := vm.Name != before.Name ||
+				vm.PowerState != before.PowerState ||
+				vm.Ready != before.Ready ||
+				!reflect.DeepEqual(vm.TerminatedAt, before.TerminatedAt)
+			now := time.Now().UTC()
+			vm.UpdatedAt = now
+			vm.LastSeenAt = now
 			cloudFake.vms[vmID] = vm
-			return vm, OutcomeBusinessChanged, nil
+			if businessChanged {
+				return vm, OutcomeBusinessChanged, nil
+			}
+			return vm, OutcomeNoChange, nil
 		}
 	}
 	now := time.Now().UTC()
@@ -342,7 +352,7 @@ func (m *memStore) UpsertVirtualMachine(_ context.Context, in VirtualMachineUpse
 		LastSeenAt:         now,
 	}
 	cloudFake.vms[vm.ID] = vm
-	return vm, OutcomeBusinessChanged, nil
+	return vm, OutcomeInserted, nil
 }
 
 func (m *memStore) GetVirtualMachine(_ context.Context, id uuid.UUID) (VirtualMachine, error) {

--- a/internal/api/server_cloud_fake_test.go
+++ b/internal/api/server_cloud_fake_test.go
@@ -305,13 +305,13 @@ func (m *memStore) CountCloudAccountsWithSecrets(_ context.Context) (int, error)
 }
 
 //nolint:gocritic // hugeParam: Store interface requires value param
-func (m *memStore) UpsertVirtualMachine(_ context.Context, in VirtualMachineUpsert) (VirtualMachine, error) {
+func (m *memStore) UpsertVirtualMachine(_ context.Context, in VirtualMachineUpsert) (VirtualMachine, UpsertOutcome, error) {
 	cloudFake.mu.Lock()
 	defer cloudFake.mu.Unlock()
 	// Check provider_vm_id conflict — simulate the nodes.provider_id dedup
 	// by also checking for a conflict marker tag.
 	if v, ok := in.Tags["argos.test.is_kube"]; ok && v == "true" {
-		return VirtualMachine{}, ErrConflict
+		return VirtualMachine{}, OutcomeBusinessChanged, ErrConflict
 	}
 	for vmID, vm := range cloudFake.vms {
 		if vm.CloudAccountID == in.CloudAccountID && vm.ProviderVMID == in.ProviderVMID {
@@ -322,7 +322,7 @@ func (m *memStore) UpsertVirtualMachine(_ context.Context, in VirtualMachineUpse
 			vm.LastSeenAt = vm.UpdatedAt
 			vm.TerminatedAt = nil
 			cloudFake.vms[vmID] = vm
-			return vm, nil
+			return vm, OutcomeBusinessChanged, nil
 		}
 	}
 	now := time.Now().UTC()
@@ -342,7 +342,7 @@ func (m *memStore) UpsertVirtualMachine(_ context.Context, in VirtualMachineUpse
 		LastSeenAt:         now,
 	}
 	cloudFake.vms[vm.ID] = vm
-	return vm, nil
+	return vm, OutcomeBusinessChanged, nil
 }
 
 func (m *memStore) GetVirtualMachine(_ context.Context, id uuid.UUID) (VirtualMachine, error) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -16,6 +17,24 @@ import (
 
 	"github.com/sthalbert/longue-vue/internal/auth"
 )
+
+// stringPtrEqual reports whether two optional strings have equal values,
+// treating two nils as equal and nil-vs-non-nil as different.
+func stringPtrEqual(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+// uuidPtrEqual mirrors stringPtrEqual for UUID pointers used by optional
+// foreign keys in upsert payloads.
+func uuidPtrEqual(a, b *uuid.UUID) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
 
 // memStore is an in-memory api.Store implementation used to exercise the
 // HTTP handlers without a PostgreSQL dependency.
@@ -817,11 +836,11 @@ func (m *memStore) UpsertPod(_ context.Context, in PodCreate) (Pod, UpsertOutcom
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.nsByID[in.NamespaceId]; !ok {
-		return Pod{}, OutcomeBusinessChanged, ErrNotFound
+		return Pod{}, OutcomeNoChange, ErrNotFound
 	}
 	if in.WorkloadId != nil {
 		if _, ok := m.workloadsByID[*in.WorkloadId]; !ok {
-			return Pod{}, OutcomeBusinessChanged, fmt.Errorf("workload %s does not exist: %w", in.WorkloadId, ErrNotFound)
+			return Pod{}, OutcomeNoChange, fmt.Errorf("workload %s does not exist: %w", in.WorkloadId, ErrNotFound)
 		}
 	}
 	key := podNatKey(in.NamespaceId, in.Name)
@@ -830,6 +849,12 @@ func (m *memStore) UpsertPod(_ context.Context, in PodCreate) (Pod, UpsertOutcom
 
 	if existingID, exists := m.podsByNatKey[key]; exists {
 		p := m.podsByID[existingID]
+		businessChanged := !stringPtrEqual(p.Phase, in.Phase) ||
+			!stringPtrEqual(p.NodeName, in.NodeName) ||
+			!stringPtrEqual(p.PodIp, in.PodIp) ||
+			!uuidPtrEqual(p.WorkloadId, in.WorkloadId) ||
+			!reflect.DeepEqual(p.Containers, in.Containers) ||
+			!reflect.DeepEqual(p.Labels, in.Labels)
 		p.Phase = in.Phase
 		p.NodeName = in.NodeName
 		p.PodIp = in.PodIp
@@ -838,7 +863,10 @@ func (m *memStore) UpsertPod(_ context.Context, in PodCreate) (Pod, UpsertOutcom
 		p.WorkloadId = in.WorkloadId
 		p.UpdatedAt = &now
 		m.podsByID[existingID] = p
-		return p, OutcomeBusinessChanged, nil
+		if businessChanged {
+			return p, OutcomeBusinessChanged, nil
+		}
+		return p, OutcomeNoChange, nil
 	}
 
 	id := uuid.New()
@@ -857,7 +885,7 @@ func (m *memStore) UpsertPod(_ context.Context, in PodCreate) (Pod, UpsertOutcom
 	}
 	m.podsByID[id] = p
 	m.podsByNatKey[key] = id
-	return p, OutcomeBusinessChanged, nil
+	return p, OutcomeInserted, nil
 }
 
 func (m *memStore) DeletePodsNotIn(_ context.Context, namespaceID uuid.UUID, keepNames []string) (int64, error) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1031,7 +1031,7 @@ func (m *memStore) UpsertWorkload(_ context.Context, in WorkloadCreate) (Workloa
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.nsByID[in.NamespaceId]; !ok {
-		return Workload{}, OutcomeBusinessChanged, ErrNotFound
+		return Workload{}, OutcomeNoChange, ErrNotFound
 	}
 	key := workloadNatKey(in.NamespaceId, in.Kind, in.Name)
 	now := time.Now().UTC().Add(time.Duration(m.createdN) * time.Nanosecond)
@@ -1039,14 +1039,19 @@ func (m *memStore) UpsertWorkload(_ context.Context, in WorkloadCreate) (Workloa
 
 	if existingID, exists := m.workloadsByNatKey[key]; exists {
 		wl := m.workloadsByID[existingID]
+		before := wl
 		wl.Replicas = in.Replicas
 		wl.ReadyReplicas = in.ReadyReplicas
 		wl.Containers = in.Containers
 		wl.Labels = in.Labels
 		wl.Spec = in.Spec
+		businessChanged := !reflect.DeepEqual(before, wl)
 		wl.UpdatedAt = &now
 		m.workloadsByID[existingID] = wl
-		return wl, OutcomeBusinessChanged, nil
+		if businessChanged {
+			return wl, OutcomeBusinessChanged, nil
+		}
+		return wl, OutcomeNoChange, nil
 	}
 
 	id := uuid.New()
@@ -1065,7 +1070,7 @@ func (m *memStore) UpsertWorkload(_ context.Context, in WorkloadCreate) (Workloa
 	}
 	m.workloadsByID[id] = wl
 	m.workloadsByNatKey[key] = id
-	return wl, OutcomeBusinessChanged, nil
+	return wl, OutcomeInserted, nil
 }
 
 func (m *memStore) DeleteWorkloadsNotIn(_ context.Context, namespaceID uuid.UUID, keepKinds, keepNames []string) (int64, error) {
@@ -1194,21 +1199,26 @@ func (m *memStore) UpsertIngress(_ context.Context, in IngressCreate) (Ingress, 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.nsByID[in.NamespaceId]; !ok {
-		return Ingress{}, OutcomeBusinessChanged, ErrNotFound
+		return Ingress{}, OutcomeNoChange, ErrNotFound
 	}
 	key := ingressNatKey(in.NamespaceId, in.Name)
 	now := time.Now().UTC().Add(time.Duration(m.createdN) * time.Nanosecond)
 	m.createdN++
 	if existingID, exists := m.ingressesByNatKey[key]; exists {
 		i := m.ingressesByID[existingID]
+		before := i
 		i.IngressClassName = in.IngressClassName
 		i.Rules = in.Rules
 		i.Tls = in.Tls
 		i.LoadBalancer = in.LoadBalancer
 		i.Labels = in.Labels
+		businessChanged := !reflect.DeepEqual(before, i)
 		i.UpdatedAt = &now
 		m.ingressesByID[existingID] = i
-		return i, OutcomeBusinessChanged, nil
+		if businessChanged {
+			return i, OutcomeBusinessChanged, nil
+		}
+		return i, OutcomeNoChange, nil
 	}
 	id := uuid.New()
 	i := Ingress{
@@ -1225,7 +1235,7 @@ func (m *memStore) UpsertIngress(_ context.Context, in IngressCreate) (Ingress, 
 	}
 	m.ingressesByID[id] = i
 	m.ingressesByNatKey[key] = id
-	return i, OutcomeBusinessChanged, nil
+	return i, OutcomeInserted, nil
 }
 
 func (m *memStore) DeleteIngressesNotIn(_ context.Context, namespaceID uuid.UUID, keepNames []string) (int64, error) {
@@ -1357,22 +1367,27 @@ func (m *memStore) UpsertService(_ context.Context, in ServiceCreate) (Service, 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.nsByID[in.NamespaceId]; !ok {
-		return Service{}, OutcomeBusinessChanged, ErrNotFound
+		return Service{}, OutcomeNoChange, ErrNotFound
 	}
 	key := serviceNatKey(in.NamespaceId, in.Name)
 	now := time.Now().UTC().Add(time.Duration(m.createdN) * time.Nanosecond)
 	m.createdN++
 	if existingID, exists := m.servicesByNatKey[key]; exists {
 		s := m.servicesByID[existingID]
+		before := s
 		s.Type = in.Type
 		s.ClusterIp = in.ClusterIp
 		s.Selector = in.Selector
 		s.Ports = in.Ports
 		s.LoadBalancer = in.LoadBalancer
 		s.Labels = in.Labels
+		businessChanged := !reflect.DeepEqual(before, s)
 		s.UpdatedAt = &now
 		m.servicesByID[existingID] = s
-		return s, OutcomeBusinessChanged, nil
+		if businessChanged {
+			return s, OutcomeBusinessChanged, nil
+		}
+		return s, OutcomeNoChange, nil
 	}
 	id := uuid.New()
 	s := Service{
@@ -1390,7 +1405,7 @@ func (m *memStore) UpsertService(_ context.Context, in ServiceCreate) (Service, 
 	}
 	m.servicesByID[id] = s
 	m.servicesByNatKey[key] = id
-	return s, OutcomeBusinessChanged, nil
+	return s, OutcomeInserted, nil
 }
 
 func (m *memStore) DeleteServicesNotIn(_ context.Context, namespaceID uuid.UUID, keepNames []string) (int64, error) {
@@ -1419,7 +1434,7 @@ func (m *memStore) UpsertNamespace(_ context.Context, in NamespaceCreate) (Names
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.byID[in.ClusterId]; !ok {
-		return Namespace{}, OutcomeBusinessChanged, ErrNotFound
+		return Namespace{}, OutcomeNoChange, ErrNotFound
 	}
 	key := nsNatKey(in.ClusterId, in.Name)
 	now := time.Now().UTC().Add(time.Duration(m.createdN) * time.Nanosecond)
@@ -1427,12 +1442,17 @@ func (m *memStore) UpsertNamespace(_ context.Context, in NamespaceCreate) (Names
 
 	if existingID, exists := m.nsByNatKey[key]; exists {
 		n := m.nsByID[existingID]
+		before := n
 		n.DisplayName = in.DisplayName
 		n.Phase = in.Phase
 		n.Labels = in.Labels
+		businessChanged := !reflect.DeepEqual(before, n)
 		n.UpdatedAt = &now
 		m.nsByID[existingID] = n
-		return n, OutcomeBusinessChanged, nil
+		if businessChanged {
+			return n, OutcomeBusinessChanged, nil
+		}
+		return n, OutcomeNoChange, nil
 	}
 
 	id := uuid.New()
@@ -1453,7 +1473,7 @@ func (m *memStore) UpsertNamespace(_ context.Context, in NamespaceCreate) (Names
 	}
 	m.nsByID[id] = n
 	m.nsByNatKey[key] = id
-	return n, OutcomeBusinessChanged, nil
+	return n, OutcomeInserted, nil
 }
 
 func (m *memStore) DeleteNodesNotIn(_ context.Context, clusterID uuid.UUID, keepNames []string) (int64, error) {
@@ -1504,7 +1524,7 @@ func (m *memStore) UpsertNode(_ context.Context, in NodeCreate) (Node, UpsertOut
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.byID[in.ClusterId]; !ok {
-		return Node{}, OutcomeBusinessChanged, ErrNotFound
+		return Node{}, OutcomeNoChange, ErrNotFound
 	}
 	key := nodeNatKey(in.ClusterId, in.Name)
 	now := time.Now().UTC().Add(time.Duration(m.createdN) * time.Nanosecond)
@@ -1512,14 +1532,19 @@ func (m *memStore) UpsertNode(_ context.Context, in NodeCreate) (Node, UpsertOut
 
 	if existingID, exists := m.nodesByNatKey[key]; exists {
 		n := m.nodesByID[existingID]
+		before := n
 		// On conflict: copy only collector-owned fields. Mirrors the
 		// DO UPDATE SET clause on the PG side so operator-set curated
 		// columns (owner / criticality / notes / runbook_url /
 		// annotations / hardware_model) survive the collector's tick.
 		copyNodeCollectorFieldsFromCreate(&n, in)
+		businessChanged := !reflect.DeepEqual(before, n)
 		n.UpdatedAt = &now
 		m.nodesByID[existingID] = n
-		return n, OutcomeBusinessChanged, nil
+		if businessChanged {
+			return n, OutcomeBusinessChanged, nil
+		}
+		return n, OutcomeNoChange, nil
 	}
 
 	id := uuid.New()
@@ -1533,7 +1558,7 @@ func (m *memStore) UpsertNode(_ context.Context, in NodeCreate) (Node, UpsertOut
 	copyNodeMutableFromCreate(&n, in)
 	m.nodesByID[id] = n
 	m.nodesByNatKey[key] = id
-	return n, OutcomeBusinessChanged, nil
+	return n, OutcomeInserted, nil
 }
 
 func pvNatKey(clusterID uuid.UUID, name string) string {
@@ -1681,7 +1706,7 @@ func (m *memStore) UpsertPersistentVolume(
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.byID[in.ClusterId]; !ok {
-		return PersistentVolume{}, OutcomeBusinessChanged, ErrNotFound
+		return PersistentVolume{}, OutcomeNoChange, ErrNotFound
 	}
 	key := pvNatKey(in.ClusterId, in.Name)
 	now := time.Now().UTC().Add(time.Duration(m.createdN) * time.Nanosecond)
@@ -1689,6 +1714,7 @@ func (m *memStore) UpsertPersistentVolume(
 
 	if existingID, exists := m.pvsByNatKey[key]; exists {
 		pv := m.pvsByID[existingID]
+		before := pv
 		pv.Capacity = in.Capacity
 		pv.AccessModes = in.AccessModes
 		pv.ReclaimPolicy = in.ReclaimPolicy
@@ -1699,9 +1725,13 @@ func (m *memStore) UpsertPersistentVolume(
 		pv.ClaimRefNamespace = in.ClaimRefNamespace
 		pv.ClaimRefName = in.ClaimRefName
 		pv.Labels = in.Labels
+		businessChanged := !reflect.DeepEqual(before, pv)
 		pv.UpdatedAt = &now
 		m.pvsByID[existingID] = pv
-		return pv, OutcomeBusinessChanged, nil
+		if businessChanged {
+			return pv, OutcomeBusinessChanged, nil
+		}
+		return pv, OutcomeNoChange, nil
 	}
 
 	id := uuid.New()
@@ -1724,7 +1754,7 @@ func (m *memStore) UpsertPersistentVolume(
 	}
 	m.pvsByID[id] = pv
 	m.pvsByNatKey[key] = id
-	return pv, OutcomeBusinessChanged, nil
+	return pv, OutcomeInserted, nil
 }
 
 func (m *memStore) DeletePersistentVolumesNotIn(_ context.Context, clusterID uuid.UUID, keepNames []string) (int64, error) {
@@ -1882,11 +1912,11 @@ func (m *memStore) UpsertPersistentVolumeClaim(
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.nsByID[in.NamespaceId]; !ok {
-		return PersistentVolumeClaim{}, OutcomeBusinessChanged, ErrNotFound
+		return PersistentVolumeClaim{}, OutcomeNoChange, ErrNotFound
 	}
 	if in.BoundVolumeId != nil {
 		if _, ok := m.pvsByID[*in.BoundVolumeId]; !ok {
-			return PersistentVolumeClaim{}, OutcomeBusinessChanged, fmt.Errorf("persistent volume %s does not exist: %w", in.BoundVolumeId, ErrNotFound)
+			return PersistentVolumeClaim{}, OutcomeNoChange, fmt.Errorf("persistent volume %s does not exist: %w", in.BoundVolumeId, ErrNotFound)
 		}
 	}
 	key := pvcNatKey(in.NamespaceId, in.Name)
@@ -1895,6 +1925,7 @@ func (m *memStore) UpsertPersistentVolumeClaim(
 
 	if existingID, exists := m.pvcsByNatKey[key]; exists {
 		pvc := m.pvcsByID[existingID]
+		before := pvc
 		pvc.Phase = in.Phase
 		pvc.StorageClassName = in.StorageClassName
 		pvc.VolumeName = in.VolumeName
@@ -1902,9 +1933,13 @@ func (m *memStore) UpsertPersistentVolumeClaim(
 		pvc.AccessModes = in.AccessModes
 		pvc.RequestedStorage = in.RequestedStorage
 		pvc.Labels = in.Labels
+		businessChanged := !reflect.DeepEqual(before, pvc)
 		pvc.UpdatedAt = &now
 		m.pvcsByID[existingID] = pvc
-		return pvc, OutcomeBusinessChanged, nil
+		if businessChanged {
+			return pvc, OutcomeBusinessChanged, nil
+		}
+		return pvc, OutcomeNoChange, nil
 	}
 
 	id := uuid.New()
@@ -1924,7 +1959,7 @@ func (m *memStore) UpsertPersistentVolumeClaim(
 	}
 	m.pvcsByID[id] = pvc
 	m.pvcsByNatKey[key] = id
-	return pvc, OutcomeBusinessChanged, nil
+	return pvc, OutcomeInserted, nil
 }
 
 func (m *memStore) DeletePersistentVolumeClaimsNotIn(_ context.Context, namespaceID uuid.UUID, keepNames []string) (int64, error) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -813,15 +813,15 @@ func (m *memStore) DeletePod(_ context.Context, id uuid.UUID) error {
 	return nil
 }
 
-func (m *memStore) UpsertPod(_ context.Context, in PodCreate) (Pod, error) { //nolint:gocritic // interface-mandated signature
+func (m *memStore) UpsertPod(_ context.Context, in PodCreate) (Pod, UpsertOutcome, error) { //nolint:gocritic // interface-mandated signature
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.nsByID[in.NamespaceId]; !ok {
-		return Pod{}, ErrNotFound
+		return Pod{}, OutcomeBusinessChanged, ErrNotFound
 	}
 	if in.WorkloadId != nil {
 		if _, ok := m.workloadsByID[*in.WorkloadId]; !ok {
-			return Pod{}, fmt.Errorf("workload %s does not exist: %w", in.WorkloadId, ErrNotFound)
+			return Pod{}, OutcomeBusinessChanged, fmt.Errorf("workload %s does not exist: %w", in.WorkloadId, ErrNotFound)
 		}
 	}
 	key := podNatKey(in.NamespaceId, in.Name)
@@ -838,7 +838,7 @@ func (m *memStore) UpsertPod(_ context.Context, in PodCreate) (Pod, error) { //n
 		p.WorkloadId = in.WorkloadId
 		p.UpdatedAt = &now
 		m.podsByID[existingID] = p
-		return p, nil
+		return p, OutcomeBusinessChanged, nil
 	}
 
 	id := uuid.New()
@@ -857,7 +857,7 @@ func (m *memStore) UpsertPod(_ context.Context, in PodCreate) (Pod, error) { //n
 	}
 	m.podsByID[id] = p
 	m.podsByNatKey[key] = id
-	return p, nil
+	return p, OutcomeBusinessChanged, nil
 }
 
 func (m *memStore) DeletePodsNotIn(_ context.Context, namespaceID uuid.UUID, keepNames []string) (int64, error) {
@@ -999,11 +999,11 @@ func (m *memStore) DeleteWorkload(_ context.Context, id uuid.UUID) error {
 	return nil
 }
 
-func (m *memStore) UpsertWorkload(_ context.Context, in WorkloadCreate) (Workload, error) { //nolint:gocritic // interface-mandated signature
+func (m *memStore) UpsertWorkload(_ context.Context, in WorkloadCreate) (Workload, UpsertOutcome, error) { //nolint:gocritic // interface-mandated signature
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.nsByID[in.NamespaceId]; !ok {
-		return Workload{}, ErrNotFound
+		return Workload{}, OutcomeBusinessChanged, ErrNotFound
 	}
 	key := workloadNatKey(in.NamespaceId, in.Kind, in.Name)
 	now := time.Now().UTC().Add(time.Duration(m.createdN) * time.Nanosecond)
@@ -1018,7 +1018,7 @@ func (m *memStore) UpsertWorkload(_ context.Context, in WorkloadCreate) (Workloa
 		wl.Spec = in.Spec
 		wl.UpdatedAt = &now
 		m.workloadsByID[existingID] = wl
-		return wl, nil
+		return wl, OutcomeBusinessChanged, nil
 	}
 
 	id := uuid.New()
@@ -1037,7 +1037,7 @@ func (m *memStore) UpsertWorkload(_ context.Context, in WorkloadCreate) (Workloa
 	}
 	m.workloadsByID[id] = wl
 	m.workloadsByNatKey[key] = id
-	return wl, nil
+	return wl, OutcomeBusinessChanged, nil
 }
 
 func (m *memStore) DeleteWorkloadsNotIn(_ context.Context, namespaceID uuid.UUID, keepKinds, keepNames []string) (int64, error) {
@@ -1162,11 +1162,11 @@ func (m *memStore) DeleteIngress(_ context.Context, id uuid.UUID) error {
 	return nil
 }
 
-func (m *memStore) UpsertIngress(_ context.Context, in IngressCreate) (Ingress, error) {
+func (m *memStore) UpsertIngress(_ context.Context, in IngressCreate) (Ingress, UpsertOutcome, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.nsByID[in.NamespaceId]; !ok {
-		return Ingress{}, ErrNotFound
+		return Ingress{}, OutcomeBusinessChanged, ErrNotFound
 	}
 	key := ingressNatKey(in.NamespaceId, in.Name)
 	now := time.Now().UTC().Add(time.Duration(m.createdN) * time.Nanosecond)
@@ -1180,7 +1180,7 @@ func (m *memStore) UpsertIngress(_ context.Context, in IngressCreate) (Ingress, 
 		i.Labels = in.Labels
 		i.UpdatedAt = &now
 		m.ingressesByID[existingID] = i
-		return i, nil
+		return i, OutcomeBusinessChanged, nil
 	}
 	id := uuid.New()
 	i := Ingress{
@@ -1197,7 +1197,7 @@ func (m *memStore) UpsertIngress(_ context.Context, in IngressCreate) (Ingress, 
 	}
 	m.ingressesByID[id] = i
 	m.ingressesByNatKey[key] = id
-	return i, nil
+	return i, OutcomeBusinessChanged, nil
 }
 
 func (m *memStore) DeleteIngressesNotIn(_ context.Context, namespaceID uuid.UUID, keepNames []string) (int64, error) {
@@ -1325,11 +1325,11 @@ func (m *memStore) DeleteService(_ context.Context, id uuid.UUID) error {
 	return nil
 }
 
-func (m *memStore) UpsertService(_ context.Context, in ServiceCreate) (Service, error) { //nolint:gocritic // interface-mandated signature
+func (m *memStore) UpsertService(_ context.Context, in ServiceCreate) (Service, UpsertOutcome, error) { //nolint:gocritic // interface-mandated signature
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.nsByID[in.NamespaceId]; !ok {
-		return Service{}, ErrNotFound
+		return Service{}, OutcomeBusinessChanged, ErrNotFound
 	}
 	key := serviceNatKey(in.NamespaceId, in.Name)
 	now := time.Now().UTC().Add(time.Duration(m.createdN) * time.Nanosecond)
@@ -1344,7 +1344,7 @@ func (m *memStore) UpsertService(_ context.Context, in ServiceCreate) (Service, 
 		s.Labels = in.Labels
 		s.UpdatedAt = &now
 		m.servicesByID[existingID] = s
-		return s, nil
+		return s, OutcomeBusinessChanged, nil
 	}
 	id := uuid.New()
 	s := Service{
@@ -1362,7 +1362,7 @@ func (m *memStore) UpsertService(_ context.Context, in ServiceCreate) (Service, 
 	}
 	m.servicesByID[id] = s
 	m.servicesByNatKey[key] = id
-	return s, nil
+	return s, OutcomeBusinessChanged, nil
 }
 
 func (m *memStore) DeleteServicesNotIn(_ context.Context, namespaceID uuid.UUID, keepNames []string) (int64, error) {
@@ -1387,11 +1387,11 @@ func (m *memStore) DeleteServicesNotIn(_ context.Context, namespaceID uuid.UUID,
 	return deleted, nil
 }
 
-func (m *memStore) UpsertNamespace(_ context.Context, in NamespaceCreate) (Namespace, error) { //nolint:gocritic // interface-mandated signature
+func (m *memStore) UpsertNamespace(_ context.Context, in NamespaceCreate) (Namespace, UpsertOutcome, error) { //nolint:gocritic // interface-mandated signature
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.byID[in.ClusterId]; !ok {
-		return Namespace{}, ErrNotFound
+		return Namespace{}, OutcomeBusinessChanged, ErrNotFound
 	}
 	key := nsNatKey(in.ClusterId, in.Name)
 	now := time.Now().UTC().Add(time.Duration(m.createdN) * time.Nanosecond)
@@ -1404,7 +1404,7 @@ func (m *memStore) UpsertNamespace(_ context.Context, in NamespaceCreate) (Names
 		n.Labels = in.Labels
 		n.UpdatedAt = &now
 		m.nsByID[existingID] = n
-		return n, nil
+		return n, OutcomeBusinessChanged, nil
 	}
 
 	id := uuid.New()
@@ -1425,7 +1425,7 @@ func (m *memStore) UpsertNamespace(_ context.Context, in NamespaceCreate) (Names
 	}
 	m.nsByID[id] = n
 	m.nsByNatKey[key] = id
-	return n, nil
+	return n, OutcomeBusinessChanged, nil
 }
 
 func (m *memStore) DeleteNodesNotIn(_ context.Context, clusterID uuid.UUID, keepNames []string) (int64, error) {
@@ -1472,11 +1472,11 @@ func (m *memStore) DeleteNamespacesNotIn(_ context.Context, clusterID uuid.UUID,
 	return deleted, nil
 }
 
-func (m *memStore) UpsertNode(_ context.Context, in NodeCreate) (Node, error) { //nolint:gocritic // interface-mandated signature
+func (m *memStore) UpsertNode(_ context.Context, in NodeCreate) (Node, UpsertOutcome, error) { //nolint:gocritic // interface-mandated signature
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.byID[in.ClusterId]; !ok {
-		return Node{}, ErrNotFound
+		return Node{}, OutcomeBusinessChanged, ErrNotFound
 	}
 	key := nodeNatKey(in.ClusterId, in.Name)
 	now := time.Now().UTC().Add(time.Duration(m.createdN) * time.Nanosecond)
@@ -1491,7 +1491,7 @@ func (m *memStore) UpsertNode(_ context.Context, in NodeCreate) (Node, error) { 
 		copyNodeCollectorFieldsFromCreate(&n, in)
 		n.UpdatedAt = &now
 		m.nodesByID[existingID] = n
-		return n, nil
+		return n, OutcomeBusinessChanged, nil
 	}
 
 	id := uuid.New()
@@ -1505,7 +1505,7 @@ func (m *memStore) UpsertNode(_ context.Context, in NodeCreate) (Node, error) { 
 	copyNodeMutableFromCreate(&n, in)
 	m.nodesByID[id] = n
 	m.nodesByNatKey[key] = id
-	return n, nil
+	return n, OutcomeBusinessChanged, nil
 }
 
 func pvNatKey(clusterID uuid.UUID, name string) string {
@@ -1649,11 +1649,11 @@ func (m *memStore) DeletePersistentVolume(_ context.Context, id uuid.UUID) error
 //nolint:gocritic // interface-mandated signature
 func (m *memStore) UpsertPersistentVolume(
 	_ context.Context, in PersistentVolumeCreate,
-) (PersistentVolume, error) {
+) (PersistentVolume, UpsertOutcome, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.byID[in.ClusterId]; !ok {
-		return PersistentVolume{}, ErrNotFound
+		return PersistentVolume{}, OutcomeBusinessChanged, ErrNotFound
 	}
 	key := pvNatKey(in.ClusterId, in.Name)
 	now := time.Now().UTC().Add(time.Duration(m.createdN) * time.Nanosecond)
@@ -1673,7 +1673,7 @@ func (m *memStore) UpsertPersistentVolume(
 		pv.Labels = in.Labels
 		pv.UpdatedAt = &now
 		m.pvsByID[existingID] = pv
-		return pv, nil
+		return pv, OutcomeBusinessChanged, nil
 	}
 
 	id := uuid.New()
@@ -1696,7 +1696,7 @@ func (m *memStore) UpsertPersistentVolume(
 	}
 	m.pvsByID[id] = pv
 	m.pvsByNatKey[key] = id
-	return pv, nil
+	return pv, OutcomeBusinessChanged, nil
 }
 
 func (m *memStore) DeletePersistentVolumesNotIn(_ context.Context, clusterID uuid.UUID, keepNames []string) (int64, error) {
@@ -1850,15 +1850,15 @@ func (m *memStore) DeletePersistentVolumeClaim(_ context.Context, id uuid.UUID) 
 //nolint:gocritic // interface-mandated signature
 func (m *memStore) UpsertPersistentVolumeClaim(
 	_ context.Context, in PersistentVolumeClaimCreate,
-) (PersistentVolumeClaim, error) {
+) (PersistentVolumeClaim, UpsertOutcome, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.nsByID[in.NamespaceId]; !ok {
-		return PersistentVolumeClaim{}, ErrNotFound
+		return PersistentVolumeClaim{}, OutcomeBusinessChanged, ErrNotFound
 	}
 	if in.BoundVolumeId != nil {
 		if _, ok := m.pvsByID[*in.BoundVolumeId]; !ok {
-			return PersistentVolumeClaim{}, fmt.Errorf("persistent volume %s does not exist: %w", in.BoundVolumeId, ErrNotFound)
+			return PersistentVolumeClaim{}, OutcomeBusinessChanged, fmt.Errorf("persistent volume %s does not exist: %w", in.BoundVolumeId, ErrNotFound)
 		}
 	}
 	key := pvcNatKey(in.NamespaceId, in.Name)
@@ -1876,7 +1876,7 @@ func (m *memStore) UpsertPersistentVolumeClaim(
 		pvc.Labels = in.Labels
 		pvc.UpdatedAt = &now
 		m.pvcsByID[existingID] = pvc
-		return pvc, nil
+		return pvc, OutcomeBusinessChanged, nil
 	}
 
 	id := uuid.New()
@@ -1896,7 +1896,7 @@ func (m *memStore) UpsertPersistentVolumeClaim(
 	}
 	m.pvcsByID[id] = pvc
 	m.pvcsByNatKey[key] = id
-	return pvc, nil
+	return pvc, OutcomeBusinessChanged, nil
 }
 
 func (m *memStore) DeletePersistentVolumeClaimsNotIn(_ context.Context, namespaceID uuid.UUID, keepNames []string) (int64, error) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -832,7 +832,8 @@ func (m *memStore) DeletePod(_ context.Context, id uuid.UUID) error {
 	return nil
 }
 
-func (m *memStore) UpsertPod(_ context.Context, in PodCreate) (Pod, UpsertOutcome, error) { //nolint:gocritic // interface-mandated signature
+//nolint:gocyclo,gocritic // mirrors PG snapshot+compare per business field
+func (m *memStore) UpsertPod(_ context.Context, in PodCreate) (Pod, UpsertOutcome, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.nsByID[in.NamespaceId]; !ok {
@@ -1027,7 +1028,11 @@ func (m *memStore) DeleteWorkload(_ context.Context, id uuid.UUID) error {
 	return nil
 }
 
-func (m *memStore) UpsertWorkload(_ context.Context, in WorkloadCreate) (Workload, UpsertOutcome, error) { //nolint:gocritic // interface-mandated signature
+//nolint:gocritic // hugeParam: interface-mandated signature
+func (m *memStore) UpsertWorkload(
+	_ context.Context,
+	in WorkloadCreate,
+) (Workload, UpsertOutcome, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.nsByID[in.NamespaceId]; !ok {
@@ -1363,7 +1368,11 @@ func (m *memStore) DeleteService(_ context.Context, id uuid.UUID) error {
 	return nil
 }
 
-func (m *memStore) UpsertService(_ context.Context, in ServiceCreate) (Service, UpsertOutcome, error) { //nolint:gocritic // interface-mandated signature
+//nolint:gocritic // hugeParam: interface-mandated signature
+func (m *memStore) UpsertService(
+	_ context.Context,
+	in ServiceCreate,
+) (Service, UpsertOutcome, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.nsByID[in.NamespaceId]; !ok {
@@ -1430,7 +1439,11 @@ func (m *memStore) DeleteServicesNotIn(_ context.Context, namespaceID uuid.UUID,
 	return deleted, nil
 }
 
-func (m *memStore) UpsertNamespace(_ context.Context, in NamespaceCreate) (Namespace, UpsertOutcome, error) { //nolint:gocritic // interface-mandated signature
+//nolint:gocritic // hugeParam: interface-mandated signature
+func (m *memStore) UpsertNamespace(
+	_ context.Context,
+	in NamespaceCreate,
+) (Namespace, UpsertOutcome, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.byID[in.ClusterId]; !ok {

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -135,9 +135,12 @@ type Store interface {
 
 	// UpsertNode inserts a node when no row exists for (cluster_id, name),
 	// or updates the mutable fields of the existing row when it does. The
-	// returned Node always reflects the post-operation state. Returns
-	// ErrNotFound if the parent cluster does not exist.
-	UpsertNode(ctx context.Context, in NodeCreate) (Node, error)
+	// returned Node always reflects the post-operation state. The second
+	// return value classifies the operation for audit filtering (ADR-0024):
+	// OutcomeInserted for a fresh insert, OutcomeBusinessChanged when a
+	// business field changed, OutcomeNoChange when only clock fields moved.
+	// Returns ErrNotFound if the parent cluster does not exist.
+	UpsertNode(ctx context.Context, in NodeCreate) (Node, UpsertOutcome, error)
 
 	// DeleteNodesNotIn removes every node of the given cluster whose name is
 	// not in keepNames. When keepNames is empty the entire set of nodes for
@@ -173,8 +176,11 @@ type Store interface {
 	// terminated in a single transaction. See ADR-0021 §IMP-007.
 	SoftDeleteNamespace(ctx context.Context, id uuid.UUID) error
 
-	// UpsertNamespace mirrors UpsertNode for namespaces.
-	UpsertNamespace(ctx context.Context, in NamespaceCreate) (Namespace, error)
+	// UpsertNamespace mirrors UpsertNode for namespaces. The second return
+	// value classifies the operation for audit filtering (ADR-0024):
+	// OutcomeInserted for a fresh insert, OutcomeBusinessChanged when a
+	// business field changed, OutcomeNoChange when only clock fields moved.
+	UpsertNamespace(ctx context.Context, in NamespaceCreate) (Namespace, UpsertOutcome, error)
 
 	// DeleteNamespacesNotIn mirrors DeleteNodesNotIn for namespaces.
 	DeleteNamespacesNotIn(ctx context.Context, clusterID uuid.UUID, keepNames []string) (int64, error)
@@ -198,8 +204,11 @@ type Store interface {
 	// DeletePod removes a pod by id. Returns ErrNotFound if absent.
 	DeletePod(ctx context.Context, id uuid.UUID) error
 
-	// UpsertPod mirrors UpsertNode, keyed on (namespace_id, name).
-	UpsertPod(ctx context.Context, in PodCreate) (Pod, error)
+	// UpsertPod mirrors UpsertNode, keyed on (namespace_id, name). The second
+	// return value classifies the operation for audit filtering (ADR-0024):
+	// OutcomeInserted for a fresh insert, OutcomeBusinessChanged when a
+	// business field changed, OutcomeNoChange when only clock fields moved.
+	UpsertPod(ctx context.Context, in PodCreate) (Pod, UpsertOutcome, error)
 
 	// DeletePodsNotIn mirrors DeleteNodesNotIn, scoped to a single namespace.
 	DeletePodsNotIn(ctx context.Context, namespaceID uuid.UUID, keepNames []string) (int64, error)
@@ -224,8 +233,11 @@ type Store interface {
 	// DeleteWorkload removes a workload by id.
 	DeleteWorkload(ctx context.Context, id uuid.UUID) error
 
-	// UpsertWorkload mirrors UpsertPod; keyed on (namespace_id, kind, name).
-	UpsertWorkload(ctx context.Context, in WorkloadCreate) (Workload, error)
+	// UpsertWorkload mirrors UpsertPod; keyed on (namespace_id, kind, name). The second
+	// return value classifies the operation for audit filtering (ADR-0024):
+	// OutcomeInserted for a fresh insert, OutcomeBusinessChanged when a
+	// business field changed, OutcomeNoChange when only clock fields moved.
+	UpsertWorkload(ctx context.Context, in WorkloadCreate) (Workload, UpsertOutcome, error)
 
 	// DeleteWorkloadsNotIn removes workloads in the namespace whose
 	// (kind, name) tuple is not in keep. An empty keep slice clears every
@@ -248,8 +260,11 @@ type Store interface {
 	// DeleteService removes by id.
 	DeleteService(ctx context.Context, id uuid.UUID) error
 
-	// UpsertService mirrors UpsertPod; keyed on (namespace_id, name).
-	UpsertService(ctx context.Context, in ServiceCreate) (Service, error)
+	// UpsertService mirrors UpsertPod; keyed on (namespace_id, name). The second
+	// return value classifies the operation for audit filtering (ADR-0024):
+	// OutcomeInserted for a fresh insert, OutcomeBusinessChanged when a
+	// business field changed, OutcomeNoChange when only clock fields moved.
+	UpsertService(ctx context.Context, in ServiceCreate) (Service, UpsertOutcome, error)
 
 	// DeleteServicesNotIn mirrors DeletePodsNotIn, scoped to a single namespace.
 	DeleteServicesNotIn(ctx context.Context, namespaceID uuid.UUID, keepNames []string) (int64, error)
@@ -269,8 +284,11 @@ type Store interface {
 	// DeleteIngress removes by id.
 	DeleteIngress(ctx context.Context, id uuid.UUID) error
 
-	// UpsertIngress mirrors UpsertService; keyed on (namespace_id, name).
-	UpsertIngress(ctx context.Context, in IngressCreate) (Ingress, error)
+	// UpsertIngress mirrors UpsertService; keyed on (namespace_id, name). The second
+	// return value classifies the operation for audit filtering (ADR-0024):
+	// OutcomeInserted for a fresh insert, OutcomeBusinessChanged when a
+	// business field changed, OutcomeNoChange when only clock fields moved.
+	UpsertIngress(ctx context.Context, in IngressCreate) (Ingress, UpsertOutcome, error)
 
 	// DeleteIngressesNotIn mirrors DeleteServicesNotIn.
 	DeleteIngressesNotIn(ctx context.Context, namespaceID uuid.UUID, keepNames []string) (int64, error)
@@ -294,8 +312,11 @@ type Store interface {
 	// DeletePersistentVolume removes by id.
 	DeletePersistentVolume(ctx context.Context, id uuid.UUID) error
 
-	// UpsertPersistentVolume mirrors UpsertNode; keyed on (cluster_id, name).
-	UpsertPersistentVolume(ctx context.Context, in PersistentVolumeCreate) (PersistentVolume, error)
+	// UpsertPersistentVolume mirrors UpsertNode; keyed on (cluster_id, name). The second
+	// return value classifies the operation for audit filtering (ADR-0024):
+	// OutcomeInserted for a fresh insert, OutcomeBusinessChanged when a
+	// business field changed, OutcomeNoChange when only clock fields moved.
+	UpsertPersistentVolume(ctx context.Context, in PersistentVolumeCreate) (PersistentVolume, UpsertOutcome, error)
 
 	// DeletePersistentVolumesNotIn removes cluster-scoped PVs whose name is
 	// not in keepNames. An empty keep slice clears every PV in that cluster.
@@ -320,8 +341,11 @@ type Store interface {
 	// DeletePersistentVolumeClaim removes by id.
 	DeletePersistentVolumeClaim(ctx context.Context, id uuid.UUID) error
 
-	// UpsertPersistentVolumeClaim mirrors UpsertPod; keyed on (namespace_id, name).
-	UpsertPersistentVolumeClaim(ctx context.Context, in PersistentVolumeClaimCreate) (PersistentVolumeClaim, error)
+	// UpsertPersistentVolumeClaim mirrors UpsertPod; keyed on (namespace_id, name). The second
+	// return value classifies the operation for audit filtering (ADR-0024):
+	// OutcomeInserted for a fresh insert, OutcomeBusinessChanged when a
+	// business field changed, OutcomeNoChange when only clock fields moved.
+	UpsertPersistentVolumeClaim(ctx context.Context, in PersistentVolumeClaimCreate) (PersistentVolumeClaim, UpsertOutcome, error)
 
 	// DeletePersistentVolumeClaimsNotIn mirrors DeletePodsNotIn.
 	DeletePersistentVolumeClaimsNotIn(ctx context.Context, namespaceID uuid.UUID, keepNames []string) (int64, error)
@@ -564,8 +588,11 @@ type Store interface {
 	// (cloud_account_id, provider_vm_id). Server-side dedup against
 	// nodes.provider_id: returns ErrConflict if the provider_vm_id already
 	// appears in any node's provider_id (the VM is already inventoried as
-	// a Kubernetes node).
-	UpsertVirtualMachine(ctx context.Context, in VirtualMachineUpsert) (VirtualMachine, error)
+	// a Kubernetes node). The second return value classifies the operation
+	// for audit filtering (ADR-0024): OutcomeInserted for a fresh insert,
+	// OutcomeBusinessChanged when a business field changed, OutcomeNoChange
+	// when only clock fields moved.
+	UpsertVirtualMachine(ctx context.Context, in VirtualMachineUpsert) (VirtualMachine, UpsertOutcome, error)
 
 	// GetVirtualMachine fetches by id. ErrNotFound when absent.
 	GetVirtualMachine(ctx context.Context, id uuid.UUID) (VirtualMachine, error)

--- a/internal/api/upsert_handlers_audit_skip_test.go
+++ b/internal/api/upsert_handlers_audit_skip_test.go
@@ -10,24 +10,25 @@ import (
 )
 
 // runUpsertSkipScenario sends three POSTs against the same path:
-//   1. fresh body  → outcome=Inserted   → bag MUST NOT skip
-//   2. identical   → outcome=NoChange   → bag MUST skip
-//   3. mutated     → outcome=Changed    → bag MUST NOT skip
+//  1. fresh body  → outcome=Inserted   → bag MUST NOT skip
+//  2. identical   → outcome=NoChange   → bag MUST skip
+//  3. mutated     → outcome=Changed    → bag MUST NOT skip
 //
 // Used by D2-D8 wiring tests. The mutated body is supplied per entity to
-// touch a single business field that the memStore tracks.
-func runUpsertSkipScenario(t *testing.T, h http.Handler, path, freshBody, mutatedBody string, wantStatus int) {
+// touch a single business field that the memStore tracks. All upserts in
+// this suite return 201 on success.
+func runUpsertSkipScenario(t *testing.T, h http.Handler, path, freshBody, mutatedBody string) {
 	t.Helper()
 
 	post := func(label, body string) *AuditBagTestView {
 		t.Helper()
-		r := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, path, strings.NewReader(body))
 		r.Header.Set("Content-Type", "application/json")
 		ctx, bag := WithAuditBagForTest(r.Context())
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, r.WithContext(ctx))
-		if w.Code != wantStatus {
-			t.Fatalf("%s POST %s: got %d, want %d, body=%q", label, path, w.Code, wantStatus, w.Body.String())
+		if w.Code != http.StatusCreated {
+			t.Fatalf("%s POST %s: got %d, want %d, body=%q", label, path, w.Code, http.StatusCreated, w.Body.String())
 		}
 		return bag
 	}
@@ -74,7 +75,7 @@ func TestCreateNode_NoOpCallsSetAuditSkip(t *testing.T) {
 	clusterID := cluster.Id.String()
 	fresh := fmt.Sprintf(`{"cluster_id":%q,"name":"node-a","kubelet_version":"v1.30.0"}`, clusterID)
 	mutated := fmt.Sprintf(`{"cluster_id":%q,"name":"node-a","kubelet_version":"v1.30.1"}`, clusterID)
-	runUpsertSkipScenario(t, h, "/v1/nodes", fresh, mutated, http.StatusCreated)
+	runUpsertSkipScenario(t, h, "/v1/nodes", fresh, mutated)
 }
 
 func TestCreateNamespace_NoOpCallsSetAuditSkip(t *testing.T) {
@@ -83,7 +84,7 @@ func TestCreateNamespace_NoOpCallsSetAuditSkip(t *testing.T) {
 	clusterID := cluster.Id.String()
 	fresh := fmt.Sprintf(`{"cluster_id":%q,"name":"ns-a","phase":"Active"}`, clusterID)
 	mutated := fmt.Sprintf(`{"cluster_id":%q,"name":"ns-a","phase":"Terminating"}`, clusterID)
-	runUpsertSkipScenario(t, h, "/v1/namespaces", fresh, mutated, http.StatusCreated)
+	runUpsertSkipScenario(t, h, "/v1/namespaces", fresh, mutated)
 }
 
 func TestCreateWorkload_NoOpCallsSetAuditSkip(t *testing.T) {
@@ -92,7 +93,7 @@ func TestCreateWorkload_NoOpCallsSetAuditSkip(t *testing.T) {
 	nsID := ns.Id.String()
 	fresh := fmt.Sprintf(`{"namespace_id":%q,"kind":"Deployment","name":"web","replicas":3}`, nsID)
 	mutated := fmt.Sprintf(`{"namespace_id":%q,"kind":"Deployment","name":"web","replicas":5}`, nsID)
-	runUpsertSkipScenario(t, h, "/v1/workloads", fresh, mutated, http.StatusCreated)
+	runUpsertSkipScenario(t, h, "/v1/workloads", fresh, mutated)
 }
 
 func TestCreateService_NoOpCallsSetAuditSkip(t *testing.T) {
@@ -101,7 +102,7 @@ func TestCreateService_NoOpCallsSetAuditSkip(t *testing.T) {
 	nsID := ns.Id.String()
 	fresh := fmt.Sprintf(`{"namespace_id":%q,"name":"svc-a","type":"ClusterIP","cluster_ip":"10.0.0.1"}`, nsID)
 	mutated := fmt.Sprintf(`{"namespace_id":%q,"name":"svc-a","type":"LoadBalancer","cluster_ip":"10.0.0.1"}`, nsID)
-	runUpsertSkipScenario(t, h, "/v1/services", fresh, mutated, http.StatusCreated)
+	runUpsertSkipScenario(t, h, "/v1/services", fresh, mutated)
 }
 
 func TestCreateIngress_NoOpCallsSetAuditSkip(t *testing.T) {
@@ -110,7 +111,7 @@ func TestCreateIngress_NoOpCallsSetAuditSkip(t *testing.T) {
 	nsID := ns.Id.String()
 	fresh := fmt.Sprintf(`{"namespace_id":%q,"name":"ing-a","ingress_class_name":"nginx"}`, nsID)
 	mutated := fmt.Sprintf(`{"namespace_id":%q,"name":"ing-a","ingress_class_name":"traefik"}`, nsID)
-	runUpsertSkipScenario(t, h, "/v1/ingresses", fresh, mutated, http.StatusCreated)
+	runUpsertSkipScenario(t, h, "/v1/ingresses", fresh, mutated)
 }
 
 func TestCreatePersistentVolume_NoOpCallsSetAuditSkip(t *testing.T) {
@@ -119,7 +120,7 @@ func TestCreatePersistentVolume_NoOpCallsSetAuditSkip(t *testing.T) {
 	clusterID := cluster.Id.String()
 	fresh := fmt.Sprintf(`{"cluster_id":%q,"name":"pv-a","capacity":"10Gi","phase":"Available"}`, clusterID)
 	mutated := fmt.Sprintf(`{"cluster_id":%q,"name":"pv-a","capacity":"20Gi","phase":"Available"}`, clusterID)
-	runUpsertSkipScenario(t, h, "/v1/persistentvolumes", fresh, mutated, http.StatusCreated)
+	runUpsertSkipScenario(t, h, "/v1/persistentvolumes", fresh, mutated)
 }
 
 func TestCreatePersistentVolumeClaim_NoOpCallsSetAuditSkip(t *testing.T) {
@@ -128,5 +129,5 @@ func TestCreatePersistentVolumeClaim_NoOpCallsSetAuditSkip(t *testing.T) {
 	nsID := ns.Id.String()
 	fresh := fmt.Sprintf(`{"namespace_id":%q,"name":"pvc-a","phase":"Bound","requested_storage":"10Gi"}`, nsID)
 	mutated := fmt.Sprintf(`{"namespace_id":%q,"name":"pvc-a","phase":"Bound","requested_storage":"20Gi"}`, nsID)
-	runUpsertSkipScenario(t, h, "/v1/persistentvolumeclaims", fresh, mutated, http.StatusCreated)
+	runUpsertSkipScenario(t, h, "/v1/persistentvolumeclaims", fresh, mutated)
 }

--- a/internal/api/upsert_handlers_audit_skip_test.go
+++ b/internal/api/upsert_handlers_audit_skip_test.go
@@ -1,0 +1,132 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// runUpsertSkipScenario sends three POSTs against the same path:
+//   1. fresh body  → outcome=Inserted   → bag MUST NOT skip
+//   2. identical   → outcome=NoChange   → bag MUST skip
+//   3. mutated     → outcome=Changed    → bag MUST NOT skip
+//
+// Used by D2-D8 wiring tests. The mutated body is supplied per entity to
+// touch a single business field that the memStore tracks.
+func runUpsertSkipScenario(t *testing.T, h http.Handler, path, freshBody, mutatedBody string, wantStatus int) {
+	t.Helper()
+
+	post := func(label, body string) *AuditBagTestView {
+		t.Helper()
+		r := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+		ctx, bag := WithAuditBagForTest(r.Context())
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r.WithContext(ctx))
+		if w.Code != wantStatus {
+			t.Fatalf("%s POST %s: got %d, want %d, body=%q", label, path, w.Code, wantStatus, w.Body.String())
+		}
+		return bag
+	}
+
+	if bag := post("first", freshBody); bag.SkipForTest() {
+		t.Fatalf("%s: first POST should NOT skip (Inserted)", path)
+	}
+	if bag := post("identical", freshBody); !bag.SkipForTest() {
+		t.Fatalf("%s: identical POST SHOULD skip (NoChange)", path)
+	}
+	if bag := post("mutated", mutatedBody); bag.SkipForTest() {
+		t.Fatalf("%s: mutated POST should NOT skip (BusinessChanged)", path)
+	}
+}
+
+func newSkipTestEnv(t *testing.T) (http.Handler, Cluster, Namespace) {
+	t.Helper()
+	store := newMemStore()
+	h := newTestHandler(t, store)
+
+	clusterResp := do(h, http.MethodPost, "/v1/clusters", `{"name":"prod-skip"}`)
+	if clusterResp.Code != http.StatusCreated {
+		t.Fatalf("create cluster: %d %q", clusterResp.Code, clusterResp.Body.String())
+	}
+	var cluster Cluster
+	if err := json.Unmarshal(clusterResp.Body.Bytes(), &cluster); err != nil {
+		t.Fatalf("decode cluster: %v", err)
+	}
+
+	nsResp := do(h, http.MethodPost, "/v1/namespaces", fmt.Sprintf(`{"cluster_id":%q,"name":"apps"}`, cluster.Id.String()))
+	if nsResp.Code != http.StatusCreated {
+		t.Fatalf("create namespace: %d %q", nsResp.Code, nsResp.Body.String())
+	}
+	var ns Namespace
+	if err := json.Unmarshal(nsResp.Body.Bytes(), &ns); err != nil {
+		t.Fatalf("decode namespace: %v", err)
+	}
+	return h, cluster, ns
+}
+
+func TestCreateNode_NoOpCallsSetAuditSkip(t *testing.T) {
+	t.Parallel()
+	h, cluster, _ := newSkipTestEnv(t)
+	clusterID := cluster.Id.String()
+	fresh := fmt.Sprintf(`{"cluster_id":%q,"name":"node-a","kubelet_version":"v1.30.0"}`, clusterID)
+	mutated := fmt.Sprintf(`{"cluster_id":%q,"name":"node-a","kubelet_version":"v1.30.1"}`, clusterID)
+	runUpsertSkipScenario(t, h, "/v1/nodes", fresh, mutated, http.StatusCreated)
+}
+
+func TestCreateNamespace_NoOpCallsSetAuditSkip(t *testing.T) {
+	t.Parallel()
+	h, cluster, _ := newSkipTestEnv(t)
+	clusterID := cluster.Id.String()
+	fresh := fmt.Sprintf(`{"cluster_id":%q,"name":"ns-a","phase":"Active"}`, clusterID)
+	mutated := fmt.Sprintf(`{"cluster_id":%q,"name":"ns-a","phase":"Terminating"}`, clusterID)
+	runUpsertSkipScenario(t, h, "/v1/namespaces", fresh, mutated, http.StatusCreated)
+}
+
+func TestCreateWorkload_NoOpCallsSetAuditSkip(t *testing.T) {
+	t.Parallel()
+	h, _, ns := newSkipTestEnv(t)
+	nsID := ns.Id.String()
+	fresh := fmt.Sprintf(`{"namespace_id":%q,"kind":"Deployment","name":"web","replicas":3}`, nsID)
+	mutated := fmt.Sprintf(`{"namespace_id":%q,"kind":"Deployment","name":"web","replicas":5}`, nsID)
+	runUpsertSkipScenario(t, h, "/v1/workloads", fresh, mutated, http.StatusCreated)
+}
+
+func TestCreateService_NoOpCallsSetAuditSkip(t *testing.T) {
+	t.Parallel()
+	h, _, ns := newSkipTestEnv(t)
+	nsID := ns.Id.String()
+	fresh := fmt.Sprintf(`{"namespace_id":%q,"name":"svc-a","type":"ClusterIP","cluster_ip":"10.0.0.1"}`, nsID)
+	mutated := fmt.Sprintf(`{"namespace_id":%q,"name":"svc-a","type":"LoadBalancer","cluster_ip":"10.0.0.1"}`, nsID)
+	runUpsertSkipScenario(t, h, "/v1/services", fresh, mutated, http.StatusCreated)
+}
+
+func TestCreateIngress_NoOpCallsSetAuditSkip(t *testing.T) {
+	t.Parallel()
+	h, _, ns := newSkipTestEnv(t)
+	nsID := ns.Id.String()
+	fresh := fmt.Sprintf(`{"namespace_id":%q,"name":"ing-a","ingress_class_name":"nginx"}`, nsID)
+	mutated := fmt.Sprintf(`{"namespace_id":%q,"name":"ing-a","ingress_class_name":"traefik"}`, nsID)
+	runUpsertSkipScenario(t, h, "/v1/ingresses", fresh, mutated, http.StatusCreated)
+}
+
+func TestCreatePersistentVolume_NoOpCallsSetAuditSkip(t *testing.T) {
+	t.Parallel()
+	h, cluster, _ := newSkipTestEnv(t)
+	clusterID := cluster.Id.String()
+	fresh := fmt.Sprintf(`{"cluster_id":%q,"name":"pv-a","capacity":"10Gi","phase":"Available"}`, clusterID)
+	mutated := fmt.Sprintf(`{"cluster_id":%q,"name":"pv-a","capacity":"20Gi","phase":"Available"}`, clusterID)
+	runUpsertSkipScenario(t, h, "/v1/persistentvolumes", fresh, mutated, http.StatusCreated)
+}
+
+func TestCreatePersistentVolumeClaim_NoOpCallsSetAuditSkip(t *testing.T) {
+	t.Parallel()
+	h, _, ns := newSkipTestEnv(t)
+	nsID := ns.Id.String()
+	fresh := fmt.Sprintf(`{"namespace_id":%q,"name":"pvc-a","phase":"Bound","requested_storage":"10Gi"}`, nsID)
+	mutated := fmt.Sprintf(`{"namespace_id":%q,"name":"pvc-a","phase":"Bound","requested_storage":"20Gi"}`, nsID)
+	runUpsertSkipScenario(t, h, "/v1/persistentvolumeclaims", fresh, mutated, http.StatusCreated)
+}

--- a/internal/api/virtual_machine_handlers.go
+++ b/internal/api/virtual_machine_handlers.go
@@ -163,7 +163,7 @@ func HandleUpsertVirtualMachine(store Store) http.HandlerFunc {
 			Tags:                 req.Tags,
 			Labels:               req.Labels,
 		}
-		vm, err := store.UpsertVirtualMachine(r.Context(), in)
+		vm, _, err := store.UpsertVirtualMachine(r.Context(), in)
 		if err != nil {
 			if errors.Is(err, ErrConflict) {
 				writeJSON(w, http.StatusConflict, map[string]any{

--- a/internal/api/virtual_machine_handlers.go
+++ b/internal/api/virtual_machine_handlers.go
@@ -163,7 +163,7 @@ func HandleUpsertVirtualMachine(store Store) http.HandlerFunc {
 			Tags:                 req.Tags,
 			Labels:               req.Labels,
 		}
-		vm, _, err := store.UpsertVirtualMachine(r.Context(), in)
+		vm, outcome, err := store.UpsertVirtualMachine(r.Context(), in)
 		if err != nil {
 			if errors.Is(err, ErrConflict) {
 				writeJSON(w, http.StatusConflict, map[string]any{
@@ -175,6 +175,9 @@ func HandleUpsertVirtualMachine(store Store) http.HandlerFunc {
 			slog.Error("upsert virtual machine", slog.Any("error", err))
 			writeProblem(w, http.StatusInternalServerError, "Internal Server Error", "")
 			return
+		}
+		if outcome == OutcomeNoChange {
+			SetAuditSkip(r.Context())
 		}
 		writeJSON(w, http.StatusOK, vm)
 	}

--- a/internal/api/virtual_machine_handlers.go
+++ b/internal/api/virtual_machine_handlers.go
@@ -531,6 +531,10 @@ func HandleReconcileVirtualMachines(store Store) http.HandlerFunc {
 			writeProblem(w, http.StatusInternalServerError, "Internal Server Error", "")
 			return
 		}
+		if n == 0 {
+			SetAuditSkipReason(r.Context(), "reconcile_empty")
+			SetAuditSkip(r.Context())
+		}
 		writeJSON(w, http.StatusOK, map[string]any{"tombstoned": n})
 	}
 }

--- a/internal/api/virtual_machine_handlers.go
+++ b/internal/api/virtual_machine_handlers.go
@@ -449,9 +449,9 @@ func callerIdentifier(caller *auth.Caller) string {
 		return caller.Username
 	case auth.CallerKindToken:
 		if caller.TokenName != "" {
-			return "token:" + caller.TokenName
+			return string(AuditEventActorKindToken) + ":" + caller.TokenName
 		}
-		return "token"
+		return string(AuditEventActorKindToken)
 	default:
 		return ""
 	}

--- a/internal/api/virtual_machine_handlers_audit_skip_test.go
+++ b/internal/api/virtual_machine_handlers_audit_skip_test.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestHandleUpsertVirtualMachine_NoOpCallsSetAuditSkip exercises the
+// audit no-op filter wiring on the VM upsert path: a brand-new POST
+// must NOT mark the audit bag skip, an identical replay (same business
+// fields, store classifies NoChange) MUST flip skip=true, and a real
+// mutation MUST clear skip again.
+func TestHandleUpsertVirtualMachine_NoOpCallsSetAuditSkip(t *testing.T) {
+	resetCloudFake()
+	store := newMemStore()
+	enc := newTestEncrypter(t)
+
+	muxAdmin := buildCloudMux(t, store, enc, adminCaller())
+	rr := doReq(t, muxAdmin, http.MethodPost, "/v1/admin/cloud-accounts", map[string]any{
+		"provider": "outscale", "name": "vm-skip-acct", "region": "eu-west-2",
+		"access_key": "ak", "secret_key": "sk",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create cloud account: %d %q", rr.Code, rr.Body.String())
+	}
+	var acct CloudAccount
+	if err := json.Unmarshal(rr.Body.Bytes(), &acct); err != nil {
+		t.Fatalf("decode account: %v", err)
+	}
+
+	muxCol := buildCloudMux(t, store, enc, collectorCaller(&acct.ID))
+
+	post := func(label string, body map[string]any) *AuditBagTestView {
+		t.Helper()
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("%s: marshal: %v", label, err)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/v1/virtual-machines", bytes.NewReader(b))
+		req.Header.Set("Content-Type", "application/json")
+		ctx, bag := WithAuditBagForTest(req.Context())
+		w := httptest.NewRecorder()
+		muxCol.ServeHTTP(w, req.WithContext(ctx))
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s POST /v1/virtual-machines: %d %q", label, w.Code, w.Body.String())
+		}
+		return bag
+	}
+
+	freshBody := map[string]any{
+		"cloud_account_id": acct.ID,
+		"provider_vm_id":   "i-aud-skip-1",
+		"name":             "vm-aud-1",
+		"power_state":      "running",
+		"ready":            true,
+	}
+	mutatedBody := map[string]any{
+		"cloud_account_id": acct.ID,
+		"provider_vm_id":   "i-aud-skip-1",
+		"name":             "vm-aud-1",
+		"power_state":      "stopped",
+		"ready":            false,
+	}
+
+	if bag := post("first", freshBody); bag.SkipForTest() {
+		t.Fatalf("first POST should NOT skip (Inserted)")
+	}
+	if bag := post("identical", freshBody); !bag.SkipForTest() {
+		t.Fatalf("identical POST SHOULD skip (NoChange), reason=%q", bag.SkipReasonForTest())
+	}
+	if bag := post("mutated", mutatedBody); bag.SkipForTest() {
+		t.Fatalf("mutated POST should NOT skip (BusinessChanged)")
+	}
+}

--- a/internal/api/virtual_machine_handlers_audit_skip_test.go
+++ b/internal/api/virtual_machine_handlers_audit_skip_test.go
@@ -39,7 +39,7 @@ func TestHandleUpsertVirtualMachine_NoOpCallsSetAuditSkip(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: marshal: %v", label, err)
 		}
-		req := httptest.NewRequest(http.MethodPost, "/v1/virtual-machines", bytes.NewReader(b))
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/virtual-machines", bytes.NewReader(b))
 		req.Header.Set("Content-Type", "application/json")
 		ctx, bag := WithAuditBagForTest(req.Context())
 		w := httptest.NewRecorder()

--- a/internal/api/virtual_machine_reconcile_audit_skip_test.go
+++ b/internal/api/virtual_machine_reconcile_audit_skip_test.go
@@ -50,7 +50,7 @@ func TestHandleReconcileVirtualMachines_EmptyCallsSetAuditSkip(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: marshal: %v", label, err)
 		}
-		req := httptest.NewRequest(http.MethodPost, "/v1/virtual-machines/reconcile", bytes.NewReader(b))
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/virtual-machines/reconcile", bytes.NewReader(b))
 		req.Header.Set("Content-Type", "application/json")
 		ctx, bag := WithAuditBagForTest(req.Context())
 		w := httptest.NewRecorder()

--- a/internal/api/virtual_machine_reconcile_audit_skip_test.go
+++ b/internal/api/virtual_machine_reconcile_audit_skip_test.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestHandleReconcileVirtualMachines_EmptyCallsSetAuditSkip exercises
+// the audit no-op filter on the VM reconcile path: a reconcile that
+// tombstones nothing (n == 0) MUST flip skip with reason
+// "reconcile_empty". A reconcile that does tombstone something MUST
+// leave skip clear.
+func TestHandleReconcileVirtualMachines_EmptyCallsSetAuditSkip(t *testing.T) {
+	resetCloudFake()
+	store := newMemStore()
+	enc := newTestEncrypter(t)
+
+	muxAdmin := buildCloudMux(t, store, enc, adminCaller())
+	rr := doReq(t, muxAdmin, http.MethodPost, "/v1/admin/cloud-accounts", map[string]any{
+		"provider": "outscale", "name": "vm-rec-skip", "region": "eu-west-2",
+		"access_key": "ak", "secret_key": "sk",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create cloud account: %d %q", rr.Code, rr.Body.String())
+	}
+	var acct CloudAccount
+	if err := json.Unmarshal(rr.Body.Bytes(), &acct); err != nil {
+		t.Fatalf("decode account: %v", err)
+	}
+
+	muxCol := buildCloudMux(t, store, enc, collectorCaller(&acct.ID))
+
+	// Seed one VM so the "delete" branch has something to tombstone.
+	rr = doReq(t, muxCol, http.MethodPost, "/v1/virtual-machines", map[string]any{
+		"cloud_account_id": acct.ID,
+		"provider_vm_id":   "i-rec-1",
+		"name":             "vm-rec-1",
+		"power_state":      "running",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("seed VM: %d %q", rr.Code, rr.Body.String())
+	}
+
+	post := func(label string, body map[string]any) *AuditBagTestView {
+		t.Helper()
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("%s: marshal: %v", label, err)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/v1/virtual-machines/reconcile", bytes.NewReader(b))
+		req.Header.Set("Content-Type", "application/json")
+		ctx, bag := WithAuditBagForTest(req.Context())
+		w := httptest.NewRecorder()
+		muxCol.ServeHTTP(w, req.WithContext(ctx))
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s POST /v1/virtual-machines/reconcile: %d %q", label, w.Code, w.Body.String())
+		}
+		return bag
+	}
+
+	// Empty path: keep the only VM → n == 0 → MUST skip.
+	bagEmpty := post("empty", map[string]any{
+		"cloud_account_id":     acct.ID,
+		"keep_provider_vm_ids": []string{"i-rec-1"},
+	})
+	if !bagEmpty.SkipForTest() {
+		t.Fatalf("empty reconcile (n==0) SHOULD skip")
+	}
+	if got := bagEmpty.SkipReasonForTest(); got != "reconcile_empty" {
+		t.Fatalf("empty reconcile reason = %q, want %q", got, "reconcile_empty")
+	}
+
+	// Delete path: drop the VM from keep → n == 1 → MUST NOT skip.
+	bagDel := post("delete", map[string]any{
+		"cloud_account_id":     acct.ID,
+		"keep_provider_vm_ids": []string{},
+	})
+	if bagDel.SkipForTest() {
+		t.Fatalf("reconcile with tombstones (n>0) should NOT skip")
+	}
+}

--- a/internal/collector/apiclient/client.go
+++ b/internal/collector/apiclient/client.go
@@ -161,12 +161,12 @@ func (s *Store) UpdateCluster(ctx context.Context, id uuid.UUID, in api.ClusterU
 // UpsertNode creates or updates a node record.
 //
 //nolint:gocritic // hugeParam: signature matches CmdbStore interface.
-func (s *Store) UpsertNode(ctx context.Context, in api.NodeCreate) (api.Node, error) {
+func (s *Store) UpsertNode(ctx context.Context, in api.NodeCreate) (api.Node, api.UpsertOutcome, error) {
 	var out api.Node
 	if err := s.doJSON(ctx, http.MethodPost, "/v1/nodes", in, &out); err != nil {
-		return api.Node{}, fmt.Errorf("upsert node: %w", err)
+		return api.Node{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert node: %w", err)
 	}
-	return out, nil
+	return out, api.OutcomeBusinessChanged, nil
 }
 
 // DeleteNodesNotIn removes nodes not in the keepNames list for the given cluster.
@@ -177,12 +177,12 @@ func (s *Store) DeleteNodesNotIn(ctx context.Context, clusterID uuid.UUID, keepN
 // UpsertNamespace creates or updates a namespace record.
 //
 //nolint:gocritic // hugeParam: signature matches CmdbStore interface.
-func (s *Store) UpsertNamespace(ctx context.Context, in api.NamespaceCreate) (api.Namespace, error) {
+func (s *Store) UpsertNamespace(ctx context.Context, in api.NamespaceCreate) (api.Namespace, api.UpsertOutcome, error) {
 	var out api.Namespace
 	if err := s.doJSON(ctx, http.MethodPost, "/v1/namespaces", in, &out); err != nil {
-		return api.Namespace{}, fmt.Errorf("upsert namespace: %w", err)
+		return api.Namespace{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert namespace: %w", err)
 	}
-	return out, nil
+	return out, api.OutcomeBusinessChanged, nil
 }
 
 // DeleteNamespacesNotIn removes namespaces not in the keepNames list for the given cluster.
@@ -193,12 +193,12 @@ func (s *Store) DeleteNamespacesNotIn(ctx context.Context, clusterID uuid.UUID, 
 // UpsertPod creates or updates a pod record.
 //
 //nolint:gocritic // hugeParam: signature matches CmdbStore interface.
-func (s *Store) UpsertPod(ctx context.Context, in api.PodCreate) (api.Pod, error) {
+func (s *Store) UpsertPod(ctx context.Context, in api.PodCreate) (api.Pod, api.UpsertOutcome, error) {
 	var out api.Pod
 	if err := s.doJSON(ctx, http.MethodPost, "/v1/pods", in, &out); err != nil {
-		return api.Pod{}, fmt.Errorf("upsert pod: %w", err)
+		return api.Pod{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert pod: %w", err)
 	}
-	return out, nil
+	return out, api.OutcomeBusinessChanged, nil
 }
 
 // DeletePodsNotIn removes pods not in the keepNames list for the given namespace.
@@ -209,12 +209,12 @@ func (s *Store) DeletePodsNotIn(ctx context.Context, namespaceID uuid.UUID, keep
 // UpsertWorkload creates or updates a workload record.
 //
 //nolint:gocritic // hugeParam: signature matches CmdbStore interface.
-func (s *Store) UpsertWorkload(ctx context.Context, in api.WorkloadCreate) (api.Workload, error) {
+func (s *Store) UpsertWorkload(ctx context.Context, in api.WorkloadCreate) (api.Workload, api.UpsertOutcome, error) {
 	var out api.Workload
 	if err := s.doJSON(ctx, http.MethodPost, "/v1/workloads", in, &out); err != nil {
-		return api.Workload{}, fmt.Errorf("upsert workload: %w", err)
+		return api.Workload{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert workload: %w", err)
 	}
-	return out, nil
+	return out, api.OutcomeBusinessChanged, nil
 }
 
 // DeleteWorkloadsNotIn removes workloads not in the keep lists for the given namespace.
@@ -234,12 +234,12 @@ func (s *Store) DeleteWorkloadsNotIn(ctx context.Context, namespaceID uuid.UUID,
 // UpsertService creates or updates a service record.
 //
 //nolint:gocritic // hugeParam: signature matches CmdbStore interface.
-func (s *Store) UpsertService(ctx context.Context, in api.ServiceCreate) (api.Service, error) {
+func (s *Store) UpsertService(ctx context.Context, in api.ServiceCreate) (api.Service, api.UpsertOutcome, error) {
 	var out api.Service
 	if err := s.doJSON(ctx, http.MethodPost, "/v1/services", in, &out); err != nil {
-		return api.Service{}, fmt.Errorf("upsert service: %w", err)
+		return api.Service{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert service: %w", err)
 	}
-	return out, nil
+	return out, api.OutcomeBusinessChanged, nil
 }
 
 // DeleteServicesNotIn removes services not in the keepNames list for the given namespace.
@@ -248,12 +248,12 @@ func (s *Store) DeleteServicesNotIn(ctx context.Context, namespaceID uuid.UUID, 
 }
 
 // UpsertIngress creates or updates an ingress record.
-func (s *Store) UpsertIngress(ctx context.Context, in api.IngressCreate) (api.Ingress, error) {
+func (s *Store) UpsertIngress(ctx context.Context, in api.IngressCreate) (api.Ingress, api.UpsertOutcome, error) {
 	var out api.Ingress
 	if err := s.doJSON(ctx, http.MethodPost, "/v1/ingresses", in, &out); err != nil {
-		return api.Ingress{}, fmt.Errorf("upsert ingress: %w", err)
+		return api.Ingress{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert ingress: %w", err)
 	}
-	return out, nil
+	return out, api.OutcomeBusinessChanged, nil
 }
 
 // DeleteIngressesNotIn removes ingresses not in the keepNames list for the given namespace.
@@ -264,12 +264,12 @@ func (s *Store) DeleteIngressesNotIn(ctx context.Context, namespaceID uuid.UUID,
 // UpsertPersistentVolume creates or updates a persistent volume record.
 //
 //nolint:gocritic // hugeParam: signature matches CmdbStore interface.
-func (s *Store) UpsertPersistentVolume(ctx context.Context, in api.PersistentVolumeCreate) (api.PersistentVolume, error) {
+func (s *Store) UpsertPersistentVolume(ctx context.Context, in api.PersistentVolumeCreate) (api.PersistentVolume, api.UpsertOutcome, error) {
 	var out api.PersistentVolume
 	if err := s.doJSON(ctx, http.MethodPost, "/v1/persistentvolumes", in, &out); err != nil {
-		return api.PersistentVolume{}, fmt.Errorf("upsert persistent volume: %w", err)
+		return api.PersistentVolume{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert persistent volume: %w", err)
 	}
-	return out, nil
+	return out, api.OutcomeBusinessChanged, nil
 }
 
 // DeletePersistentVolumesNotIn removes PVs not in the keepNames list for the given cluster.
@@ -280,12 +280,12 @@ func (s *Store) DeletePersistentVolumesNotIn(ctx context.Context, clusterID uuid
 // UpsertPersistentVolumeClaim creates or updates a PVC record.
 //
 //nolint:gocritic // hugeParam: signature matches CmdbStore interface.
-func (s *Store) UpsertPersistentVolumeClaim(ctx context.Context, in api.PersistentVolumeClaimCreate) (api.PersistentVolumeClaim, error) {
+func (s *Store) UpsertPersistentVolumeClaim(ctx context.Context, in api.PersistentVolumeClaimCreate) (api.PersistentVolumeClaim, api.UpsertOutcome, error) {
 	var out api.PersistentVolumeClaim
 	if err := s.doJSON(ctx, http.MethodPost, "/v1/persistentvolumeclaims", in, &out); err != nil {
-		return api.PersistentVolumeClaim{}, fmt.Errorf("upsert persistent volume claim: %w", err)
+		return api.PersistentVolumeClaim{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert persistent volume claim: %w", err)
 	}
-	return out, nil
+	return out, api.OutcomeBusinessChanged, nil
 }
 
 // DeletePersistentVolumeClaimsNotIn removes PVCs not in the keepNames list for the given namespace.

--- a/internal/collector/apiclient/client.go
+++ b/internal/collector/apiclient/client.go
@@ -280,7 +280,10 @@ func (s *Store) DeletePersistentVolumesNotIn(ctx context.Context, clusterID uuid
 // UpsertPersistentVolumeClaim creates or updates a PVC record.
 //
 //nolint:gocritic // hugeParam: signature matches CmdbStore interface.
-func (s *Store) UpsertPersistentVolumeClaim(ctx context.Context, in api.PersistentVolumeClaimCreate) (api.PersistentVolumeClaim, api.UpsertOutcome, error) {
+func (s *Store) UpsertPersistentVolumeClaim(
+	ctx context.Context,
+	in api.PersistentVolumeClaimCreate,
+) (api.PersistentVolumeClaim, api.UpsertOutcome, error) {
 	var out api.PersistentVolumeClaim
 	if err := s.doJSON(ctx, http.MethodPost, "/v1/persistentvolumeclaims", in, &out); err != nil {
 		return api.PersistentVolumeClaim{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert persistent volume claim: %w", err)

--- a/internal/collector/apiclient/client_test.go
+++ b/internal/collector/apiclient/client_test.go
@@ -186,7 +186,7 @@ func TestUpsertNodeMethod(t *testing.T) {
 
 	s := newTestStore(t, srv, nil)
 	clusterID := uuid.New()
-	node, err := s.UpsertNode(context.Background(), api.NodeCreate{
+	node, _, err := s.UpsertNode(context.Background(), api.NodeCreate{
 		ClusterId: clusterID,
 		Name:      "node-1",
 	})
@@ -322,7 +322,7 @@ func TestNoRetryOn403(t *testing.T) {
 	defer srv.Close()
 
 	s := newTestStore(t, srv, nil)
-	_, err := s.UpsertNode(context.Background(), api.NodeCreate{Name: "x"})
+	_, _, err := s.UpsertNode(context.Background(), api.NodeCreate{Name: "x"})
 	if err == nil {
 		t.Fatal("expected error on 403")
 	}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -254,21 +254,21 @@ type KubeSource interface {
 type CmdbStore interface {
 	EnsureCluster(ctx context.Context, in api.ClusterCreate) (cluster api.Cluster, created bool, err error)
 	UpdateCluster(ctx context.Context, id uuid.UUID, in api.ClusterUpdate) (api.Cluster, error)
-	UpsertNode(ctx context.Context, in api.NodeCreate) (api.Node, error)
+	UpsertNode(ctx context.Context, in api.NodeCreate) (api.Node, api.UpsertOutcome, error)
 	DeleteNodesNotIn(ctx context.Context, clusterID uuid.UUID, keepNames []string) (int64, error)
-	UpsertNamespace(ctx context.Context, in api.NamespaceCreate) (api.Namespace, error)
+	UpsertNamespace(ctx context.Context, in api.NamespaceCreate) (api.Namespace, api.UpsertOutcome, error)
 	DeleteNamespacesNotIn(ctx context.Context, clusterID uuid.UUID, keepNames []string) (int64, error)
-	UpsertPod(ctx context.Context, in api.PodCreate) (api.Pod, error)
+	UpsertPod(ctx context.Context, in api.PodCreate) (api.Pod, api.UpsertOutcome, error)
 	DeletePodsNotIn(ctx context.Context, namespaceID uuid.UUID, keepNames []string) (int64, error)
-	UpsertWorkload(ctx context.Context, in api.WorkloadCreate) (api.Workload, error)
+	UpsertWorkload(ctx context.Context, in api.WorkloadCreate) (api.Workload, api.UpsertOutcome, error)
 	DeleteWorkloadsNotIn(ctx context.Context, namespaceID uuid.UUID, keepKinds, keepNames []string) (int64, error)
-	UpsertService(ctx context.Context, in api.ServiceCreate) (api.Service, error)
+	UpsertService(ctx context.Context, in api.ServiceCreate) (api.Service, api.UpsertOutcome, error)
 	DeleteServicesNotIn(ctx context.Context, namespaceID uuid.UUID, keepNames []string) (int64, error)
-	UpsertIngress(ctx context.Context, in api.IngressCreate) (api.Ingress, error)
+	UpsertIngress(ctx context.Context, in api.IngressCreate) (api.Ingress, api.UpsertOutcome, error)
 	DeleteIngressesNotIn(ctx context.Context, namespaceID uuid.UUID, keepNames []string) (int64, error)
-	UpsertPersistentVolume(ctx context.Context, in api.PersistentVolumeCreate) (api.PersistentVolume, error)
+	UpsertPersistentVolume(ctx context.Context, in api.PersistentVolumeCreate) (api.PersistentVolume, api.UpsertOutcome, error)
 	DeletePersistentVolumesNotIn(ctx context.Context, clusterID uuid.UUID, keepNames []string) (int64, error)
-	UpsertPersistentVolumeClaim(ctx context.Context, in api.PersistentVolumeClaimCreate) (api.PersistentVolumeClaim, error)
+	UpsertPersistentVolumeClaim(ctx context.Context, in api.PersistentVolumeClaimCreate) (api.PersistentVolumeClaim, api.UpsertOutcome, error)
 	DeletePersistentVolumeClaimsNotIn(ctx context.Context, namespaceID uuid.UUID, keepNames []string) (int64, error)
 }
 
@@ -440,7 +440,7 @@ func (c *Collector) ingestNodes(ctx context.Context, clusterID uuid.UUID) {
 			labels := n.Labels
 			in.Labels = &labels
 		}
-		if _, err := c.store.UpsertNode(ctx, in); err != nil {
+		if _, _, err := c.store.UpsertNode(ctx, in); err != nil {
 			metrics.ObserveError(c.clusterName, "nodes", "upsert")
 			slog.Warn("collector: upsert node failed",
 				slog.Any("error", err), slog.String("node", n.Name), slog.String("cluster_name", c.clusterName))
@@ -495,7 +495,7 @@ func (c *Collector) ingestNamespaces(ctx context.Context, clusterID uuid.UUID) m
 			labels := ns.Labels
 			in.Labels = &labels
 		}
-		stored, err := c.store.UpsertNamespace(ctx, in)
+		stored, _, err := c.store.UpsertNamespace(ctx, in)
 		if err != nil {
 			metrics.ObserveError(c.clusterName, "namespaces", "upsert")
 			slog.Warn("collector: upsert namespace failed",
@@ -622,7 +622,7 @@ func (c *Collector) ingestPods(ctx context.Context, namespaceIDsByName map[strin
 			continue
 		}
 		in := buildPodCreate(p, nsID, workloadIDs, rsOwners)
-		if _, err := c.store.UpsertPod(ctx, in); err != nil {
+		if _, _, err := c.store.UpsertPod(ctx, in); err != nil {
 			metrics.ObserveError(c.clusterName, "pods", "upsert")
 			slog.Warn("collector: upsert pod failed",
 				slog.Any("error", err), slog.String("pod", p.Name), slog.String("namespace", p.Namespace), slog.String("cluster_name", c.clusterName))
@@ -691,7 +691,7 @@ func (c *Collector) ingestWorkloads(ctx context.Context, namespaceIDsByName map[
 			labels := w.Labels
 			in.Labels = &labels
 		}
-		stored, err := c.store.UpsertWorkload(ctx, in)
+		stored, _, err := c.store.UpsertWorkload(ctx, in)
 		if err != nil {
 			metrics.ObserveError(c.clusterName, "workloads", "upsert")
 			slog.Warn("collector: upsert workload failed",
@@ -748,7 +748,7 @@ func (c *Collector) ingestServices(ctx context.Context, namespaceIDsByName map[s
 			continue
 		}
 		in := buildServiceCreate(s, nsID)
-		if _, err := c.store.UpsertService(ctx, in); err != nil {
+		if _, _, err := c.store.UpsertService(ctx, in); err != nil {
 			metrics.ObserveError(c.clusterName, "services", "upsert")
 			slog.Warn("collector: upsert service failed",
 				slog.Any("error", err), slog.String("service", s.Name),
@@ -796,7 +796,7 @@ func (c *Collector) ingestIngresses(ctx context.Context, namespaceIDsByName map[
 			continue
 		}
 		in := buildIngressCreate(ing, nsID)
-		if _, err := c.store.UpsertIngress(ctx, in); err != nil {
+		if _, _, err := c.store.UpsertIngress(ctx, in); err != nil {
 			metrics.ObserveError(c.clusterName, "ingresses", "upsert")
 			slog.Warn("collector: upsert ingress failed",
 				slog.Any("error", err), slog.String("ingress", ing.Name),
@@ -1031,7 +1031,7 @@ func (c *Collector) ingestPersistentVolumes(ctx context.Context, clusterID uuid.
 			labels := pv.Labels
 			in.Labels = &labels
 		}
-		stored, err := c.store.UpsertPersistentVolume(ctx, in)
+		stored, _, err := c.store.UpsertPersistentVolume(ctx, in)
 		if err != nil {
 			metrics.ObserveError(c.clusterName, "persistentvolumes", "upsert")
 			slog.Warn("collector: upsert persistent volume failed",
@@ -1091,7 +1091,7 @@ func (c *Collector) ingestPersistentVolumeClaims(ctx context.Context, namespaceI
 			continue
 		}
 		in := buildPVCCreate(pvc, nsID, pvIDsByName)
-		if _, err := c.store.UpsertPersistentVolumeClaim(ctx, in); err != nil {
+		if _, _, err := c.store.UpsertPersistentVolumeClaim(ctx, in); err != nil {
 			metrics.ObserveError(c.clusterName, "persistentvolumeclaims", "upsert")
 			slog.Warn("collector: upsert pvc failed",
 				slog.Any("error", err), slog.String("pvc", pvc.Name),

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -203,11 +203,11 @@ func (s *fakeStore) UpdateCluster(_ context.Context, id uuid.UUID, in api.Cluste
 }
 
 //nolint:gocritic // hugeParam: signature matches CmdbStore interface
-func (s *fakeStore) UpsertNode(_ context.Context, in api.NodeCreate) (api.Node, error) {
+func (s *fakeStore) UpsertNode(_ context.Context, in api.NodeCreate) (api.Node, api.UpsertOutcome, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.upsertErr != nil {
-		return api.Node{}, s.upsertErr
+		return api.Node{}, api.OutcomeBusinessChanged, s.upsertErr
 	}
 	s.upsertedNode = append(s.upsertedNode, in)
 	key := in.ClusterId.String() + "/" + in.Name
@@ -218,7 +218,7 @@ func (s *fakeStore) UpsertNode(_ context.Context, in api.NodeCreate) (api.Node, 
 		ClusterId:      in.ClusterId,
 		Name:           in.Name,
 		KubeletVersion: in.KubeletVersion,
-	}, nil
+	}, api.OutcomeBusinessChanged, nil
 }
 
 func (s *fakeStore) DeleteNodesNotIn(_ context.Context, clusterID uuid.UUID, keepNames []string) (int64, error) {
@@ -273,11 +273,11 @@ func (s *fakeStore) DeleteNamespacesNotIn(_ context.Context, clusterID uuid.UUID
 }
 
 //nolint:gocritic // hugeParam: signature matches CmdbStore interface
-func (s *fakeStore) UpsertNamespace(_ context.Context, in api.NamespaceCreate) (api.Namespace, error) {
+func (s *fakeStore) UpsertNamespace(_ context.Context, in api.NamespaceCreate) (api.Namespace, api.UpsertOutcome, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.upsertNSErr != nil {
-		return api.Namespace{}, s.upsertNSErr
+		return api.Namespace{}, api.OutcomeBusinessChanged, s.upsertNSErr
 	}
 	s.upsertedNS = append(s.upsertedNS, in)
 	key := in.ClusterId.String() + "/" + in.Name
@@ -291,15 +291,15 @@ func (s *fakeStore) UpsertNamespace(_ context.Context, in api.NamespaceCreate) (
 		ClusterId: in.ClusterId,
 		Name:      in.Name,
 		Phase:     in.Phase,
-	}, nil
+	}, api.OutcomeBusinessChanged, nil
 }
 
 //nolint:gocritic // hugeParam: signature matches CmdbStore interface
-func (s *fakeStore) UpsertPod(_ context.Context, in api.PodCreate) (api.Pod, error) {
+func (s *fakeStore) UpsertPod(_ context.Context, in api.PodCreate) (api.Pod, api.UpsertOutcome, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.upsertPodErr != nil {
-		return api.Pod{}, s.upsertPodErr
+		return api.Pod{}, api.OutcomeBusinessChanged, s.upsertPodErr
 	}
 	s.upsertedPod = append(s.upsertedPod, in)
 	key := in.NamespaceId.String() + "/" + in.Name
@@ -310,7 +310,7 @@ func (s *fakeStore) UpsertPod(_ context.Context, in api.PodCreate) (api.Pod, err
 		NamespaceId: in.NamespaceId,
 		Name:        in.Name,
 		Phase:       in.Phase,
-	}, nil
+	}, api.OutcomeBusinessChanged, nil
 }
 
 func (s *fakeStore) DeletePodsNotIn(_ context.Context, namespaceID uuid.UUID, keepNames []string) (int64, error) {
@@ -339,11 +339,11 @@ func (s *fakeStore) DeletePodsNotIn(_ context.Context, namespaceID uuid.UUID, ke
 }
 
 //nolint:gocritic // hugeParam: signature matches CmdbStore interface
-func (s *fakeStore) UpsertService(_ context.Context, in api.ServiceCreate) (api.Service, error) {
+func (s *fakeStore) UpsertService(_ context.Context, in api.ServiceCreate) (api.Service, api.UpsertOutcome, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.upsertServiceErr != nil {
-		return api.Service{}, s.upsertServiceErr
+		return api.Service{}, api.OutcomeBusinessChanged, s.upsertServiceErr
 	}
 	s.upsertedService = append(s.upsertedService, in)
 	key := in.NamespaceId.String() + "/" + in.Name
@@ -354,14 +354,14 @@ func (s *fakeStore) UpsertService(_ context.Context, in api.ServiceCreate) (api.
 		NamespaceId: in.NamespaceId,
 		Name:        in.Name,
 		Type:        in.Type,
-	}, nil
+	}, api.OutcomeBusinessChanged, nil
 }
 
-func (s *fakeStore) UpsertIngress(_ context.Context, in api.IngressCreate) (api.Ingress, error) {
+func (s *fakeStore) UpsertIngress(_ context.Context, in api.IngressCreate) (api.Ingress, api.UpsertOutcome, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.upsertIngressErr != nil {
-		return api.Ingress{}, s.upsertIngressErr
+		return api.Ingress{}, api.OutcomeBusinessChanged, s.upsertIngressErr
 	}
 	s.upsertedIngress = append(s.upsertedIngress, in)
 	key := in.NamespaceId.String() + "/" + in.Name
@@ -371,7 +371,7 @@ func (s *fakeStore) UpsertIngress(_ context.Context, in api.IngressCreate) (api.
 		Id:          &id,
 		NamespaceId: in.NamespaceId,
 		Name:        in.Name,
-	}, nil
+	}, api.OutcomeBusinessChanged, nil
 }
 
 func (s *fakeStore) DeleteIngressesNotIn(_ context.Context, namespaceID uuid.UUID, keepNames []string) (int64, error) {
@@ -425,11 +425,11 @@ func (s *fakeStore) DeleteServicesNotIn(_ context.Context, namespaceID uuid.UUID
 }
 
 //nolint:gocritic // hugeParam: signature matches CmdbStore interface
-func (s *fakeStore) UpsertWorkload(_ context.Context, in api.WorkloadCreate) (api.Workload, error) {
+func (s *fakeStore) UpsertWorkload(_ context.Context, in api.WorkloadCreate) (api.Workload, api.UpsertOutcome, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.upsertWorkloadErr != nil {
-		return api.Workload{}, s.upsertWorkloadErr
+		return api.Workload{}, api.OutcomeBusinessChanged, s.upsertWorkloadErr
 	}
 	s.upsertedWorkload = append(s.upsertedWorkload, in)
 	key := in.NamespaceId.String() + "/" + string(in.Kind) + "/" + in.Name
@@ -440,7 +440,7 @@ func (s *fakeStore) UpsertWorkload(_ context.Context, in api.WorkloadCreate) (ap
 		NamespaceId: in.NamespaceId,
 		Kind:        in.Kind,
 		Name:        in.Name,
-	}, nil
+	}, api.OutcomeBusinessChanged, nil
 }
 
 func (s *fakeStore) DeleteWorkloadsNotIn(_ context.Context, namespaceID uuid.UUID, keepKinds, keepNames []string) (int64, error) {
@@ -474,11 +474,11 @@ func (s *fakeStore) DeleteWorkloadsNotIn(_ context.Context, namespaceID uuid.UUI
 }
 
 //nolint:gocritic // hugeParam: signature matches CmdbStore interface
-func (s *fakeStore) UpsertPersistentVolume(_ context.Context, in api.PersistentVolumeCreate) (api.PersistentVolume, error) {
+func (s *fakeStore) UpsertPersistentVolume(_ context.Context, in api.PersistentVolumeCreate) (api.PersistentVolume, api.UpsertOutcome, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.upsertPVErr != nil {
-		return api.PersistentVolume{}, s.upsertPVErr
+		return api.PersistentVolume{}, api.OutcomeBusinessChanged, s.upsertPVErr
 	}
 	s.upsertedPV = append(s.upsertedPV, in)
 	key := in.ClusterId.String() + "/" + in.Name
@@ -491,7 +491,7 @@ func (s *fakeStore) UpsertPersistentVolume(_ context.Context, in api.PersistentV
 		Id:        &id,
 		ClusterId: in.ClusterId,
 		Name:      in.Name,
-	}, nil
+	}, api.OutcomeBusinessChanged, nil
 }
 
 func (s *fakeStore) DeletePersistentVolumesNotIn(_ context.Context, clusterID uuid.UUID, keepNames []string) (int64, error) {
@@ -520,11 +520,11 @@ func (s *fakeStore) DeletePersistentVolumesNotIn(_ context.Context, clusterID uu
 }
 
 //nolint:gocritic // hugeParam: signature matches CmdbStore interface
-func (s *fakeStore) UpsertPersistentVolumeClaim(_ context.Context, in api.PersistentVolumeClaimCreate) (api.PersistentVolumeClaim, error) {
+func (s *fakeStore) UpsertPersistentVolumeClaim(_ context.Context, in api.PersistentVolumeClaimCreate) (api.PersistentVolumeClaim, api.UpsertOutcome, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.upsertPVCErr != nil {
-		return api.PersistentVolumeClaim{}, s.upsertPVCErr
+		return api.PersistentVolumeClaim{}, api.OutcomeBusinessChanged, s.upsertPVCErr
 	}
 	s.upsertedPVC = append(s.upsertedPVC, in)
 	key := in.NamespaceId.String() + "/" + in.Name
@@ -535,7 +535,7 @@ func (s *fakeStore) UpsertPersistentVolumeClaim(_ context.Context, in api.Persis
 		NamespaceId:   in.NamespaceId,
 		Name:          in.Name,
 		BoundVolumeId: in.BoundVolumeId,
-	}, nil
+	}, api.OutcomeBusinessChanged, nil
 }
 
 func (s *fakeStore) DeletePersistentVolumeClaimsNotIn(_ context.Context, namespaceID uuid.UUID, keepNames []string) (int64, error) {

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -519,8 +519,12 @@ func (s *fakeStore) DeletePersistentVolumesNotIn(_ context.Context, clusterID uu
 	return deleted, nil
 }
 
+//
 //nolint:gocritic // hugeParam: signature matches CmdbStore interface
-func (s *fakeStore) UpsertPersistentVolumeClaim(_ context.Context, in api.PersistentVolumeClaimCreate) (api.PersistentVolumeClaim, api.UpsertOutcome, error) {
+func (s *fakeStore) UpsertPersistentVolumeClaim(
+	_ context.Context,
+	in api.PersistentVolumeClaimCreate,
+) (api.PersistentVolumeClaim, api.UpsertOutcome, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.upsertPVCErr != nil {

--- a/internal/integration/audit_noop_test.go
+++ b/internal/integration/audit_noop_test.go
@@ -1,0 +1,72 @@
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/sthalbert/longue-vue/internal/api"
+	"github.com/sthalbert/longue-vue/internal/metrics"
+)
+
+// TestAuditNoOp_IdempotentUpsertsProduceOneAuditRow proves the end-to-end
+// SecNumCloud-aligned no-op filter from ADR-0024: three identical POST
+// /v1/pods calls collapse into exactly one audit row plus two skipped-
+// counter increments. Validates the full chain — handler → store
+// outcome detection → audit middleware bypass → metrics.
+func TestAuditNoOp_IdempotentUpsertsProduceOneAuditRow(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Seed: cluster + namespace (POSTs to /v1/clusters and /v1/namespaces
+	// each fire one audit row of their own — irrelevant; we filter on
+	// pod-only events below).
+	var cluster api.Cluster
+	if s := env.doJSON(t, http.MethodPost, "/v1/clusters", `{"name":"audit-noop-cluster"}`, &cluster); s != http.StatusCreated {
+		t.Fatalf("seed cluster: %d", s)
+	}
+	clusterID := cluster.Id.String()
+
+	var ns api.Namespace
+	nsBody := fmt.Sprintf(`{"cluster_id":%q,"name":"apps"}`, clusterID)
+	if s := env.doJSON(t, http.MethodPost, "/v1/namespaces", nsBody, &ns); s != http.StatusCreated {
+		t.Fatalf("seed namespace: %d", s)
+	}
+	nsID := ns.Id.String()
+
+	// Snapshot the prom counter — testutil.ToFloat64 reads the live value
+	// of the labelset. PAT auth gives actor_kind=token (per audit.go).
+	before := testutil.ToFloat64(metrics.AuditEventsSkippedFor("token", "pod", "no_change"))
+
+	podBody := fmt.Sprintf(`{"namespace_id":%q,"name":"pod-noop","phase":"Running"}`, nsID)
+	for i := 0; i < 3; i++ {
+		resp := env.doReq(t, http.MethodPost, "/v1/pods", podBody)
+		if resp.StatusCode != http.StatusCreated {
+			_ = resp.Body.Close()
+			t.Fatalf("post %d: status=%d", i, resp.StatusCode)
+		}
+		_ = resp.Body.Close()
+	}
+
+	// Counter must have grown by exactly 2 (calls #2 and #3 skipped).
+	after := testutil.ToFloat64(metrics.AuditEventsSkippedFor("token", "pod", "no_change"))
+	if delta := after - before; delta != 2 {
+		t.Errorf("audit_events_skipped_total{...,pod,no_change} delta = %v; want 2", delta)
+	}
+
+	// And the table must have grown by exactly 1 POST /v1/pods row.
+	var auditList api.AuditEventList
+	if s := env.doJSON(t, http.MethodGet, "/v1/admin/audit", "", &auditList); s != http.StatusOK {
+		t.Fatalf("list audit: %d", s)
+	}
+	podPosts := 0
+	for _, evt := range auditList.Items {
+		if evt.HttpMethod == http.MethodPost && evt.HttpPath == "/v1/pods" {
+			podPosts++
+		}
+	}
+	if podPosts != 1 {
+		t.Errorf("audit rows for POST /v1/pods = %d; want 1 (first insert only)", podPosts)
+	}
+}

--- a/internal/integration/audit_noop_test.go
+++ b/internal/integration/audit_noop_test.go
@@ -16,6 +16,8 @@ import (
 // /v1/pods calls collapse into exactly one audit row plus two skipped-
 // counter increments. Validates the full chain — handler → store
 // outcome detection → audit middleware bypass → metrics.
+//
+//nolint:gocyclo // sequential seed + replay + counter + audit-list checks
 func TestAuditNoOp_IdempotentUpsertsProduceOneAuditRow(t *testing.T) {
 	env := newTestEnv(t)
 
@@ -40,7 +42,7 @@ func TestAuditNoOp_IdempotentUpsertsProduceOneAuditRow(t *testing.T) {
 	before := testutil.ToFloat64(metrics.AuditEventsSkippedFor("token", "pod", "no_change"))
 
 	podBody := fmt.Sprintf(`{"namespace_id":%q,"name":"pod-noop","phase":"Running"}`, nsID)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		resp := env.doReq(t, http.MethodPost, "/v1/pods", podBody)
 		if resp.StatusCode != http.StatusCreated {
 			_ = resp.Body.Close()

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -903,12 +903,12 @@ type notifyingStore struct {
 }
 
 //nolint:gocritic // signature is fixed by the collector.CmdbStore interface
-func (s *notifyingStore) UpsertPersistentVolumeClaim(ctx context.Context, in api.PersistentVolumeClaimCreate) (api.PersistentVolumeClaim, error) {
-	pvc, err := s.CmdbStore.UpsertPersistentVolumeClaim(ctx, in)
+func (s *notifyingStore) UpsertPersistentVolumeClaim(ctx context.Context, in api.PersistentVolumeClaimCreate) (api.PersistentVolumeClaim, api.UpsertOutcome, error) {
+	pvc, outcome, err := s.CmdbStore.UpsertPersistentVolumeClaim(ctx, in)
 	if err == nil {
 		s.once.Do(func() { close(s.tickDone) })
 	}
-	return pvc, err //nolint:wrapcheck // pass through interface error verbatim
+	return pvc, outcome, err //nolint:wrapcheck // pass through interface error verbatim
 }
 
 func runCollectorOnce(

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -121,7 +121,7 @@ func newTestEnv(t *testing.T) *testEnv {
 	// regardless of prior test runs or existing OrbStack data.
 	truncate := func() {
 		_, _ = rawPool.Exec(context.Background(),
-			"TRUNCATE clusters, api_tokens, sessions, user_identities, oidc_auth_states, audit_events, users CASCADE")
+			"TRUNCATE clusters, cloud_accounts, api_tokens, sessions, user_identities, oidc_auth_states, audit_events, users CASCADE")
 	}
 	truncate()
 	t.Cleanup(func() {
@@ -185,9 +185,12 @@ func newTestEnv(t *testing.T) *testEnv {
 	)
 	api.HandlerWithOptions(strict, api.StdHTTPServerOptions{
 		BaseRouter: mux,
+		// Order mirrors cmd/longue-vue/main.go: oapi-codegen applies these
+		// in list order so the last entry (Auth) is outermost and runs
+		// first, resolving the Caller before Audit reads it.
 		Middlewares: []api.MiddlewareFunc{
-			api.AuthMiddleware(pg, auth.SecureNever, nil),
 			api.AuditMiddleware(pg, "api", nil),
+			api.AuthMiddleware(pg, auth.SecureNever, nil),
 		},
 	})
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -902,8 +902,12 @@ type notifyingStore struct {
 	tickDone chan struct{}
 }
 
+//
 //nolint:gocritic // signature is fixed by the collector.CmdbStore interface
-func (s *notifyingStore) UpsertPersistentVolumeClaim(ctx context.Context, in api.PersistentVolumeClaimCreate) (api.PersistentVolumeClaim, api.UpsertOutcome, error) {
+func (s *notifyingStore) UpsertPersistentVolumeClaim(
+	ctx context.Context,
+	in api.PersistentVolumeClaimCreate,
+) (api.PersistentVolumeClaim, api.UpsertOutcome, error) {
 	pvc, outcome, err := s.CmdbStore.UpsertPersistentVolumeClaim(ctx, in)
 	if err == nil {
 		s.once.Do(func() { close(s.tickDone) })

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -172,6 +172,15 @@ var (
 		Name:      "client_cert_failures_total",
 		Help:      "Failed mTLS client-cert validations on the ingest listener, per reason (bad_ca / expired / cn_not_allowed / none_provided).",
 	}, []string{"reason"})
+
+	auditEventsSkipped = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "longue_vue",
+		Subsystem: "audit",
+		Name:      "events_skipped_total",
+		Help: "audit_events INSERTs suppressed by the no-op filter, labelled " +
+			"by actor kind, resource type, and reason " +
+			"(no_change|reconcile_empty). See ADR-0024.",
+	}, []string{"actor_kind", "resource_type", "reason"})
 )
 
 func init() {
@@ -199,6 +208,7 @@ func init() {
 		ingestVerifyTotal,
 		ingestListenerClientCertFailures,
 		timeTravelWritesTotal,
+		auditEventsSkipped,
 	)
 }
 
@@ -327,6 +337,19 @@ func ObserveMCPToolCall(tool string, duration time.Duration) {
 // the upserts reflect live state, which is what the freshness signal tracks.
 func MarkPoll(cluster, resource string) {
 	collectorLastPoll.WithLabelValues(cluster, resource).Set(float64(time.Now().Unix()))
+}
+
+// ObserveAuditSkipped increments the audit-skipped counter. actor_kind is
+// "user" | "token" | "anonymous"; resource_type is the singular resource
+// label (e.g., "pod"); reason is "no_change" or "reconcile_empty".
+func ObserveAuditSkipped(actorKind, resourceType, reason string) {
+	auditEventsSkipped.WithLabelValues(actorKind, resourceType, reason).Inc()
+}
+
+// AuditEventsSkippedFor returns the per-labelset Counter for tests. Not
+// for production code paths — production should call ObserveAuditSkipped.
+func AuditEventsSkippedFor(actorKind, resourceType, reason string) prometheus.Counter {
+	return auditEventsSkipped.WithLabelValues(actorKind, resourceType, reason)
 }
 
 // InstrumentHandler wraps an http.Handler with request counting + duration

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -88,3 +88,15 @@ func TestHandlerExposesRegisteredMetrics(t *testing.T) {
 		}
 	}
 }
+
+func TestObserveAuditSkipped(t *testing.T) {
+	t.Parallel()
+	ObserveAuditSkipped("token", "pod", "no_change")
+	ObserveAuditSkipped("token", "pod", "no_change")
+	ObserveAuditSkipped("user", "user", "no_change")
+
+	got := testutil.ToFloat64(AuditEventsSkippedFor("token", "pod", "no_change"))
+	if got != 2 {
+		t.Errorf("token+pod+no_change counter = %v, want 2", got)
+	}
+}

--- a/internal/store/include_terminated_test.go
+++ b/internal/store/include_terminated_test.go
@@ -26,7 +26,7 @@ func TestListNodesIncludeTerminated(t *testing.T) {
 	}
 
 	// Create three nodes: two live and one to be soft-deleted.
-	node1, err := pg.UpsertNode(ctx, api.NodeCreate{
+	node1, _, err := pg.UpsertNode(ctx, api.NodeCreate{
 		ClusterId: *cluster.Id,
 		Name:      "live-1",
 	})
@@ -37,7 +37,7 @@ func TestListNodesIncludeTerminated(t *testing.T) {
 		t.Fatal("node1.Id is nil")
 	}
 
-	node2, err := pg.UpsertNode(ctx, api.NodeCreate{
+	node2, _, err := pg.UpsertNode(ctx, api.NodeCreate{
 		ClusterId: *cluster.Id,
 		Name:      "live-2",
 	})
@@ -48,7 +48,7 @@ func TestListNodesIncludeTerminated(t *testing.T) {
 		t.Fatal("node2.Id is nil")
 	}
 
-	node3, err := pg.UpsertNode(ctx, api.NodeCreate{
+	node3, _, err := pg.UpsertNode(ctx, api.NodeCreate{
 		ClusterId: *cluster.Id,
 		Name:      "soon-dead",
 	})
@@ -129,7 +129,7 @@ func TestListNamespacesIncludeTerminated(t *testing.T) {
 	}
 
 	// Create three namespaces: two live and one to be soft-deleted.
-	ns1, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
+	ns1, _, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
 		ClusterId: *cluster.Id,
 		Name:      "ns-live-1",
 	})
@@ -140,7 +140,7 @@ func TestListNamespacesIncludeTerminated(t *testing.T) {
 		t.Fatal("ns1.Id is nil")
 	}
 
-	ns2, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
+	ns2, _, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
 		ClusterId: *cluster.Id,
 		Name:      "ns-live-2",
 	})
@@ -151,7 +151,7 @@ func TestListNamespacesIncludeTerminated(t *testing.T) {
 		t.Fatal("ns2.Id is nil")
 	}
 
-	ns3, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
+	ns3, _, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
 		ClusterId: *cluster.Id,
 		Name:      "ns-soon-dead",
 	})

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -4450,27 +4450,51 @@ func (p *PG) UpsertPersistentVolumeClaim(ctx context.Context, in api.PersistentV
 
 	labelsJSON, err := marshalLabels(in.Labels)
 	if err != nil {
-		return api.PersistentVolumeClaim{}, api.OutcomeBusinessChanged, err
+		return api.PersistentVolumeClaim{}, api.OutcomeNoChange, err
 	}
 
+	// AUDIT_BUSINESS_FIELDS: phase, storage_class_name, volume_name,
+	// bound_volume_id, access_modes, requested_storage, labels.
+	// updated_at is a clock field — excluded.
 	const q = `
-		INSERT INTO persistent_volume_claims (
-			id, namespace_id, name, phase, storage_class_name,
-			volume_name, bound_volume_id, access_modes, requested_storage,
-			labels, created_at, updated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $11)
-		ON CONFLICT (namespace_id, name) DO UPDATE SET
-			phase              = EXCLUDED.phase,
-			storage_class_name = EXCLUDED.storage_class_name,
-			volume_name        = EXCLUDED.volume_name,
-			bound_volume_id    = EXCLUDED.bound_volume_id,
-			access_modes       = EXCLUDED.access_modes,
-			requested_storage  = EXCLUDED.requested_storage,
-			labels             = EXCLUDED.labels,
-			updated_at         = EXCLUDED.updated_at
-		RETURNING id, namespace_id, name, phase, storage_class_name,
-		          volume_name, bound_volume_id, access_modes, requested_storage,
-		          labels, created_at, updated_at
+		WITH old AS (
+		  SELECT phase, storage_class_name, volume_name, bound_volume_id,
+		         access_modes, requested_storage, labels
+		    FROM persistent_volume_claims WHERE namespace_id=$2 AND name=$3
+		),
+		upserted AS (
+		  INSERT INTO persistent_volume_claims (
+		    id, namespace_id, name, phase, storage_class_name,
+		    volume_name, bound_volume_id, access_modes, requested_storage,
+		    labels, created_at, updated_at
+		  ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $11)
+		  ON CONFLICT (namespace_id, name) DO UPDATE SET
+		      phase              = EXCLUDED.phase,
+		      storage_class_name = EXCLUDED.storage_class_name,
+		      volume_name        = EXCLUDED.volume_name,
+		      bound_volume_id    = EXCLUDED.bound_volume_id,
+		      access_modes       = EXCLUDED.access_modes,
+		      requested_storage  = EXCLUDED.requested_storage,
+		      labels             = EXCLUDED.labels,
+		      updated_at         = EXCLUDED.updated_at
+		  RETURNING id, namespace_id, name, phase, storage_class_name,
+		            volume_name, bound_volume_id, access_modes, requested_storage,
+		            labels, created_at, updated_at, xmax
+		)
+		SELECT id, namespace_id, name, phase, storage_class_name,
+		       volume_name, bound_volume_id, access_modes, requested_storage,
+		       labels, created_at, updated_at,
+		       (xmax = 0) AS inserted,
+		       (xmax <> 0 AND (
+		           o.phase              IS DISTINCT FROM upserted.phase              OR
+		           o.storage_class_name IS DISTINCT FROM upserted.storage_class_name OR
+		           o.volume_name        IS DISTINCT FROM upserted.volume_name        OR
+		           o.bound_volume_id    IS DISTINCT FROM upserted.bound_volume_id    OR
+		           o.access_modes       IS DISTINCT FROM upserted.access_modes       OR
+		           o.requested_storage  IS DISTINCT FROM upserted.requested_storage  OR
+		           o.labels             IS DISTINCT FROM upserted.labels
+		       )) AS business_changed
+		  FROM upserted LEFT JOIN old o ON true
 	`
 	row := p.pool.QueryRow(ctx, q,
 		id, in.NamespaceId, in.Name,
@@ -4479,14 +4503,15 @@ func (p *PG) UpsertPersistentVolumeClaim(ctx context.Context, in api.PersistentV
 		accessModesValue(in.AccessModes), in.RequestedStorage,
 		labelsJSON, now,
 	)
-	pvc, err := scanPersistentVolumeClaim(row)
+	var inserted, businessChanged bool
+	pvc, err := scanPersistentVolumeClaim(scanRowWith{row: row, extra: []any{&inserted, &businessChanged}})
 	if err != nil {
 		if pErr := classifyPVCFKError(err, in.NamespaceId, in.BoundVolumeId); pErr != nil {
-			return api.PersistentVolumeClaim{}, api.OutcomeBusinessChanged, pErr
+			return api.PersistentVolumeClaim{}, api.OutcomeNoChange, pErr
 		}
-		return api.PersistentVolumeClaim{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert pvc: %w", err)
+		return api.PersistentVolumeClaim{}, api.OutcomeNoChange, fmt.Errorf("upsert pvc: %w", err)
 	}
-	return pvc, api.OutcomeBusinessChanged, nil
+	return pvc, classifyOutcome(inserted, businessChanged), nil
 }
 
 // DeletePersistentVolumeClaimsNotIn removes namespace-scoped PVCs whose name

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -91,6 +91,20 @@ func (p *PG) Migrate(ctx context.Context) error {
 	return nil
 }
 
+// classifyOutcome maps the CTE's (inserted, business_changed) tuple to the
+// corresponding api.UpsertOutcome — used by every Upsert* impl that computes
+// audit-noop detection. See ADR-0024.
+func classifyOutcome(inserted, businessChanged bool) api.UpsertOutcome {
+	switch {
+	case inserted:
+		return api.OutcomeInserted
+	case businessChanged:
+		return api.OutcomeBusinessChanged
+	default:
+		return api.OutcomeNoChange
+	}
+}
+
 // EnsureCluster inserts a cluster row when no row with the same name exists,
 // or returns the existing row unchanged when one does. The returned bool is
 // true when a new row was inserted, false when an existing row was returned.
@@ -1677,41 +1691,108 @@ func (p *PG) UpsertPod(ctx context.Context, in api.PodCreate) (api.Pod, api.Upse
 
 	labelsJSON, err := marshalLabels(in.Labels)
 	if err != nil {
-		return api.Pod{}, api.OutcomeBusinessChanged, err
+		return api.Pod{}, api.OutcomeNoChange, err
 	}
 	containersJSON, err := marshalPorts(in.Containers)
 	if err != nil {
-		return api.Pod{}, api.OutcomeBusinessChanged, err
+		return api.Pod{}, api.OutcomeNoChange, err
 	}
 
+	// AUDIT_BUSINESS_FIELDS: phase, node_name, pod_ip, workload_id,
+	// containers, labels. updated_at is a clock field — excluded from
+	// business_changed detection so reconcile-only ticks turn into NoChange.
 	const q = `
-		INSERT INTO pods (
-			id, namespace_id, name, phase, node_name, pod_ip,
-			workload_id, containers, labels, created_at, updated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $10)
-		ON CONFLICT (namespace_id, name) DO UPDATE SET
-			phase       = EXCLUDED.phase,
-			node_name   = EXCLUDED.node_name,
-			pod_ip      = EXCLUDED.pod_ip,
-			workload_id = EXCLUDED.workload_id,
-			containers  = EXCLUDED.containers,
-			labels      = EXCLUDED.labels,
-			updated_at  = EXCLUDED.updated_at
-		RETURNING id, namespace_id, name, phase, node_name, pod_ip,
-		          workload_id, containers, labels, created_at, updated_at
+		WITH old AS (
+		  SELECT phase, node_name, pod_ip, workload_id, containers, labels
+		    FROM pods WHERE namespace_id = $2 AND name = $3
+		),
+		upserted AS (
+		  INSERT INTO pods (
+		      id, namespace_id, name, phase, node_name, pod_ip,
+		      workload_id, containers, labels, created_at, updated_at
+		  ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $10)
+		  ON CONFLICT (namespace_id, name) DO UPDATE SET
+		      phase       = EXCLUDED.phase,
+		      node_name   = EXCLUDED.node_name,
+		      pod_ip      = EXCLUDED.pod_ip,
+		      workload_id = EXCLUDED.workload_id,
+		      containers  = EXCLUDED.containers,
+		      labels      = EXCLUDED.labels,
+		      updated_at  = EXCLUDED.updated_at
+		  RETURNING id, namespace_id, name, phase, node_name, pod_ip,
+		            workload_id, containers, labels, created_at, updated_at,
+		            xmax
+		)
+		SELECT u.id, u.namespace_id, u.name, u.phase, u.node_name, u.pod_ip,
+		       u.workload_id, u.containers, u.labels, u.created_at, u.updated_at,
+		       (u.xmax = 0) AS inserted,
+		       (u.xmax <> 0 AND (
+		           o.phase       IS DISTINCT FROM u.phase       OR
+		           o.node_name   IS DISTINCT FROM u.node_name   OR
+		           o.pod_ip      IS DISTINCT FROM u.pod_ip      OR
+		           o.workload_id IS DISTINCT FROM u.workload_id OR
+		           o.containers  IS DISTINCT FROM u.containers  OR
+		           o.labels      IS DISTINCT FROM u.labels
+		       )) AS business_changed
+		  FROM upserted u LEFT JOIN old o ON true
 	`
 	row := p.pool.QueryRow(ctx, q,
 		id, in.NamespaceId, in.Name, in.Phase, in.NodeName, in.PodIp,
 		in.WorkloadId, containersJSON, labelsJSON, now,
 	)
-	pod, err := scanPod(row)
-	if err != nil {
+
+	var (
+		pod             api.Pod
+		podID           uuid.UUID
+		namespaceID     uuid.UUID
+		createdAt       time.Time
+		updatedAt       time.Time
+		phase           sql.NullString
+		nodeName        sql.NullString
+		podIP           sql.NullString
+		workloadID      *uuid.UUID
+		containersOut   []byte
+		labelsOut       []byte
+		inserted        bool
+		businessChanged bool
+	)
+	if err := row.Scan(
+		&podID, &namespaceID, &pod.Name,
+		&phase, &nodeName, &podIP,
+		&workloadID, &containersOut, &labelsOut,
+		&createdAt, &updatedAt,
+		&inserted, &businessChanged,
+	); err != nil {
 		if pErr := classifyPodFKError(err, in.NamespaceId, in.WorkloadId); pErr != nil {
-			return api.Pod{}, api.OutcomeBusinessChanged, pErr
+			return api.Pod{}, api.OutcomeNoChange, pErr
 		}
-		return api.Pod{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert pod: %w", err)
+		return api.Pod{}, api.OutcomeNoChange, fmt.Errorf("upsert pod: %w", err)
 	}
-	return pod, api.OutcomeBusinessChanged, nil
+	pod.Id = &podID
+	pod.NamespaceId = namespaceID
+	pod.CreatedAt = &createdAt
+	pod.UpdatedAt = &updatedAt
+	pod.Phase = nullableString(phase)
+	pod.NodeName = nullableString(nodeName)
+	pod.PodIp = nullableString(podIP)
+	if workloadID != nil {
+		pod.WorkloadId = workloadID
+	}
+	if cs, err := unmarshalContainers(containersOut); err != nil {
+		return api.Pod{}, api.OutcomeNoChange, fmt.Errorf("unmarshal pod containers: %w", err)
+	} else if cs != nil {
+		pod.Containers = cs
+	}
+	if len(labelsOut) > 0 {
+		var labels map[string]string
+		if err := json.Unmarshal(labelsOut, &labels); err != nil {
+			return api.Pod{}, api.OutcomeNoChange, fmt.Errorf("unmarshal pod labels: %w", err)
+		}
+		if len(labels) > 0 {
+			pod.Labels = &labels
+		}
+	}
+	return pod, classifyOutcome(inserted, businessChanged), nil
 }
 
 // DeletePodsNotIn removes every pod in the given namespace whose name is not

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -105,6 +105,18 @@ func classifyOutcome(inserted, businessChanged bool) api.UpsertOutcome {
 	}
 }
 
+// scanRowWith wraps a pgx.Row so a scan* helper can be reused while the
+// caller threads extra destinations (e.g. the audit CTE's inserted /
+// business_changed bool tail) onto the same row.Scan call.
+type scanRowWith struct {
+	row   pgx.Row
+	extra []any
+}
+
+func (r scanRowWith) Scan(dest ...any) error {
+	return r.row.Scan(append(dest, r.extra...)...)
+}
+
 // EnsureCluster inserts a cluster row when no row with the same name exists,
 // or returns the existing row unchanged when one does. The returned bool is
 // true when a new row was inserted, false when an existing row was returned.
@@ -3393,61 +3405,117 @@ func (p *PG) UpsertNode(ctx context.Context, in api.NodeCreate) (api.Node, api.U
 
 	values, err := nodeInsertValues(&in, id, now)
 	if err != nil {
-		return api.Node{}, api.OutcomeBusinessChanged, err
+		return api.Node{}, api.OutcomeNoChange, err
 	}
 
 	tx, err := p.pool.Begin(ctx)
 	if err != nil {
-		return api.Node{}, api.OutcomeBusinessChanged, fmt.Errorf("begin upsert node: %w", err)
+		return api.Node{}, api.OutcomeNoChange, fmt.Errorf("begin upsert node: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
 	changeType := detectNodeUpsertChangeType(ctx, tx, in.ClusterId, in.Name)
 
+	// AUDIT_BUSINESS_FIELDS: display_name, role, kubelet_version, kube_proxy_version,
+	// container_runtime_version, os_image, operating_system, kernel_version, architecture,
+	// internal_ip, external_ip, pod_cidr, provider_id, instance_type, zone,
+	// capacity_cpu, capacity_memory, capacity_pods, capacity_ephemeral_storage,
+	// allocatable_cpu, allocatable_memory, allocatable_pods, allocatable_ephemeral_storage,
+	// conditions, taints, unschedulable, ready, labels, terminated_at (restore flips it).
+	// updated_at is a clock field — excluded. Curator-only fields
+	// (owner/criticality/notes/runbook_url/annotations/hardware_model) are not touched
+	// by the collector upsert and excluded from the OR-chain.
 	const q = `
-		INSERT INTO nodes (` + nodeColumns + `)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$38)
-		ON CONFLICT (cluster_id, name) DO UPDATE SET
-			display_name                  = EXCLUDED.display_name,
-			role                          = EXCLUDED.role,
-			kubelet_version               = EXCLUDED.kubelet_version,
-			kube_proxy_version            = EXCLUDED.kube_proxy_version,
-			container_runtime_version     = EXCLUDED.container_runtime_version,
-			os_image                      = EXCLUDED.os_image,
-			operating_system              = EXCLUDED.operating_system,
-			kernel_version                = EXCLUDED.kernel_version,
-			architecture                  = EXCLUDED.architecture,
-			internal_ip                   = EXCLUDED.internal_ip,
-			external_ip                   = EXCLUDED.external_ip,
-			pod_cidr                      = EXCLUDED.pod_cidr,
-			provider_id                   = EXCLUDED.provider_id,
-			instance_type                 = EXCLUDED.instance_type,
-			zone                          = EXCLUDED.zone,
-			capacity_cpu                  = EXCLUDED.capacity_cpu,
-			capacity_memory               = EXCLUDED.capacity_memory,
-			capacity_pods                 = EXCLUDED.capacity_pods,
-			capacity_ephemeral_storage    = EXCLUDED.capacity_ephemeral_storage,
-			allocatable_cpu               = EXCLUDED.allocatable_cpu,
-			allocatable_memory            = EXCLUDED.allocatable_memory,
-			allocatable_pods              = EXCLUDED.allocatable_pods,
-			allocatable_ephemeral_storage = EXCLUDED.allocatable_ephemeral_storage,
-			conditions                    = EXCLUDED.conditions,
-			taints                        = EXCLUDED.taints,
-			unschedulable                 = EXCLUDED.unschedulable,
-			ready                         = EXCLUDED.ready,
-			labels                        = EXCLUDED.labels,
-			terminated_at                 = NULL,
-			updated_at                    = EXCLUDED.updated_at
-		RETURNING ` + nodeColumns + `
+		WITH old AS (
+		  SELECT display_name, role, kubelet_version, kube_proxy_version,
+		         container_runtime_version, os_image, operating_system, kernel_version,
+		         architecture, internal_ip, external_ip, pod_cidr,
+		         provider_id, instance_type, zone,
+		         capacity_cpu, capacity_memory, capacity_pods, capacity_ephemeral_storage,
+		         allocatable_cpu, allocatable_memory, allocatable_pods, allocatable_ephemeral_storage,
+		         conditions, taints, unschedulable, ready, labels, terminated_at
+		    FROM nodes WHERE cluster_id=$2 AND name=$3
+		),
+		upserted AS (
+		  INSERT INTO nodes (` + nodeColumns + `)
+		    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$38)
+		  ON CONFLICT (cluster_id, name) DO UPDATE SET
+		      display_name                  = EXCLUDED.display_name,
+		      role                          = EXCLUDED.role,
+		      kubelet_version               = EXCLUDED.kubelet_version,
+		      kube_proxy_version            = EXCLUDED.kube_proxy_version,
+		      container_runtime_version     = EXCLUDED.container_runtime_version,
+		      os_image                      = EXCLUDED.os_image,
+		      operating_system              = EXCLUDED.operating_system,
+		      kernel_version                = EXCLUDED.kernel_version,
+		      architecture                  = EXCLUDED.architecture,
+		      internal_ip                   = EXCLUDED.internal_ip,
+		      external_ip                   = EXCLUDED.external_ip,
+		      pod_cidr                      = EXCLUDED.pod_cidr,
+		      provider_id                   = EXCLUDED.provider_id,
+		      instance_type                 = EXCLUDED.instance_type,
+		      zone                          = EXCLUDED.zone,
+		      capacity_cpu                  = EXCLUDED.capacity_cpu,
+		      capacity_memory               = EXCLUDED.capacity_memory,
+		      capacity_pods                 = EXCLUDED.capacity_pods,
+		      capacity_ephemeral_storage    = EXCLUDED.capacity_ephemeral_storage,
+		      allocatable_cpu               = EXCLUDED.allocatable_cpu,
+		      allocatable_memory            = EXCLUDED.allocatable_memory,
+		      allocatable_pods              = EXCLUDED.allocatable_pods,
+		      allocatable_ephemeral_storage = EXCLUDED.allocatable_ephemeral_storage,
+		      conditions                    = EXCLUDED.conditions,
+		      taints                        = EXCLUDED.taints,
+		      unschedulable                 = EXCLUDED.unschedulable,
+		      ready                         = EXCLUDED.ready,
+		      labels                        = EXCLUDED.labels,
+		      terminated_at                 = NULL,
+		      updated_at                    = EXCLUDED.updated_at
+		  RETURNING ` + nodeColumns + `, terminated_at, xmax
+		)
+		SELECT ` + nodeColumns + `,
+		       (xmax = 0) AS inserted,
+		       (xmax <> 0 AND (
+		           o.display_name                  IS DISTINCT FROM upserted.display_name                  OR
+		           o.role                          IS DISTINCT FROM upserted.role                          OR
+		           o.kubelet_version               IS DISTINCT FROM upserted.kubelet_version               OR
+		           o.kube_proxy_version            IS DISTINCT FROM upserted.kube_proxy_version            OR
+		           o.container_runtime_version     IS DISTINCT FROM upserted.container_runtime_version     OR
+		           o.os_image                      IS DISTINCT FROM upserted.os_image                      OR
+		           o.operating_system              IS DISTINCT FROM upserted.operating_system              OR
+		           o.kernel_version                IS DISTINCT FROM upserted.kernel_version                OR
+		           o.architecture                  IS DISTINCT FROM upserted.architecture                  OR
+		           o.internal_ip                   IS DISTINCT FROM upserted.internal_ip                   OR
+		           o.external_ip                   IS DISTINCT FROM upserted.external_ip                   OR
+		           o.pod_cidr                      IS DISTINCT FROM upserted.pod_cidr                      OR
+		           o.provider_id                   IS DISTINCT FROM upserted.provider_id                   OR
+		           o.instance_type                 IS DISTINCT FROM upserted.instance_type                 OR
+		           o.zone                          IS DISTINCT FROM upserted.zone                          OR
+		           o.capacity_cpu                  IS DISTINCT FROM upserted.capacity_cpu                  OR
+		           o.capacity_memory               IS DISTINCT FROM upserted.capacity_memory               OR
+		           o.capacity_pods                 IS DISTINCT FROM upserted.capacity_pods                 OR
+		           o.capacity_ephemeral_storage    IS DISTINCT FROM upserted.capacity_ephemeral_storage    OR
+		           o.allocatable_cpu               IS DISTINCT FROM upserted.allocatable_cpu               OR
+		           o.allocatable_memory            IS DISTINCT FROM upserted.allocatable_memory            OR
+		           o.allocatable_pods              IS DISTINCT FROM upserted.allocatable_pods              OR
+		           o.allocatable_ephemeral_storage IS DISTINCT FROM upserted.allocatable_ephemeral_storage OR
+		           o.conditions                    IS DISTINCT FROM upserted.conditions                    OR
+		           o.taints                        IS DISTINCT FROM upserted.taints                        OR
+		           o.unschedulable                 IS DISTINCT FROM upserted.unschedulable                 OR
+		           o.ready                         IS DISTINCT FROM upserted.ready                         OR
+		           o.labels                        IS DISTINCT FROM upserted.labels                        OR
+		           o.terminated_at                 IS DISTINCT FROM upserted.terminated_at
+		       )) AS business_changed
+		  FROM upserted LEFT JOIN old o ON true
 	`
 	row := tx.QueryRow(ctx, q, values...)
-	n, err := scanNode(row)
+	var inserted, businessChanged bool
+	n, err := scanNode(scanRowWith{row: row, extra: []any{&inserted, &businessChanged}})
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
-			return api.Node{}, api.OutcomeBusinessChanged, fmt.Errorf("cluster %s does not exist: %w", in.ClusterId, api.ErrNotFound)
+			return api.Node{}, api.OutcomeNoChange, fmt.Errorf("cluster %s does not exist: %w", in.ClusterId, api.ErrNotFound)
 		}
-		return api.Node{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert node: %w", err)
+		return api.Node{}, api.OutcomeNoChange, fmt.Errorf("upsert node: %w", err)
 	}
 
 	actualID := *n.Id
@@ -3457,9 +3525,9 @@ func (p *PG) UpsertNode(ctx context.Context, in api.NodeCreate) (api.Node, api.U
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return api.Node{}, api.OutcomeBusinessChanged, fmt.Errorf("commit upsert node: %w", err)
+		return api.Node{}, api.OutcomeNoChange, fmt.Errorf("commit upsert node: %w", err)
 	}
-	return n, api.OutcomeBusinessChanged, nil
+	return n, classifyOutcome(inserted, businessChanged), nil
 }
 
 func scanNode(row pgx.Row) (api.Node, error) {

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -1383,12 +1383,12 @@ func (p *PG) UpsertNamespace(ctx context.Context, in api.NamespaceCreate) (api.N
 
 	labelsJSON, err := marshalLabels(in.Labels)
 	if err != nil {
-		return api.Namespace{}, api.OutcomeBusinessChanged, err
+		return api.Namespace{}, api.OutcomeNoChange, err
 	}
 
 	tx, err := p.pool.Begin(ctx)
 	if err != nil {
-		return api.Namespace{}, api.OutcomeBusinessChanged, fmt.Errorf("begin upsert namespace: %w", err)
+		return api.Namespace{}, api.OutcomeNoChange, fmt.Errorf("begin upsert namespace: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
@@ -1402,32 +1402,54 @@ func (p *PG) UpsertNamespace(ctx context.Context, in api.NamespaceCreate) (api.N
 	isCreate := prevID == nil
 	isRestore := prevID != nil && prevTerminatedAt != nil
 
+	// AUDIT_BUSINESS_FIELDS: display_name, phase, labels, terminated_at
+	// (restore flips it). updated_at is a clock field — excluded.
+	// Curator fields (owner/criticality/notes/runbook_url/annotations) are
+	// not touched by the collector upsert and excluded from the OR-chain.
 	const q = `
-		INSERT INTO namespaces (
-			id, cluster_id, name, display_name, phase,
-			labels, created_at, updated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $7)
-		ON CONFLICT (cluster_id, name) DO UPDATE SET
-			display_name  = EXCLUDED.display_name,
-			phase         = EXCLUDED.phase,
-			labels        = EXCLUDED.labels,
-			terminated_at = NULL,
-			updated_at    = EXCLUDED.updated_at
-		RETURNING id, cluster_id, name, display_name, phase, labels,
-		          owner, criticality, notes, runbook_url, annotations,
-		          created_at, updated_at
+		WITH old AS (
+		  SELECT display_name, phase, labels, terminated_at
+		    FROM namespaces WHERE cluster_id=$2 AND name=$3
+		),
+		upserted AS (
+		  INSERT INTO namespaces (
+		    id, cluster_id, name, display_name, phase,
+		    labels, created_at, updated_at
+		  ) VALUES ($1, $2, $3, $4, $5, $6, $7, $7)
+		  ON CONFLICT (cluster_id, name) DO UPDATE SET
+		      display_name  = EXCLUDED.display_name,
+		      phase         = EXCLUDED.phase,
+		      labels        = EXCLUDED.labels,
+		      terminated_at = NULL,
+		      updated_at    = EXCLUDED.updated_at
+		  RETURNING id, cluster_id, name, display_name, phase, labels,
+		            owner, criticality, notes, runbook_url, annotations,
+		            created_at, updated_at, terminated_at, xmax
+		)
+		SELECT id, cluster_id, name, display_name, phase, labels,
+		       owner, criticality, notes, runbook_url, annotations,
+		       created_at, updated_at,
+		       (xmax = 0) AS inserted,
+		       (xmax <> 0 AND (
+		           o.display_name  IS DISTINCT FROM upserted.display_name  OR
+		           o.phase         IS DISTINCT FROM upserted.phase         OR
+		           o.labels        IS DISTINCT FROM upserted.labels        OR
+		           o.terminated_at IS DISTINCT FROM upserted.terminated_at
+		       )) AS business_changed
+		  FROM upserted LEFT JOIN old o ON true
 	`
 	row := tx.QueryRow(ctx, q,
 		id, in.ClusterId, in.Name, in.DisplayName, in.Phase,
 		labelsJSON, now,
 	)
-	n, err := scanNamespace(row)
+	var inserted, businessChanged bool
+	n, err := scanNamespace(scanRowWith{row: row, extra: []any{&inserted, &businessChanged}})
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
-			return api.Namespace{}, api.OutcomeBusinessChanged, fmt.Errorf("cluster %s does not exist: %w", in.ClusterId, api.ErrNotFound)
+			return api.Namespace{}, api.OutcomeNoChange, fmt.Errorf("cluster %s does not exist: %w", in.ClusterId, api.ErrNotFound)
 		}
-		return api.Namespace{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert namespace: %w", err)
+		return api.Namespace{}, api.OutcomeNoChange, fmt.Errorf("upsert namespace: %w", err)
 	}
 
 	actualID := *n.Id
@@ -1443,9 +1465,9 @@ func (p *PG) UpsertNamespace(ctx context.Context, in api.NamespaceCreate) (api.N
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return api.Namespace{}, api.OutcomeBusinessChanged, fmt.Errorf("commit upsert namespace: %w", err)
+		return api.Namespace{}, api.OutcomeNoChange, fmt.Errorf("commit upsert namespace: %w", err)
 	}
-	return n, api.OutcomeBusinessChanged, nil
+	return n, classifyOutcome(inserted, businessChanged), nil
 }
 
 // CreatePod inserts a new pod.

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -2507,19 +2507,19 @@ func (p *PG) UpsertService(ctx context.Context, in api.ServiceCreate) (api.Servi
 
 	labelsJSON, err := marshalLabels(in.Labels)
 	if err != nil {
-		return api.Service{}, api.OutcomeBusinessChanged, err
+		return api.Service{}, api.OutcomeNoChange, err
 	}
 	selectorJSON, err := marshalLabels(in.Selector)
 	if err != nil {
-		return api.Service{}, api.OutcomeBusinessChanged, err
+		return api.Service{}, api.OutcomeNoChange, err
 	}
 	portsJSON, err := marshalPorts(in.Ports)
 	if err != nil {
-		return api.Service{}, api.OutcomeBusinessChanged, err
+		return api.Service{}, api.OutcomeNoChange, err
 	}
 	lbJSON, err := marshalPorts(in.LoadBalancer)
 	if err != nil {
-		return api.Service{}, api.OutcomeBusinessChanged, err
+		return api.Service{}, api.OutcomeNoChange, err
 	}
 
 	var svcType *string
@@ -2528,30 +2528,120 @@ func (p *PG) UpsertService(ctx context.Context, in api.ServiceCreate) (api.Servi
 		svcType = &t
 	}
 
-	q := `
-		INSERT INTO services (` + serviceColumns + `) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$10)
-		ON CONFLICT (namespace_id, name) DO UPDATE SET
-			type          = EXCLUDED.type,
-			cluster_ip    = EXCLUDED.cluster_ip,
-			selector      = EXCLUDED.selector,
-			ports         = EXCLUDED.ports,
-			load_balancer = EXCLUDED.load_balancer,
-			labels        = EXCLUDED.labels,
-			updated_at    = EXCLUDED.updated_at
-		RETURNING ` + serviceColumns
+	// AUDIT_BUSINESS_FIELDS: type, cluster_ip, selector, ports, load_balancer,
+	// labels. updated_at is a clock field — excluded from business_changed
+	// detection so reconcile-only ticks turn into NoChange.
+	const q = `
+		WITH old AS (
+		  SELECT type, cluster_ip, selector, ports, load_balancer, labels
+		    FROM services WHERE namespace_id = $2 AND name = $3
+		),
+		upserted AS (
+		  INSERT INTO services (
+		      id, namespace_id, name, type, cluster_ip,
+		      selector, ports, load_balancer, labels, created_at, updated_at
+		  ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$10)
+		  ON CONFLICT (namespace_id, name) DO UPDATE SET
+		      type          = EXCLUDED.type,
+		      cluster_ip    = EXCLUDED.cluster_ip,
+		      selector      = EXCLUDED.selector,
+		      ports         = EXCLUDED.ports,
+		      load_balancer = EXCLUDED.load_balancer,
+		      labels        = EXCLUDED.labels,
+		      updated_at    = EXCLUDED.updated_at
+		  RETURNING id, namespace_id, name, type, cluster_ip,
+		            selector, ports, load_balancer, labels, created_at, updated_at,
+		            xmax
+		)
+		SELECT u.id, u.namespace_id, u.name, u.type, u.cluster_ip,
+		       u.selector, u.ports, u.load_balancer, u.labels,
+		       u.created_at, u.updated_at,
+		       (u.xmax = 0) AS inserted,
+		       (u.xmax <> 0 AND (
+		           o.type          IS DISTINCT FROM u.type          OR
+		           o.cluster_ip    IS DISTINCT FROM u.cluster_ip    OR
+		           o.selector      IS DISTINCT FROM u.selector      OR
+		           o.ports         IS DISTINCT FROM u.ports         OR
+		           o.load_balancer IS DISTINCT FROM u.load_balancer OR
+		           o.labels        IS DISTINCT FROM u.labels
+		       )) AS business_changed
+		  FROM upserted u LEFT JOIN old o ON true
+	`
 	row := p.pool.QueryRow(ctx, q,
 		id, in.NamespaceId, in.Name, svcType, in.ClusterIp,
 		selectorJSON, portsJSON, lbJSON, labelsJSON, now,
 	)
-	s, err := scanService(row)
-	if err != nil {
+
+	var (
+		s               api.Service
+		svcID           uuid.UUID
+		namespaceID     uuid.UUID
+		createdAt       time.Time
+		updatedAt       time.Time
+		svcTypeOut      sql.NullString
+		clusterIP       sql.NullString
+		selectorOut     []byte
+		portsOut        []byte
+		lbOut           []byte
+		labelsOut       []byte
+		inserted        bool
+		businessChanged bool
+	)
+	if err := row.Scan(
+		&svcID, &namespaceID, &s.Name,
+		&svcTypeOut, &clusterIP,
+		&selectorOut, &portsOut, &lbOut, &labelsOut,
+		&createdAt, &updatedAt,
+		&inserted, &businessChanged,
+	); err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
-			return api.Service{}, api.OutcomeBusinessChanged, fmt.Errorf("namespace %s does not exist: %w", in.NamespaceId, api.ErrNotFound)
+			return api.Service{}, api.OutcomeNoChange, fmt.Errorf("namespace %s does not exist: %w", in.NamespaceId, api.ErrNotFound)
 		}
-		return api.Service{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert service: %w", err)
+		return api.Service{}, api.OutcomeNoChange, fmt.Errorf("upsert service: %w", err)
 	}
-	return s, api.OutcomeBusinessChanged, nil
+	s.Id = &svcID
+	s.NamespaceId = namespaceID
+	s.CreatedAt = &createdAt
+	s.UpdatedAt = &updatedAt
+	s.ClusterIp = nullableString(clusterIP)
+	if svcTypeOut.Valid {
+		t := api.ServiceType(svcTypeOut.String)
+		s.Type = &t
+	}
+	if len(selectorOut) > 0 {
+		var sel map[string]string
+		if err := json.Unmarshal(selectorOut, &sel); err != nil {
+			return api.Service{}, api.OutcomeNoChange, fmt.Errorf("unmarshal service selector: %w", err)
+		}
+		if len(sel) > 0 {
+			s.Selector = &sel
+		}
+	}
+	if len(portsOut) > 0 {
+		var ports []map[string]interface{}
+		if err := json.Unmarshal(portsOut, &ports); err != nil {
+			return api.Service{}, api.OutcomeNoChange, fmt.Errorf("unmarshal service ports: %w", err)
+		}
+		if len(ports) > 0 {
+			s.Ports = &ports
+		}
+	}
+	if lb, err := unmarshalMapArray(lbOut); err != nil {
+		return api.Service{}, api.OutcomeNoChange, fmt.Errorf("unmarshal service load_balancer: %w", err)
+	} else {
+		s.LoadBalancer = lb
+	}
+	if len(labelsOut) > 0 {
+		var labels map[string]string
+		if err := json.Unmarshal(labelsOut, &labels); err != nil {
+			return api.Service{}, api.OutcomeNoChange, fmt.Errorf("unmarshal service labels: %w", err)
+		}
+		if len(labels) > 0 {
+			s.Labels = &labels
+		}
+	}
+	return s, classifyOutcome(inserted, businessChanged), nil
 }
 
 // DeleteServicesNotIn mirrors DeletePodsNotIn.

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -2068,20 +2068,20 @@ func (p *PG) UpsertWorkload(ctx context.Context, in api.WorkloadCreate) (api.Wor
 
 	labelsJSON, err := marshalLabels(in.Labels)
 	if err != nil {
-		return api.Workload{}, api.OutcomeBusinessChanged, err
+		return api.Workload{}, api.OutcomeNoChange, err
 	}
 	specJSON, err := marshalSpec(in.Spec)
 	if err != nil {
-		return api.Workload{}, api.OutcomeBusinessChanged, err
+		return api.Workload{}, api.OutcomeNoChange, err
 	}
 	containersJSON, err := marshalPorts(in.Containers)
 	if err != nil {
-		return api.Workload{}, api.OutcomeBusinessChanged, err
+		return api.Workload{}, api.OutcomeNoChange, err
 	}
 
 	tx, err := p.pool.Begin(ctx)
 	if err != nil {
-		return api.Workload{}, api.OutcomeBusinessChanged, fmt.Errorf("begin upsert workload: %w", err)
+		return api.Workload{}, api.OutcomeNoChange, fmt.Errorf("begin upsert workload: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
@@ -2094,33 +2094,111 @@ func (p *PG) UpsertWorkload(ctx context.Context, in api.WorkloadCreate) (api.Wor
 	isCreate := prevWLID == nil
 	isRestore := prevWLID != nil && prevTerminatedAt != nil
 
+	// AUDIT_BUSINESS_FIELDS: replicas, ready_replicas, containers, labels, spec,
+	// terminated_at (restore flips it). updated_at is a clock field — excluded.
 	const q = `
-		INSERT INTO workloads (
-			id, namespace_id, kind, name, replicas, ready_replicas,
-			containers, labels, spec, created_at, updated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $10)
-		ON CONFLICT (namespace_id, kind, name) DO UPDATE SET
-			replicas       = EXCLUDED.replicas,
-			ready_replicas = EXCLUDED.ready_replicas,
-			containers     = EXCLUDED.containers,
-			labels         = EXCLUDED.labels,
-			spec           = EXCLUDED.spec,
-			terminated_at  = NULL,
-			updated_at     = EXCLUDED.updated_at
-		RETURNING id, namespace_id, kind, name, replicas, ready_replicas,
-		          containers, labels, spec, created_at, updated_at
+		WITH old AS (
+		  SELECT replicas, ready_replicas, containers, labels, spec, terminated_at
+		    FROM workloads WHERE namespace_id=$2 AND kind=$3 AND name=$4
+		),
+		upserted AS (
+		  INSERT INTO workloads (
+		      id, namespace_id, kind, name, replicas, ready_replicas,
+		      containers, labels, spec, created_at, updated_at
+		  ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $10)
+		  ON CONFLICT (namespace_id, kind, name) DO UPDATE SET
+		      replicas       = EXCLUDED.replicas,
+		      ready_replicas = EXCLUDED.ready_replicas,
+		      containers     = EXCLUDED.containers,
+		      labels         = EXCLUDED.labels,
+		      spec           = EXCLUDED.spec,
+		      terminated_at  = NULL,
+		      updated_at     = EXCLUDED.updated_at
+		  RETURNING id, namespace_id, kind, name, replicas, ready_replicas,
+		            containers, labels, spec, created_at, updated_at,
+		            terminated_at, xmax
+		)
+		SELECT u.id, u.namespace_id, u.kind, u.name, u.replicas, u.ready_replicas,
+		       u.containers, u.labels, u.spec, u.created_at, u.updated_at,
+		       (u.xmax = 0) AS inserted,
+		       (u.xmax <> 0 AND (
+		           o.replicas       IS DISTINCT FROM u.replicas       OR
+		           o.ready_replicas IS DISTINCT FROM u.ready_replicas OR
+		           o.containers     IS DISTINCT FROM u.containers     OR
+		           o.labels         IS DISTINCT FROM u.labels         OR
+		           o.spec           IS DISTINCT FROM u.spec           OR
+		           o.terminated_at  IS DISTINCT FROM u.terminated_at
+		       )) AS business_changed
+		  FROM upserted u LEFT JOIN old o ON true
 	`
 	row := tx.QueryRow(ctx, q,
 		id, in.NamespaceId, string(in.Kind), in.Name, in.Replicas, in.ReadyReplicas,
 		containersJSON, labelsJSON, specJSON, now,
 	)
-	w, err := scanWorkload(row)
-	if err != nil {
+
+	var (
+		w               api.Workload
+		wID             uuid.UUID
+		namespaceID     uuid.UUID
+		kind            string
+		replicas        sql.NullInt32
+		readyReplicas   sql.NullInt32
+		createdAt       time.Time
+		updatedAt       time.Time
+		containersOut   []byte
+		labelsOut       []byte
+		specOut         []byte
+		inserted        bool
+		businessChanged bool
+	)
+	if err := row.Scan(
+		&wID, &namespaceID, &kind, &w.Name,
+		&replicas, &readyReplicas,
+		&containersOut, &labelsOut, &specOut,
+		&createdAt, &updatedAt,
+		&inserted, &businessChanged,
+	); err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
-			return api.Workload{}, api.OutcomeBusinessChanged, fmt.Errorf("namespace %s does not exist: %w", in.NamespaceId, api.ErrNotFound)
+			return api.Workload{}, api.OutcomeNoChange, fmt.Errorf("namespace %s does not exist: %w", in.NamespaceId, api.ErrNotFound)
 		}
-		return api.Workload{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert workload: %w", err)
+		return api.Workload{}, api.OutcomeNoChange, fmt.Errorf("upsert workload: %w", err)
+	}
+	w.Id = &wID
+	w.NamespaceId = namespaceID
+	w.Kind = api.WorkloadKind(kind)
+	w.CreatedAt = &createdAt
+	w.UpdatedAt = &updatedAt
+	if replicas.Valid {
+		v := int(replicas.Int32)
+		w.Replicas = &v
+	}
+	if readyReplicas.Valid {
+		v := int(readyReplicas.Int32)
+		w.ReadyReplicas = &v
+	}
+	if cs, err := unmarshalContainers(containersOut); err != nil {
+		return api.Workload{}, api.OutcomeNoChange, fmt.Errorf("unmarshal workload containers: %w", err)
+	} else if cs != nil {
+		w.Containers = cs
+	}
+	if len(labelsOut) > 0 {
+		var labels map[string]string
+		if err := json.Unmarshal(labelsOut, &labels); err != nil {
+			return api.Workload{}, api.OutcomeNoChange, fmt.Errorf("unmarshal workload labels: %w", err)
+		}
+		if len(labels) > 0 {
+			w.Labels = &labels
+		}
+	}
+	if len(specOut) > 0 {
+		var spec map[string]interface{}
+		if err := json.Unmarshal(specOut, &spec); err != nil {
+			return api.Workload{}, api.OutcomeNoChange, fmt.Errorf("unmarshal workload spec: %w", err)
+		}
+		if len(spec) > 0 {
+			w.Spec = &spec
+		}
 	}
 
 	actualID := *w.Id
@@ -2136,9 +2214,9 @@ func (p *PG) UpsertWorkload(ctx context.Context, in api.WorkloadCreate) (api.Wor
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return api.Workload{}, api.OutcomeBusinessChanged, fmt.Errorf("commit upsert workload: %w", err)
+		return api.Workload{}, api.OutcomeNoChange, fmt.Errorf("commit upsert workload: %w", err)
 	}
-	return w, api.OutcomeBusinessChanged, nil
+	return w, classifyOutcome(inserted, businessChanged), nil
 }
 
 // DeleteWorkloadsNotIn soft-deletes workloads in the namespace whose

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -1351,18 +1351,18 @@ func liveWorkloadIDsForNamespace(ctx context.Context, tx pgx.Tx, namespaceID uui
 // UpsertNamespace inserts-or-updates a namespace keyed by (cluster_id, name).
 //
 //nolint:gocritic,gocyclo // hugeParam: Store interface requires value param; history capture adds branches
-func (p *PG) UpsertNamespace(ctx context.Context, in api.NamespaceCreate) (api.Namespace, error) {
+func (p *PG) UpsertNamespace(ctx context.Context, in api.NamespaceCreate) (api.Namespace, api.UpsertOutcome, error) {
 	id := uuid.New()
 	now := time.Now().UTC()
 
 	labelsJSON, err := marshalLabels(in.Labels)
 	if err != nil {
-		return api.Namespace{}, err
+		return api.Namespace{}, api.OutcomeBusinessChanged, err
 	}
 
 	tx, err := p.pool.Begin(ctx)
 	if err != nil {
-		return api.Namespace{}, fmt.Errorf("begin upsert namespace: %w", err)
+		return api.Namespace{}, api.OutcomeBusinessChanged, fmt.Errorf("begin upsert namespace: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
@@ -1399,9 +1399,9 @@ func (p *PG) UpsertNamespace(ctx context.Context, in api.NamespaceCreate) (api.N
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
-			return api.Namespace{}, fmt.Errorf("cluster %s does not exist: %w", in.ClusterId, api.ErrNotFound)
+			return api.Namespace{}, api.OutcomeBusinessChanged, fmt.Errorf("cluster %s does not exist: %w", in.ClusterId, api.ErrNotFound)
 		}
-		return api.Namespace{}, fmt.Errorf("upsert namespace: %w", err)
+		return api.Namespace{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert namespace: %w", err)
 	}
 
 	actualID := *n.Id
@@ -1417,9 +1417,9 @@ func (p *PG) UpsertNamespace(ctx context.Context, in api.NamespaceCreate) (api.N
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return api.Namespace{}, fmt.Errorf("commit upsert namespace: %w", err)
+		return api.Namespace{}, api.OutcomeBusinessChanged, fmt.Errorf("commit upsert namespace: %w", err)
 	}
-	return n, nil
+	return n, api.OutcomeBusinessChanged, nil
 }
 
 // CreatePod inserts a new pod.
@@ -1671,17 +1671,17 @@ func (p *PG) DeletePod(ctx context.Context, id uuid.UUID) error {
 // UpsertPod inserts-or-updates a pod keyed by (namespace_id, name).
 //
 //nolint:gocritic // hugeParam: Store interface requires value param
-func (p *PG) UpsertPod(ctx context.Context, in api.PodCreate) (api.Pod, error) {
+func (p *PG) UpsertPod(ctx context.Context, in api.PodCreate) (api.Pod, api.UpsertOutcome, error) {
 	id := uuid.New()
 	now := time.Now().UTC()
 
 	labelsJSON, err := marshalLabels(in.Labels)
 	if err != nil {
-		return api.Pod{}, err
+		return api.Pod{}, api.OutcomeBusinessChanged, err
 	}
 	containersJSON, err := marshalPorts(in.Containers)
 	if err != nil {
-		return api.Pod{}, err
+		return api.Pod{}, api.OutcomeBusinessChanged, err
 	}
 
 	const q = `
@@ -1707,11 +1707,11 @@ func (p *PG) UpsertPod(ctx context.Context, in api.PodCreate) (api.Pod, error) {
 	pod, err := scanPod(row)
 	if err != nil {
 		if pErr := classifyPodFKError(err, in.NamespaceId, in.WorkloadId); pErr != nil {
-			return api.Pod{}, pErr
+			return api.Pod{}, api.OutcomeBusinessChanged, pErr
 		}
-		return api.Pod{}, fmt.Errorf("upsert pod: %w", err)
+		return api.Pod{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert pod: %w", err)
 	}
-	return pod, nil
+	return pod, api.OutcomeBusinessChanged, nil
 }
 
 // DeletePodsNotIn removes every pod in the given namespace whose name is not
@@ -1981,26 +1981,26 @@ func (p *PG) DeleteWorkload(ctx context.Context, id uuid.UUID) error {
 // UpsertWorkload inserts-or-updates a workload keyed by (namespace_id, kind, name).
 //
 //nolint:gocritic,gocyclo // hugeParam: Store interface requires value param; history capture adds branches
-func (p *PG) UpsertWorkload(ctx context.Context, in api.WorkloadCreate) (api.Workload, error) {
+func (p *PG) UpsertWorkload(ctx context.Context, in api.WorkloadCreate) (api.Workload, api.UpsertOutcome, error) {
 	id := uuid.New()
 	now := time.Now().UTC()
 
 	labelsJSON, err := marshalLabels(in.Labels)
 	if err != nil {
-		return api.Workload{}, err
+		return api.Workload{}, api.OutcomeBusinessChanged, err
 	}
 	specJSON, err := marshalSpec(in.Spec)
 	if err != nil {
-		return api.Workload{}, err
+		return api.Workload{}, api.OutcomeBusinessChanged, err
 	}
 	containersJSON, err := marshalPorts(in.Containers)
 	if err != nil {
-		return api.Workload{}, err
+		return api.Workload{}, api.OutcomeBusinessChanged, err
 	}
 
 	tx, err := p.pool.Begin(ctx)
 	if err != nil {
-		return api.Workload{}, fmt.Errorf("begin upsert workload: %w", err)
+		return api.Workload{}, api.OutcomeBusinessChanged, fmt.Errorf("begin upsert workload: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
@@ -2037,9 +2037,9 @@ func (p *PG) UpsertWorkload(ctx context.Context, in api.WorkloadCreate) (api.Wor
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
-			return api.Workload{}, fmt.Errorf("namespace %s does not exist: %w", in.NamespaceId, api.ErrNotFound)
+			return api.Workload{}, api.OutcomeBusinessChanged, fmt.Errorf("namespace %s does not exist: %w", in.NamespaceId, api.ErrNotFound)
 		}
-		return api.Workload{}, fmt.Errorf("upsert workload: %w", err)
+		return api.Workload{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert workload: %w", err)
 	}
 
 	actualID := *w.Id
@@ -2055,9 +2055,9 @@ func (p *PG) UpsertWorkload(ctx context.Context, in api.WorkloadCreate) (api.Wor
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return api.Workload{}, fmt.Errorf("commit upsert workload: %w", err)
+		return api.Workload{}, api.OutcomeBusinessChanged, fmt.Errorf("commit upsert workload: %w", err)
 	}
-	return w, nil
+	return w, api.OutcomeBusinessChanged, nil
 }
 
 // DeleteWorkloadsNotIn soft-deletes workloads in the namespace whose
@@ -2420,25 +2420,25 @@ func (p *PG) DeleteService(ctx context.Context, id uuid.UUID) error {
 // UpsertService inserts-or-updates a service keyed by (namespace_id, name).
 //
 //nolint:gocritic // hugeParam: Store interface requires value param
-func (p *PG) UpsertService(ctx context.Context, in api.ServiceCreate) (api.Service, error) {
+func (p *PG) UpsertService(ctx context.Context, in api.ServiceCreate) (api.Service, api.UpsertOutcome, error) {
 	id := uuid.New()
 	now := time.Now().UTC()
 
 	labelsJSON, err := marshalLabels(in.Labels)
 	if err != nil {
-		return api.Service{}, err
+		return api.Service{}, api.OutcomeBusinessChanged, err
 	}
 	selectorJSON, err := marshalLabels(in.Selector)
 	if err != nil {
-		return api.Service{}, err
+		return api.Service{}, api.OutcomeBusinessChanged, err
 	}
 	portsJSON, err := marshalPorts(in.Ports)
 	if err != nil {
-		return api.Service{}, err
+		return api.Service{}, api.OutcomeBusinessChanged, err
 	}
 	lbJSON, err := marshalPorts(in.LoadBalancer)
 	if err != nil {
-		return api.Service{}, err
+		return api.Service{}, api.OutcomeBusinessChanged, err
 	}
 
 	var svcType *string
@@ -2466,11 +2466,11 @@ func (p *PG) UpsertService(ctx context.Context, in api.ServiceCreate) (api.Servi
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
-			return api.Service{}, fmt.Errorf("namespace %s does not exist: %w", in.NamespaceId, api.ErrNotFound)
+			return api.Service{}, api.OutcomeBusinessChanged, fmt.Errorf("namespace %s does not exist: %w", in.NamespaceId, api.ErrNotFound)
 		}
-		return api.Service{}, fmt.Errorf("upsert service: %w", err)
+		return api.Service{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert service: %w", err)
 	}
-	return s, nil
+	return s, api.OutcomeBusinessChanged, nil
 }
 
 // DeleteServicesNotIn mirrors DeletePodsNotIn.
@@ -2713,25 +2713,25 @@ func (p *PG) DeleteIngress(ctx context.Context, id uuid.UUID) error {
 }
 
 // UpsertIngress inserts-or-updates an ingress keyed by (namespace_id, name).
-func (p *PG) UpsertIngress(ctx context.Context, in api.IngressCreate) (api.Ingress, error) {
+func (p *PG) UpsertIngress(ctx context.Context, in api.IngressCreate) (api.Ingress, api.UpsertOutcome, error) {
 	id := uuid.New()
 	now := time.Now().UTC()
 
 	labelsJSON, err := marshalLabels(in.Labels)
 	if err != nil {
-		return api.Ingress{}, err
+		return api.Ingress{}, api.OutcomeBusinessChanged, err
 	}
 	rulesJSON, err := marshalPorts(in.Rules)
 	if err != nil {
-		return api.Ingress{}, err
+		return api.Ingress{}, api.OutcomeBusinessChanged, err
 	}
 	tlsJSON, err := marshalPorts(in.Tls)
 	if err != nil {
-		return api.Ingress{}, err
+		return api.Ingress{}, api.OutcomeBusinessChanged, err
 	}
 	lbJSON, err := marshalPorts(in.LoadBalancer)
 	if err != nil {
-		return api.Ingress{}, err
+		return api.Ingress{}, api.OutcomeBusinessChanged, err
 	}
 
 	q := `
@@ -2752,11 +2752,11 @@ func (p *PG) UpsertIngress(ctx context.Context, in api.IngressCreate) (api.Ingre
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
-			return api.Ingress{}, fmt.Errorf("namespace %s does not exist: %w", in.NamespaceId, api.ErrNotFound)
+			return api.Ingress{}, api.OutcomeBusinessChanged, fmt.Errorf("namespace %s does not exist: %w", in.NamespaceId, api.ErrNotFound)
 		}
-		return api.Ingress{}, fmt.Errorf("upsert ingress: %w", err)
+		return api.Ingress{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert ingress: %w", err)
 	}
-	return ing, nil
+	return ing, api.OutcomeBusinessChanged, nil
 }
 
 // DeleteIngressesNotIn mirrors DeleteServicesNotIn.
@@ -3051,18 +3051,18 @@ func detectNodeUpsertChangeType(ctx context.Context, tx pgx.Tx, clusterID uuid.U
 // conflict only mutable columns are overwritten so created_at is preserved.
 //
 //nolint:gocritic // hugeParam: Store interface requires value param
-func (p *PG) UpsertNode(ctx context.Context, in api.NodeCreate) (api.Node, error) {
+func (p *PG) UpsertNode(ctx context.Context, in api.NodeCreate) (api.Node, api.UpsertOutcome, error) {
 	id := uuid.New()
 	now := time.Now().UTC()
 
 	values, err := nodeInsertValues(&in, id, now)
 	if err != nil {
-		return api.Node{}, err
+		return api.Node{}, api.OutcomeBusinessChanged, err
 	}
 
 	tx, err := p.pool.Begin(ctx)
 	if err != nil {
-		return api.Node{}, fmt.Errorf("begin upsert node: %w", err)
+		return api.Node{}, api.OutcomeBusinessChanged, fmt.Errorf("begin upsert node: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
@@ -3109,9 +3109,9 @@ func (p *PG) UpsertNode(ctx context.Context, in api.NodeCreate) (api.Node, error
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
-			return api.Node{}, fmt.Errorf("cluster %s does not exist: %w", in.ClusterId, api.ErrNotFound)
+			return api.Node{}, api.OutcomeBusinessChanged, fmt.Errorf("cluster %s does not exist: %w", in.ClusterId, api.ErrNotFound)
 		}
-		return api.Node{}, fmt.Errorf("upsert node: %w", err)
+		return api.Node{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert node: %w", err)
 	}
 
 	actualID := *n.Id
@@ -3121,9 +3121,9 @@ func (p *PG) UpsertNode(ctx context.Context, in api.NodeCreate) (api.Node, error
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return api.Node{}, fmt.Errorf("commit upsert node: %w", err)
+		return api.Node{}, api.OutcomeBusinessChanged, fmt.Errorf("commit upsert node: %w", err)
 	}
-	return n, nil
+	return n, api.OutcomeBusinessChanged, nil
 }
 
 func scanNode(row pgx.Row) (api.Node, error) {
@@ -3631,13 +3631,13 @@ func (p *PG) DeletePersistentVolume(ctx context.Context, id uuid.UUID) error {
 // UpsertPersistentVolume inserts-or-updates a PV keyed by (cluster_id, name).
 //
 //nolint:gocritic // hugeParam: Store interface requires value param
-func (p *PG) UpsertPersistentVolume(ctx context.Context, in api.PersistentVolumeCreate) (api.PersistentVolume, error) {
+func (p *PG) UpsertPersistentVolume(ctx context.Context, in api.PersistentVolumeCreate) (api.PersistentVolume, api.UpsertOutcome, error) {
 	id := uuid.New()
 	now := time.Now().UTC()
 
 	labelsJSON, err := marshalLabels(in.Labels)
 	if err != nil {
-		return api.PersistentVolume{}, err
+		return api.PersistentVolume{}, api.OutcomeBusinessChanged, err
 	}
 
 	const q = `
@@ -3678,11 +3678,11 @@ func (p *PG) UpsertPersistentVolume(ctx context.Context, in api.PersistentVolume
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
-			return api.PersistentVolume{}, fmt.Errorf("cluster %s does not exist: %w", in.ClusterId, api.ErrNotFound)
+			return api.PersistentVolume{}, api.OutcomeBusinessChanged, fmt.Errorf("cluster %s does not exist: %w", in.ClusterId, api.ErrNotFound)
 		}
-		return api.PersistentVolume{}, fmt.Errorf("upsert persistent volume: %w", err)
+		return api.PersistentVolume{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert persistent volume: %w", err)
 	}
-	return pv, nil
+	return pv, api.OutcomeBusinessChanged, nil
 }
 
 // DeletePersistentVolumesNotIn removes cluster-scoped PVs whose name is not in keepNames.
@@ -3987,13 +3987,13 @@ func (p *PG) DeletePersistentVolumeClaim(ctx context.Context, id uuid.UUID) erro
 // UpsertPersistentVolumeClaim inserts-or-updates a PVC keyed by (namespace_id, name).
 //
 //nolint:gocritic // hugeParam: Store interface requires value param
-func (p *PG) UpsertPersistentVolumeClaim(ctx context.Context, in api.PersistentVolumeClaimCreate) (api.PersistentVolumeClaim, error) {
+func (p *PG) UpsertPersistentVolumeClaim(ctx context.Context, in api.PersistentVolumeClaimCreate) (api.PersistentVolumeClaim, api.UpsertOutcome, error) {
 	id := uuid.New()
 	now := time.Now().UTC()
 
 	labelsJSON, err := marshalLabels(in.Labels)
 	if err != nil {
-		return api.PersistentVolumeClaim{}, err
+		return api.PersistentVolumeClaim{}, api.OutcomeBusinessChanged, err
 	}
 
 	const q = `
@@ -4025,11 +4025,11 @@ func (p *PG) UpsertPersistentVolumeClaim(ctx context.Context, in api.PersistentV
 	pvc, err := scanPersistentVolumeClaim(row)
 	if err != nil {
 		if pErr := classifyPVCFKError(err, in.NamespaceId, in.BoundVolumeId); pErr != nil {
-			return api.PersistentVolumeClaim{}, pErr
+			return api.PersistentVolumeClaim{}, api.OutcomeBusinessChanged, pErr
 		}
-		return api.PersistentVolumeClaim{}, fmt.Errorf("upsert pvc: %w", err)
+		return api.PersistentVolumeClaim{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert pvc: %w", err)
 	}
-	return pvc, nil
+	return pvc, api.OutcomeBusinessChanged, nil
 }
 
 // DeletePersistentVolumeClaimsNotIn removes namespace-scoped PVCs whose name

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -113,8 +113,14 @@ type scanRowWith struct {
 	extra []any
 }
 
+// Scan forwards to the wrapped row, appending the extra destinations after
+// the caller's so a single Scan call can hydrate both the normal columns
+// and the CTE outcome bools.
 func (r scanRowWith) Scan(dest ...any) error {
-	return r.row.Scan(append(dest, r.extra...)...)
+	if err := r.row.Scan(append(dest, r.extra...)...); err != nil {
+		return fmt.Errorf("scan row: %w", err)
+	}
+	return nil
 }
 
 // EnsureCluster inserts a cluster row when no row with the same name exists,
@@ -1718,7 +1724,7 @@ func (p *PG) DeletePod(ctx context.Context, id uuid.UUID) error {
 
 // UpsertPod inserts-or-updates a pod keyed by (namespace_id, name).
 //
-//nolint:gocritic // hugeParam: Store interface requires value param
+//nolint:gocritic,gocyclo // hugeParam: Store interface requires value param; CTE drives branch count
 func (p *PG) UpsertPod(ctx context.Context, in api.PodCreate) (api.Pod, api.UpsertOutcome, error) {
 	id := uuid.New()
 	now := time.Now().UTC()
@@ -2612,7 +2618,7 @@ func (p *PG) DeleteService(ctx context.Context, id uuid.UUID) error {
 
 // UpsertService inserts-or-updates a service keyed by (namespace_id, name).
 //
-//nolint:gocritic // hugeParam: Store interface requires value param
+//nolint:gocritic,gocyclo // hugeParam: Store interface requires value param; CTE drives branch count
 func (p *PG) UpsertService(ctx context.Context, in api.ServiceCreate) (api.Service, api.UpsertOutcome, error) {
 	id := uuid.New()
 	now := time.Now().UTC()
@@ -2997,7 +3003,7 @@ func (p *PG) DeleteIngress(ctx context.Context, id uuid.UUID) error {
 
 // UpsertIngress inserts-or-updates an ingress keyed by (namespace_id, name).
 //
-//nolint:gocritic // hugeParam: Store interface requires value param
+//nolint:gocyclo // CTE drives branch count
 func (p *PG) UpsertIngress(ctx context.Context, in api.IngressCreate) (api.Ingress, api.UpsertOutcome, error) {
 	id := uuid.New()
 	now := time.Now().UTC()
@@ -4444,7 +4450,10 @@ func (p *PG) DeletePersistentVolumeClaim(ctx context.Context, id uuid.UUID) erro
 // UpsertPersistentVolumeClaim inserts-or-updates a PVC keyed by (namespace_id, name).
 //
 //nolint:gocritic // hugeParam: Store interface requires value param
-func (p *PG) UpsertPersistentVolumeClaim(ctx context.Context, in api.PersistentVolumeClaimCreate) (api.PersistentVolumeClaim, api.UpsertOutcome, error) {
+func (p *PG) UpsertPersistentVolumeClaim(
+	ctx context.Context,
+	in api.PersistentVolumeClaimCreate,
+) (api.PersistentVolumeClaim, api.UpsertOutcome, error) {
 	id := uuid.New()
 	now := time.Now().UTC()
 

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -660,6 +660,21 @@ const nodeColumns = `id, cluster_id, name, display_name, role,
 	owner, criticality, notes, runbook_url, annotations, hardware_model,
 	created_at, updated_at`
 
+// nodeColumnsUAliased is nodeColumns with every column qualified by the `u`
+// alias — used by UpsertNode's final SELECT, which joins `upserted u` against
+// the snapshot CTE `old o` and must disambiguate columns present in both.
+const nodeColumnsUAliased = `u.id, u.cluster_id, u.name, u.display_name, u.role,
+	u.kubelet_version, u.kube_proxy_version, u.container_runtime_version,
+	u.os_image, u.operating_system, u.kernel_version, u.architecture,
+	u.internal_ip, u.external_ip, u.pod_cidr,
+	u.provider_id, u.instance_type, u.zone,
+	u.capacity_cpu, u.capacity_memory, u.capacity_pods, u.capacity_ephemeral_storage,
+	u.allocatable_cpu, u.allocatable_memory, u.allocatable_pods, u.allocatable_ephemeral_storage,
+	u.conditions, u.taints, u.unschedulable, u.ready,
+	u.labels,
+	u.owner, u.criticality, u.notes, u.runbook_url, u.annotations, u.hardware_model,
+	u.created_at, u.updated_at`
+
 func nodeInsertValues(in *api.NodeCreate, id uuid.UUID, now time.Time) ([]any, error) {
 	labelsJSON, err := marshalLabels(in.Labels)
 	if err != nil {
@@ -1432,17 +1447,17 @@ func (p *PG) UpsertNamespace(ctx context.Context, in api.NamespaceCreate) (api.N
 		            owner, criticality, notes, runbook_url, annotations,
 		            created_at, updated_at, terminated_at, xmax
 		)
-		SELECT id, cluster_id, name, display_name, phase, labels,
-		       owner, criticality, notes, runbook_url, annotations,
-		       created_at, updated_at,
-		       (xmax = 0) AS inserted,
-		       (xmax <> 0 AND (
-		           o.display_name  IS DISTINCT FROM upserted.display_name  OR
-		           o.phase         IS DISTINCT FROM upserted.phase         OR
-		           o.labels        IS DISTINCT FROM upserted.labels        OR
-		           o.terminated_at IS DISTINCT FROM upserted.terminated_at
+		SELECT u.id, u.cluster_id, u.name, u.display_name, u.phase, u.labels,
+		       u.owner, u.criticality, u.notes, u.runbook_url, u.annotations,
+		       u.created_at, u.updated_at,
+		       (u.xmax = 0) AS inserted,
+		       (u.xmax <> 0 AND (
+		           o.display_name  IS DISTINCT FROM u.display_name  OR
+		           o.phase         IS DISTINCT FROM u.phase         OR
+		           o.labels        IS DISTINCT FROM u.labels        OR
+		           o.terminated_at IS DISTINCT FROM u.terminated_at
 		       )) AS business_changed
-		  FROM upserted LEFT JOIN old o ON true
+		  FROM upserted u LEFT JOIN old o ON true
 	`
 	row := tx.QueryRow(ctx, q,
 		id, in.ClusterId, in.Name, in.DisplayName, in.Phase,
@@ -3500,40 +3515,40 @@ func (p *PG) UpsertNode(ctx context.Context, in api.NodeCreate) (api.Node, api.U
 		      updated_at                    = EXCLUDED.updated_at
 		  RETURNING ` + nodeColumns + `, terminated_at, xmax
 		)
-		SELECT ` + nodeColumns + `,
-		       (xmax = 0) AS inserted,
-		       (xmax <> 0 AND (
-		           o.display_name                  IS DISTINCT FROM upserted.display_name                  OR
-		           o.role                          IS DISTINCT FROM upserted.role                          OR
-		           o.kubelet_version               IS DISTINCT FROM upserted.kubelet_version               OR
-		           o.kube_proxy_version            IS DISTINCT FROM upserted.kube_proxy_version            OR
-		           o.container_runtime_version     IS DISTINCT FROM upserted.container_runtime_version     OR
-		           o.os_image                      IS DISTINCT FROM upserted.os_image                      OR
-		           o.operating_system              IS DISTINCT FROM upserted.operating_system              OR
-		           o.kernel_version                IS DISTINCT FROM upserted.kernel_version                OR
-		           o.architecture                  IS DISTINCT FROM upserted.architecture                  OR
-		           o.internal_ip                   IS DISTINCT FROM upserted.internal_ip                   OR
-		           o.external_ip                   IS DISTINCT FROM upserted.external_ip                   OR
-		           o.pod_cidr                      IS DISTINCT FROM upserted.pod_cidr                      OR
-		           o.provider_id                   IS DISTINCT FROM upserted.provider_id                   OR
-		           o.instance_type                 IS DISTINCT FROM upserted.instance_type                 OR
-		           o.zone                          IS DISTINCT FROM upserted.zone                          OR
-		           o.capacity_cpu                  IS DISTINCT FROM upserted.capacity_cpu                  OR
-		           o.capacity_memory               IS DISTINCT FROM upserted.capacity_memory               OR
-		           o.capacity_pods                 IS DISTINCT FROM upserted.capacity_pods                 OR
-		           o.capacity_ephemeral_storage    IS DISTINCT FROM upserted.capacity_ephemeral_storage    OR
-		           o.allocatable_cpu               IS DISTINCT FROM upserted.allocatable_cpu               OR
-		           o.allocatable_memory            IS DISTINCT FROM upserted.allocatable_memory            OR
-		           o.allocatable_pods              IS DISTINCT FROM upserted.allocatable_pods              OR
-		           o.allocatable_ephemeral_storage IS DISTINCT FROM upserted.allocatable_ephemeral_storage OR
-		           o.conditions                    IS DISTINCT FROM upserted.conditions                    OR
-		           o.taints                        IS DISTINCT FROM upserted.taints                        OR
-		           o.unschedulable                 IS DISTINCT FROM upserted.unschedulable                 OR
-		           o.ready                         IS DISTINCT FROM upserted.ready                         OR
-		           o.labels                        IS DISTINCT FROM upserted.labels                        OR
-		           o.terminated_at                 IS DISTINCT FROM upserted.terminated_at
+		SELECT ` + nodeColumnsUAliased + `,
+		       (u.xmax = 0) AS inserted,
+		       (u.xmax <> 0 AND (
+		           o.display_name                  IS DISTINCT FROM u.display_name                  OR
+		           o.role                          IS DISTINCT FROM u.role                          OR
+		           o.kubelet_version               IS DISTINCT FROM u.kubelet_version               OR
+		           o.kube_proxy_version            IS DISTINCT FROM u.kube_proxy_version            OR
+		           o.container_runtime_version     IS DISTINCT FROM u.container_runtime_version     OR
+		           o.os_image                      IS DISTINCT FROM u.os_image                      OR
+		           o.operating_system              IS DISTINCT FROM u.operating_system              OR
+		           o.kernel_version                IS DISTINCT FROM u.kernel_version                OR
+		           o.architecture                  IS DISTINCT FROM u.architecture                  OR
+		           o.internal_ip                   IS DISTINCT FROM u.internal_ip                   OR
+		           o.external_ip                   IS DISTINCT FROM u.external_ip                   OR
+		           o.pod_cidr                      IS DISTINCT FROM u.pod_cidr                      OR
+		           o.provider_id                   IS DISTINCT FROM u.provider_id                   OR
+		           o.instance_type                 IS DISTINCT FROM u.instance_type                 OR
+		           o.zone                          IS DISTINCT FROM u.zone                          OR
+		           o.capacity_cpu                  IS DISTINCT FROM u.capacity_cpu                  OR
+		           o.capacity_memory               IS DISTINCT FROM u.capacity_memory               OR
+		           o.capacity_pods                 IS DISTINCT FROM u.capacity_pods                 OR
+		           o.capacity_ephemeral_storage    IS DISTINCT FROM u.capacity_ephemeral_storage    OR
+		           o.allocatable_cpu               IS DISTINCT FROM u.allocatable_cpu               OR
+		           o.allocatable_memory            IS DISTINCT FROM u.allocatable_memory            OR
+		           o.allocatable_pods              IS DISTINCT FROM u.allocatable_pods              OR
+		           o.allocatable_ephemeral_storage IS DISTINCT FROM u.allocatable_ephemeral_storage OR
+		           o.conditions                    IS DISTINCT FROM u.conditions                    OR
+		           o.taints                        IS DISTINCT FROM u.taints                        OR
+		           o.unschedulable                 IS DISTINCT FROM u.unschedulable                 OR
+		           o.ready                         IS DISTINCT FROM u.ready                         OR
+		           o.labels                        IS DISTINCT FROM u.labels                        OR
+		           o.terminated_at                 IS DISTINCT FROM u.terminated_at
 		       )) AS business_changed
-		  FROM upserted LEFT JOIN old o ON true
+		  FROM upserted u LEFT JOIN old o ON true
 	`
 	row := tx.QueryRow(ctx, q, values...)
 	var inserted, businessChanged bool
@@ -4108,25 +4123,25 @@ func (p *PG) UpsertPersistentVolume(ctx context.Context, in api.PersistentVolume
 		            claim_ref_namespace, claim_ref_name,
 		            labels, created_at, updated_at, xmax
 		)
-		SELECT id, cluster_id, name, capacity, access_modes,
-		       reclaim_policy, phase, storage_class_name,
-		       csi_driver, volume_handle,
-		       claim_ref_namespace, claim_ref_name,
-		       labels, created_at, updated_at,
-		       (xmax = 0) AS inserted,
-		       (xmax <> 0 AND (
-		           o.capacity            IS DISTINCT FROM upserted.capacity            OR
-		           o.access_modes        IS DISTINCT FROM upserted.access_modes        OR
-		           o.reclaim_policy      IS DISTINCT FROM upserted.reclaim_policy      OR
-		           o.phase               IS DISTINCT FROM upserted.phase               OR
-		           o.storage_class_name  IS DISTINCT FROM upserted.storage_class_name  OR
-		           o.csi_driver          IS DISTINCT FROM upserted.csi_driver          OR
-		           o.volume_handle       IS DISTINCT FROM upserted.volume_handle       OR
-		           o.claim_ref_namespace IS DISTINCT FROM upserted.claim_ref_namespace OR
-		           o.claim_ref_name      IS DISTINCT FROM upserted.claim_ref_name      OR
-		           o.labels              IS DISTINCT FROM upserted.labels
+		SELECT u.id, u.cluster_id, u.name, u.capacity, u.access_modes,
+		       u.reclaim_policy, u.phase, u.storage_class_name,
+		       u.csi_driver, u.volume_handle,
+		       u.claim_ref_namespace, u.claim_ref_name,
+		       u.labels, u.created_at, u.updated_at,
+		       (u.xmax = 0) AS inserted,
+		       (u.xmax <> 0 AND (
+		           o.capacity            IS DISTINCT FROM u.capacity            OR
+		           o.access_modes        IS DISTINCT FROM u.access_modes        OR
+		           o.reclaim_policy      IS DISTINCT FROM u.reclaim_policy      OR
+		           o.phase               IS DISTINCT FROM u.phase               OR
+		           o.storage_class_name  IS DISTINCT FROM u.storage_class_name  OR
+		           o.csi_driver          IS DISTINCT FROM u.csi_driver          OR
+		           o.volume_handle       IS DISTINCT FROM u.volume_handle       OR
+		           o.claim_ref_namespace IS DISTINCT FROM u.claim_ref_namespace OR
+		           o.claim_ref_name      IS DISTINCT FROM u.claim_ref_name      OR
+		           o.labels              IS DISTINCT FROM u.labels
 		       )) AS business_changed
-		  FROM upserted LEFT JOIN old o ON true
+		  FROM upserted u LEFT JOIN old o ON true
 	`
 	row := p.pool.QueryRow(ctx, q,
 		id, in.ClusterId, in.Name,
@@ -4490,20 +4505,20 @@ func (p *PG) UpsertPersistentVolumeClaim(
 		            volume_name, bound_volume_id, access_modes, requested_storage,
 		            labels, created_at, updated_at, xmax
 		)
-		SELECT id, namespace_id, name, phase, storage_class_name,
-		       volume_name, bound_volume_id, access_modes, requested_storage,
-		       labels, created_at, updated_at,
-		       (xmax = 0) AS inserted,
-		       (xmax <> 0 AND (
-		           o.phase              IS DISTINCT FROM upserted.phase              OR
-		           o.storage_class_name IS DISTINCT FROM upserted.storage_class_name OR
-		           o.volume_name        IS DISTINCT FROM upserted.volume_name        OR
-		           o.bound_volume_id    IS DISTINCT FROM upserted.bound_volume_id    OR
-		           o.access_modes       IS DISTINCT FROM upserted.access_modes       OR
-		           o.requested_storage  IS DISTINCT FROM upserted.requested_storage  OR
-		           o.labels             IS DISTINCT FROM upserted.labels
+		SELECT u.id, u.namespace_id, u.name, u.phase, u.storage_class_name,
+		       u.volume_name, u.bound_volume_id, u.access_modes, u.requested_storage,
+		       u.labels, u.created_at, u.updated_at,
+		       (u.xmax = 0) AS inserted,
+		       (u.xmax <> 0 AND (
+		           o.phase              IS DISTINCT FROM u.phase              OR
+		           o.storage_class_name IS DISTINCT FROM u.storage_class_name OR
+		           o.volume_name        IS DISTINCT FROM u.volume_name        OR
+		           o.bound_volume_id    IS DISTINCT FROM u.bound_volume_id    OR
+		           o.access_modes       IS DISTINCT FROM u.access_modes       OR
+		           o.requested_storage  IS DISTINCT FROM u.requested_storage  OR
+		           o.labels             IS DISTINCT FROM u.labels
 		       )) AS business_changed
-		  FROM upserted LEFT JOIN old o ON true
+		  FROM upserted u LEFT JOIN old o ON true
 	`
 	row := p.pool.QueryRow(ctx, q,
 		id, in.NamespaceId, in.Name,

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -4063,34 +4063,64 @@ func (p *PG) UpsertPersistentVolume(ctx context.Context, in api.PersistentVolume
 
 	labelsJSON, err := marshalLabels(in.Labels)
 	if err != nil {
-		return api.PersistentVolume{}, api.OutcomeBusinessChanged, err
+		return api.PersistentVolume{}, api.OutcomeNoChange, err
 	}
 
+	// AUDIT_BUSINESS_FIELDS: capacity, access_modes, reclaim_policy, phase,
+	// storage_class_name, csi_driver, volume_handle, claim_ref_namespace,
+	// claim_ref_name, labels. updated_at is a clock field — excluded.
 	const q = `
-		INSERT INTO persistent_volumes (
-			id, cluster_id, name, capacity, access_modes,
-			reclaim_policy, phase, storage_class_name,
-			csi_driver, volume_handle,
-			claim_ref_namespace, claim_ref_name,
-			labels, created_at, updated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $14)
-		ON CONFLICT (cluster_id, name) DO UPDATE SET
-			capacity            = EXCLUDED.capacity,
-			access_modes        = EXCLUDED.access_modes,
-			reclaim_policy      = EXCLUDED.reclaim_policy,
-			phase               = EXCLUDED.phase,
-			storage_class_name  = EXCLUDED.storage_class_name,
-			csi_driver          = EXCLUDED.csi_driver,
-			volume_handle       = EXCLUDED.volume_handle,
-			claim_ref_namespace = EXCLUDED.claim_ref_namespace,
-			claim_ref_name      = EXCLUDED.claim_ref_name,
-			labels              = EXCLUDED.labels,
-			updated_at          = EXCLUDED.updated_at
-		RETURNING id, cluster_id, name, capacity, access_modes,
-		          reclaim_policy, phase, storage_class_name,
-		          csi_driver, volume_handle,
-		          claim_ref_namespace, claim_ref_name,
-		          labels, created_at, updated_at
+		WITH old AS (
+		  SELECT capacity, access_modes, reclaim_policy, phase,
+		         storage_class_name, csi_driver, volume_handle,
+		         claim_ref_namespace, claim_ref_name, labels
+		    FROM persistent_volumes WHERE cluster_id=$2 AND name=$3
+		),
+		upserted AS (
+		  INSERT INTO persistent_volumes (
+		    id, cluster_id, name, capacity, access_modes,
+		    reclaim_policy, phase, storage_class_name,
+		    csi_driver, volume_handle,
+		    claim_ref_namespace, claim_ref_name,
+		    labels, created_at, updated_at
+		  ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $14)
+		  ON CONFLICT (cluster_id, name) DO UPDATE SET
+		      capacity            = EXCLUDED.capacity,
+		      access_modes        = EXCLUDED.access_modes,
+		      reclaim_policy      = EXCLUDED.reclaim_policy,
+		      phase               = EXCLUDED.phase,
+		      storage_class_name  = EXCLUDED.storage_class_name,
+		      csi_driver          = EXCLUDED.csi_driver,
+		      volume_handle       = EXCLUDED.volume_handle,
+		      claim_ref_namespace = EXCLUDED.claim_ref_namespace,
+		      claim_ref_name      = EXCLUDED.claim_ref_name,
+		      labels              = EXCLUDED.labels,
+		      updated_at          = EXCLUDED.updated_at
+		  RETURNING id, cluster_id, name, capacity, access_modes,
+		            reclaim_policy, phase, storage_class_name,
+		            csi_driver, volume_handle,
+		            claim_ref_namespace, claim_ref_name,
+		            labels, created_at, updated_at, xmax
+		)
+		SELECT id, cluster_id, name, capacity, access_modes,
+		       reclaim_policy, phase, storage_class_name,
+		       csi_driver, volume_handle,
+		       claim_ref_namespace, claim_ref_name,
+		       labels, created_at, updated_at,
+		       (xmax = 0) AS inserted,
+		       (xmax <> 0 AND (
+		           o.capacity            IS DISTINCT FROM upserted.capacity            OR
+		           o.access_modes        IS DISTINCT FROM upserted.access_modes        OR
+		           o.reclaim_policy      IS DISTINCT FROM upserted.reclaim_policy      OR
+		           o.phase               IS DISTINCT FROM upserted.phase               OR
+		           o.storage_class_name  IS DISTINCT FROM upserted.storage_class_name  OR
+		           o.csi_driver          IS DISTINCT FROM upserted.csi_driver          OR
+		           o.volume_handle       IS DISTINCT FROM upserted.volume_handle       OR
+		           o.claim_ref_namespace IS DISTINCT FROM upserted.claim_ref_namespace OR
+		           o.claim_ref_name      IS DISTINCT FROM upserted.claim_ref_name      OR
+		           o.labels              IS DISTINCT FROM upserted.labels
+		       )) AS business_changed
+		  FROM upserted LEFT JOIN old o ON true
 	`
 	row := p.pool.QueryRow(ctx, q,
 		id, in.ClusterId, in.Name,
@@ -4100,15 +4130,16 @@ func (p *PG) UpsertPersistentVolume(ctx context.Context, in api.PersistentVolume
 		in.ClaimRefNamespace, in.ClaimRefName,
 		labelsJSON, now,
 	)
-	pv, err := scanPersistentVolume(row)
+	var inserted, businessChanged bool
+	pv, err := scanPersistentVolume(scanRowWith{row: row, extra: []any{&inserted, &businessChanged}})
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
-			return api.PersistentVolume{}, api.OutcomeBusinessChanged, fmt.Errorf("cluster %s does not exist: %w", in.ClusterId, api.ErrNotFound)
+			return api.PersistentVolume{}, api.OutcomeNoChange, fmt.Errorf("cluster %s does not exist: %w", in.ClusterId, api.ErrNotFound)
 		}
-		return api.PersistentVolume{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert persistent volume: %w", err)
+		return api.PersistentVolume{}, api.OutcomeNoChange, fmt.Errorf("upsert persistent volume: %w", err)
 	}
-	return pv, api.OutcomeBusinessChanged, nil
+	return pv, classifyOutcome(inserted, businessChanged), nil
 }
 
 // DeletePersistentVolumesNotIn removes cluster-scoped PVs whose name is not in keepNames.

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -2962,50 +2962,137 @@ func (p *PG) DeleteIngress(ctx context.Context, id uuid.UUID) error {
 }
 
 // UpsertIngress inserts-or-updates an ingress keyed by (namespace_id, name).
+//
+//nolint:gocritic // hugeParam: Store interface requires value param
 func (p *PG) UpsertIngress(ctx context.Context, in api.IngressCreate) (api.Ingress, api.UpsertOutcome, error) {
 	id := uuid.New()
 	now := time.Now().UTC()
 
 	labelsJSON, err := marshalLabels(in.Labels)
 	if err != nil {
-		return api.Ingress{}, api.OutcomeBusinessChanged, err
+		return api.Ingress{}, api.OutcomeNoChange, err
 	}
 	rulesJSON, err := marshalPorts(in.Rules)
 	if err != nil {
-		return api.Ingress{}, api.OutcomeBusinessChanged, err
+		return api.Ingress{}, api.OutcomeNoChange, err
 	}
 	tlsJSON, err := marshalPorts(in.Tls)
 	if err != nil {
-		return api.Ingress{}, api.OutcomeBusinessChanged, err
+		return api.Ingress{}, api.OutcomeNoChange, err
 	}
 	lbJSON, err := marshalPorts(in.LoadBalancer)
 	if err != nil {
-		return api.Ingress{}, api.OutcomeBusinessChanged, err
+		return api.Ingress{}, api.OutcomeNoChange, err
 	}
 
-	q := `
-		INSERT INTO ingresses (` + ingressColumns + `) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$9)
-		ON CONFLICT (namespace_id, name) DO UPDATE SET
-			ingress_class_name = EXCLUDED.ingress_class_name,
-			rules              = EXCLUDED.rules,
-			tls                = EXCLUDED.tls,
-			load_balancer      = EXCLUDED.load_balancer,
-			labels             = EXCLUDED.labels,
-			updated_at         = EXCLUDED.updated_at
-		RETURNING ` + ingressColumns
+	// AUDIT_BUSINESS_FIELDS: ingress_class_name, rules, tls, load_balancer,
+	// labels. updated_at is a clock field — excluded from business_changed.
+	const q = `
+		WITH old AS (
+		  SELECT ingress_class_name, rules, tls, load_balancer, labels
+		    FROM ingresses WHERE namespace_id = $2 AND name = $3
+		),
+		upserted AS (
+		  INSERT INTO ingresses (
+		      id, namespace_id, name, ingress_class_name,
+		      rules, tls, load_balancer, labels, created_at, updated_at
+		  ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$9)
+		  ON CONFLICT (namespace_id, name) DO UPDATE SET
+		      ingress_class_name = EXCLUDED.ingress_class_name,
+		      rules              = EXCLUDED.rules,
+		      tls                = EXCLUDED.tls,
+		      load_balancer      = EXCLUDED.load_balancer,
+		      labels             = EXCLUDED.labels,
+		      updated_at         = EXCLUDED.updated_at
+		  RETURNING id, namespace_id, name, ingress_class_name,
+		            rules, tls, load_balancer, labels, created_at, updated_at,
+		            xmax
+		)
+		SELECT u.id, u.namespace_id, u.name, u.ingress_class_name,
+		       u.rules, u.tls, u.load_balancer, u.labels,
+		       u.created_at, u.updated_at,
+		       (u.xmax = 0) AS inserted,
+		       (u.xmax <> 0 AND (
+		           o.ingress_class_name IS DISTINCT FROM u.ingress_class_name OR
+		           o.rules              IS DISTINCT FROM u.rules              OR
+		           o.tls                IS DISTINCT FROM u.tls                OR
+		           o.load_balancer      IS DISTINCT FROM u.load_balancer      OR
+		           o.labels             IS DISTINCT FROM u.labels
+		       )) AS business_changed
+		  FROM upserted u LEFT JOIN old o ON true
+	`
+
 	row := p.pool.QueryRow(ctx, q,
 		id, in.NamespaceId, in.Name, in.IngressClassName,
 		rulesJSON, tlsJSON, lbJSON, labelsJSON, now,
 	)
-	ing, err := scanIngress(row)
-	if err != nil {
+
+	var (
+		i                api.Ingress
+		ingID            uuid.UUID
+		namespaceID      uuid.UUID
+		createdAt        time.Time
+		updatedAt        time.Time
+		ingressClassName sql.NullString
+		rulesOut         []byte
+		tlsOut           []byte
+		lbOut            []byte
+		labelsOut        []byte
+		inserted         bool
+		businessChanged  bool
+	)
+	if err := row.Scan(
+		&ingID, &namespaceID, &i.Name,
+		&ingressClassName,
+		&rulesOut, &tlsOut, &lbOut, &labelsOut,
+		&createdAt, &updatedAt,
+		&inserted, &businessChanged,
+	); err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
-			return api.Ingress{}, api.OutcomeBusinessChanged, fmt.Errorf("namespace %s does not exist: %w", in.NamespaceId, api.ErrNotFound)
+			return api.Ingress{}, api.OutcomeNoChange, fmt.Errorf("namespace %s does not exist: %w", in.NamespaceId, api.ErrNotFound)
 		}
-		return api.Ingress{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert ingress: %w", err)
+		return api.Ingress{}, api.OutcomeNoChange, fmt.Errorf("upsert ingress: %w", err)
 	}
-	return ing, api.OutcomeBusinessChanged, nil
+	i.Id = &ingID
+	i.NamespaceId = namespaceID
+	i.CreatedAt = &createdAt
+	i.UpdatedAt = &updatedAt
+	i.IngressClassName = nullableString(ingressClassName)
+	if len(rulesOut) > 0 {
+		var rules []map[string]interface{}
+		if err := json.Unmarshal(rulesOut, &rules); err != nil {
+			return api.Ingress{}, api.OutcomeNoChange, fmt.Errorf("unmarshal ingress rules: %w", err)
+		}
+		if len(rules) > 0 {
+			i.Rules = &rules
+		}
+	}
+	if len(tlsOut) > 0 {
+		var tls []map[string]interface{}
+		if err := json.Unmarshal(tlsOut, &tls); err != nil {
+			return api.Ingress{}, api.OutcomeNoChange, fmt.Errorf("unmarshal ingress tls: %w", err)
+		}
+		if len(tls) > 0 {
+			i.Tls = &tls
+		}
+	}
+	if lb, err := unmarshalMapArray(lbOut); err != nil {
+		return api.Ingress{}, api.OutcomeNoChange, fmt.Errorf("unmarshal ingress load_balancer: %w", err)
+	} else {
+		i.LoadBalancer = lb
+	}
+	if len(labelsOut) > 0 {
+		var labels map[string]string
+		if err := json.Unmarshal(labelsOut, &labels); err != nil {
+			return api.Ingress{}, api.OutcomeNoChange, fmt.Errorf("unmarshal ingress labels: %w", err)
+		}
+		if len(labels) > 0 {
+			i.Labels = &labels
+		}
+	}
+
+	return i, classifyOutcome(inserted, businessChanged), nil
 }
 
 // DeleteIngressesNotIn mirrors DeleteServicesNotIn.

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -58,8 +58,10 @@ func newTestPG(t *testing.T) *PG {
 		// auth tables stand on their own so TRUNCATE them alongside.
 		// api_tokens RESTRICTs on user deletion, so truncate them in
 		// order (api_tokens → users gets CASCADEd via sessions / identities).
+		// cloud_accounts is independent of clusters; CASCADE wipes
+		// virtual_machines via FK so the VM upsert tests see a clean slate.
 		_, _ = pg.pool.Exec(context.Background(),
-			"TRUNCATE clusters, image_versions, api_tokens, sessions, user_identities, oidc_auth_states, audit_events, users CASCADE")
+			"TRUNCATE clusters, cloud_accounts, image_versions, api_tokens, sessions, user_identities, oidc_auth_states, audit_events, users CASCADE")
 		pg.Close()
 	})
 	return pg

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -1579,6 +1579,177 @@ func TestPG_UpsertIngress_OutcomeBusinessChanged_PerField(t *testing.T) {
 	}
 }
 
+func TestPG_UpsertNode_OutcomeInserted(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "node-outcome-inserted"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+
+	role := "worker"
+	_, outcome, err := pg.UpsertNode(ctx, api.NodeCreate{
+		ClusterId: *cluster.Id,
+		Name:      "node-a",
+		Role:      &role,
+	})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if outcome != api.OutcomeInserted {
+		t.Errorf("first upsert outcome = %v, want Inserted", outcome)
+	}
+}
+
+func TestPG_UpsertNode_OutcomeNoChange_ClockOnly(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "node-outcome-nochange"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+
+	role := "worker"
+	kubeletV := "v1.29.0"
+	providerID := "aws:///us-east-1a/i-0123456789abcdef"
+	capCPU := "8"
+	allocMem := "15Gi"
+	unsched := false
+	ready := true
+	conditions := []map[string]interface{}{{"type": "Ready", "status": "True"}}
+	taints := []map[string]interface{}{{"key": "dedicated", "value": "gpu", "effect": "NoSchedule"}}
+	labels := map[string]string{"env": "prod"}
+	payload := api.NodeCreate{
+		ClusterId:         *cluster.Id,
+		Name:              "node-a",
+		Role:              &role,
+		KubeletVersion:    &kubeletV,
+		ProviderId:        &providerID,
+		CapacityCpu:       &capCPU,
+		AllocatableMemory: &allocMem,
+		Unschedulable:     &unsched,
+		Ready:             &ready,
+		Conditions:        &conditions,
+		Taints:            &taints,
+		Labels:            &labels,
+	}
+
+	if _, _, err := pg.UpsertNode(ctx, payload); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	_, outcome, err := pg.UpsertNode(ctx, payload)
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if outcome != api.OutcomeNoChange {
+		t.Errorf("identical second upsert outcome = %v, want NoChange", outcome)
+	}
+}
+
+//nolint:gocyclo // table-driven covers a representative slice of node business fields
+func TestPG_UpsertNode_OutcomeBusinessChanged_PerField(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "node-outcome-changed"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+
+	displayName := "node-a.example"
+	role := "worker"
+	kubeletV := "v1.29.0"
+	providerID := "aws:///us-east-1a/i-0123456789abcdef"
+	capCPU := "8"
+	allocMem := "15Gi"
+	unsched := false
+	ready := true
+	conditions := []map[string]interface{}{{"type": "Ready", "status": "True"}}
+	taints := []map[string]interface{}{{"key": "dedicated", "value": "gpu", "effect": "NoSchedule"}}
+	labels := map[string]string{"env": "prod"}
+	base := api.NodeCreate{
+		ClusterId:         *cluster.Id,
+		Name:              "node-a",
+		DisplayName:       &displayName,
+		Role:              &role,
+		KubeletVersion:    &kubeletV,
+		ProviderId:        &providerID,
+		CapacityCpu:       &capCPU,
+		AllocatableMemory: &allocMem,
+		Unschedulable:     &unsched,
+		Ready:             &ready,
+		Conditions:        &conditions,
+		Taints:            &taints,
+		Labels:            &labels,
+	}
+	if _, _, err := pg.UpsertNode(ctx, base); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	displayName2 := "node-a.alt.example"
+	role2 := "control-plane"
+	kubeletV2 := "v1.30.1"
+	providerID2 := "aws:///us-east-1b/i-99999999"
+	capCPU2 := "16"
+	allocMem2 := "30Gi"
+	unsched2 := true
+	ready2 := false
+	conditions2 := []map[string]interface{}{{"type": "Ready", "status": "False"}}
+	taints2 := []map[string]interface{}{{"key": "dedicated", "value": "cpu", "effect": "NoSchedule"}}
+	labels2 := map[string]string{"env": "stage"}
+
+	mutations := []struct {
+		name string
+		mut  func(p *api.NodeCreate)
+	}{
+		{"display_name", func(p *api.NodeCreate) { p.DisplayName = &displayName2 }},
+		{"role", func(p *api.NodeCreate) { p.Role = &role2 }},
+		{"kubelet_version", func(p *api.NodeCreate) { p.KubeletVersion = &kubeletV2 }},
+		{"provider_id", func(p *api.NodeCreate) { p.ProviderId = &providerID2 }},
+		{"capacity_cpu", func(p *api.NodeCreate) { p.CapacityCpu = &capCPU2 }},
+		{"allocatable_memory", func(p *api.NodeCreate) { p.AllocatableMemory = &allocMem2 }},
+		{"unschedulable", func(p *api.NodeCreate) { p.Unschedulable = &unsched2 }},
+		{"ready", func(p *api.NodeCreate) { p.Ready = &ready2 }},
+		{"conditions", func(p *api.NodeCreate) { p.Conditions = &conditions2 }},
+		{"taints", func(p *api.NodeCreate) { p.Taints = &taints2 }},
+		{"labels", func(p *api.NodeCreate) { p.Labels = &labels2 }},
+	}
+	for _, m := range mutations {
+		m := m
+		t.Run(m.name, func(t *testing.T) {
+			pl := base
+			m.mut(&pl)
+			_, outcome, err := pg.UpsertNode(ctx, pl)
+			if err != nil {
+				t.Fatalf("upsert: %v", err)
+			}
+			if outcome != api.OutcomeBusinessChanged {
+				t.Errorf("touching %s gave outcome=%v, want BusinessChanged", m.name, outcome)
+			}
+			if _, _, err := pg.UpsertNode(ctx, base); err != nil {
+				t.Fatalf("reset: %v", err)
+			}
+		})
+	}
+
+	// terminated_at restore: soft-delete then re-upsert should be BusinessChanged
+	// because terminated_at flips from non-NULL -> NULL.
+	t.Run("terminated_at_restore", func(t *testing.T) {
+		if _, err := pg.DeleteNodesNotIn(ctx, *cluster.Id, nil); err != nil {
+			t.Fatalf("soft-delete: %v", err)
+		}
+		_, outcome, err := pg.UpsertNode(ctx, base)
+		if err != nil {
+			t.Fatalf("restore upsert: %v", err)
+		}
+		if outcome != api.OutcomeBusinessChanged {
+			t.Errorf("restore upsert outcome = %v, want BusinessChanged", outcome)
+		}
+	})
+}
+
 // TestPGPodAndWorkloadContainersRoundTrip verifies the new containers JSONB
 // column survives an upsert + read cycle on both Pod and Workload. Each entity
 // type writes its own subset of fields into the generic map: Pod has

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -1874,6 +1874,158 @@ func TestPG_UpsertNamespace_OutcomeBusinessChanged_PerField(t *testing.T) {
 	})
 }
 
+func TestPG_UpsertPersistentVolume_OutcomeInserted(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "pv-outcome-inserted"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+
+	capacity := "10Gi"
+	_, outcome, err := pg.UpsertPersistentVolume(ctx, api.PersistentVolumeCreate{
+		ClusterId: *cluster.Id,
+		Name:      "pv-a",
+		Capacity:  &capacity,
+	})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if outcome != api.OutcomeInserted {
+		t.Errorf("first upsert outcome = %v, want Inserted", outcome)
+	}
+}
+
+func TestPG_UpsertPersistentVolume_OutcomeNoChange_ClockOnly(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "pv-outcome-nochange"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+
+	capacity := "10Gi"
+	modes := []string{"ReadWriteOnce"}
+	reclaim := "Retain"
+	phase := "Bound"
+	sc := "gp3"
+	driver := "ebs.csi.aws.com"
+	handle := "vol-abc"
+	claimNs := "apps"
+	claimName := "data-0"
+	labels := map[string]string{"tier": "fast"}
+	payload := api.PersistentVolumeCreate{
+		ClusterId:         *cluster.Id,
+		Name:              "pv-a",
+		Capacity:          &capacity,
+		AccessModes:       &modes,
+		ReclaimPolicy:     &reclaim,
+		Phase:             &phase,
+		StorageClassName:  &sc,
+		CsiDriver:         &driver,
+		VolumeHandle:      &handle,
+		ClaimRefNamespace: &claimNs,
+		ClaimRefName:      &claimName,
+		Labels:            &labels,
+	}
+
+	if _, _, err := pg.UpsertPersistentVolume(ctx, payload); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	_, outcome, err := pg.UpsertPersistentVolume(ctx, payload)
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if outcome != api.OutcomeNoChange {
+		t.Errorf("identical second upsert outcome = %v, want NoChange", outcome)
+	}
+}
+
+//nolint:gocyclo // table-driven covers a representative slice of PV business fields
+func TestPG_UpsertPersistentVolume_OutcomeBusinessChanged_PerField(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "pv-outcome-changed"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+
+	capacity := "10Gi"
+	modes := []string{"ReadWriteOnce"}
+	reclaim := "Retain"
+	phase := "Bound"
+	sc := "gp3"
+	driver := "ebs.csi.aws.com"
+	handle := "vol-abc"
+	claimNs := "apps"
+	claimName := "data-0"
+	labels := map[string]string{"tier": "fast"}
+	base := api.PersistentVolumeCreate{
+		ClusterId:         *cluster.Id,
+		Name:              "pv-a",
+		Capacity:          &capacity,
+		AccessModes:       &modes,
+		ReclaimPolicy:     &reclaim,
+		Phase:             &phase,
+		StorageClassName:  &sc,
+		CsiDriver:         &driver,
+		VolumeHandle:      &handle,
+		ClaimRefNamespace: &claimNs,
+		ClaimRefName:      &claimName,
+		Labels:            &labels,
+	}
+	if _, _, err := pg.UpsertPersistentVolume(ctx, base); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	capacity2 := "20Gi"
+	modes2 := []string{"ReadWriteMany"}
+	reclaim2 := "Delete"
+	phase2 := "Released"
+	sc2 := "io2"
+	driver2 := "efs.csi.aws.com"
+	handle2 := "vol-def"
+	claimNs2 := "other"
+	claimName2 := "data-1"
+	labels2 := map[string]string{"tier": "slow"}
+
+	mutations := []struct {
+		name string
+		mut  func(p *api.PersistentVolumeCreate)
+	}{
+		{"capacity", func(p *api.PersistentVolumeCreate) { p.Capacity = &capacity2 }},
+		{"access_modes", func(p *api.PersistentVolumeCreate) { p.AccessModes = &modes2 }},
+		{"reclaim_policy", func(p *api.PersistentVolumeCreate) { p.ReclaimPolicy = &reclaim2 }},
+		{"phase", func(p *api.PersistentVolumeCreate) { p.Phase = &phase2 }},
+		{"storage_class_name", func(p *api.PersistentVolumeCreate) { p.StorageClassName = &sc2 }},
+		{"csi_driver", func(p *api.PersistentVolumeCreate) { p.CsiDriver = &driver2 }},
+		{"volume_handle", func(p *api.PersistentVolumeCreate) { p.VolumeHandle = &handle2 }},
+		{"claim_ref_namespace", func(p *api.PersistentVolumeCreate) { p.ClaimRefNamespace = &claimNs2 }},
+		{"claim_ref_name", func(p *api.PersistentVolumeCreate) { p.ClaimRefName = &claimName2 }},
+		{"labels", func(p *api.PersistentVolumeCreate) { p.Labels = &labels2 }},
+	}
+	for _, m := range mutations {
+		m := m
+		t.Run(m.name, func(t *testing.T) {
+			pl := base
+			m.mut(&pl)
+			_, outcome, err := pg.UpsertPersistentVolume(ctx, pl)
+			if err != nil {
+				t.Fatalf("upsert: %v", err)
+			}
+			if outcome != api.OutcomeBusinessChanged {
+				t.Errorf("touching %s gave outcome=%v, want BusinessChanged", m.name, outcome)
+			}
+			if _, _, err := pg.UpsertPersistentVolume(ctx, base); err != nil {
+				t.Fatalf("reset: %v", err)
+			}
+		})
+	}
+}
+
 // TestPGPodAndWorkloadContainersRoundTrip verifies the new containers JSONB
 // column survives an upsert + read cycle on both Pod and Workload. Each entity
 // type writes its own subset of fields into the generic map: Pod has

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -1750,6 +1750,130 @@ func TestPG_UpsertNode_OutcomeBusinessChanged_PerField(t *testing.T) {
 	})
 }
 
+func TestPG_UpsertNamespace_OutcomeInserted(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "ns-outcome-inserted"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+
+	phase := "Active"
+	_, outcome, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
+		ClusterId: *cluster.Id,
+		Name:      "default",
+		Phase:     &phase,
+	})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if outcome != api.OutcomeInserted {
+		t.Errorf("first upsert outcome = %v, want Inserted", outcome)
+	}
+}
+
+func TestPG_UpsertNamespace_OutcomeNoChange_ClockOnly(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "ns-outcome-nochange"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+
+	displayName := "Default"
+	phase := "Active"
+	labels := map[string]string{"team": "platform"}
+	payload := api.NamespaceCreate{
+		ClusterId:   *cluster.Id,
+		Name:        "default",
+		DisplayName: &displayName,
+		Phase:       &phase,
+		Labels:      &labels,
+	}
+
+	if _, _, err := pg.UpsertNamespace(ctx, payload); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	_, outcome, err := pg.UpsertNamespace(ctx, payload)
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if outcome != api.OutcomeNoChange {
+		t.Errorf("identical second upsert outcome = %v, want NoChange", outcome)
+	}
+}
+
+func TestPG_UpsertNamespace_OutcomeBusinessChanged_PerField(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "ns-outcome-changed"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+
+	displayName := "Default"
+	phase := "Active"
+	labels := map[string]string{"team": "platform"}
+	base := api.NamespaceCreate{
+		ClusterId:   *cluster.Id,
+		Name:        "default",
+		DisplayName: &displayName,
+		Phase:       &phase,
+		Labels:      &labels,
+	}
+	if _, _, err := pg.UpsertNamespace(ctx, base); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	displayName2 := "Default (renamed)"
+	phase2 := "Terminating"
+	labels2 := map[string]string{"team": "infra"}
+
+	mutations := []struct {
+		name string
+		mut  func(p *api.NamespaceCreate)
+	}{
+		{"display_name", func(p *api.NamespaceCreate) { p.DisplayName = &displayName2 }},
+		{"phase", func(p *api.NamespaceCreate) { p.Phase = &phase2 }},
+		{"labels", func(p *api.NamespaceCreate) { p.Labels = &labels2 }},
+	}
+	for _, m := range mutations {
+		m := m
+		t.Run(m.name, func(t *testing.T) {
+			pl := base
+			m.mut(&pl)
+			_, outcome, err := pg.UpsertNamespace(ctx, pl)
+			if err != nil {
+				t.Fatalf("upsert: %v", err)
+			}
+			if outcome != api.OutcomeBusinessChanged {
+				t.Errorf("touching %s gave outcome=%v, want BusinessChanged", m.name, outcome)
+			}
+			if _, _, err := pg.UpsertNamespace(ctx, base); err != nil {
+				t.Fatalf("reset: %v", err)
+			}
+		})
+	}
+
+	// terminated_at restore: soft-delete then re-upsert should be BusinessChanged
+	// because terminated_at flips from non-NULL -> NULL.
+	t.Run("terminated_at_restore", func(t *testing.T) {
+		if _, err := pg.DeleteNamespacesNotIn(ctx, *cluster.Id, nil); err != nil {
+			t.Fatalf("soft-delete: %v", err)
+		}
+		_, outcome, err := pg.UpsertNamespace(ctx, base)
+		if err != nil {
+			t.Fatalf("restore upsert: %v", err)
+		}
+		if outcome != api.OutcomeBusinessChanged {
+			t.Errorf("restore upsert outcome = %v, want BusinessChanged", outcome)
+		}
+	})
+}
+
 // TestPGPodAndWorkloadContainersRoundTrip verifies the new containers JSONB
 // column survives an upsert + read cycle on both Pod and Workload. Each entity
 // type writes its own subset of fields into the generic map: Pod has

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -2026,6 +2026,146 @@ func TestPG_UpsertPersistentVolume_OutcomeBusinessChanged_PerField(t *testing.T)
 	}
 }
 
+func TestPG_UpsertPersistentVolumeClaim_OutcomeInserted(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "pvc-outcome-inserted"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+	ns, err := pg.CreateNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "apps"})
+	if err != nil {
+		t.Fatalf("namespace: %v", err)
+	}
+
+	phase := "Bound"
+	_, outcome, err := pg.UpsertPersistentVolumeClaim(ctx, api.PersistentVolumeClaimCreate{
+		NamespaceId: *ns.Id,
+		Name:        "data-0",
+		Phase:       &phase,
+	})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if outcome != api.OutcomeInserted {
+		t.Errorf("first upsert outcome = %v, want Inserted", outcome)
+	}
+}
+
+func TestPG_UpsertPersistentVolumeClaim_OutcomeNoChange_ClockOnly(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "pvc-outcome-nochange"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+	ns, err := pg.CreateNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "apps"})
+	if err != nil {
+		t.Fatalf("namespace: %v", err)
+	}
+
+	phase := "Bound"
+	sc := "gp3"
+	vol := "pv-a"
+	modes := []string{"ReadWriteOnce"}
+	req := "5Gi"
+	labels := map[string]string{"tier": "fast"}
+	payload := api.PersistentVolumeClaimCreate{
+		NamespaceId:      *ns.Id,
+		Name:             "data-0",
+		Phase:            &phase,
+		StorageClassName: &sc,
+		VolumeName:       &vol,
+		AccessModes:      &modes,
+		RequestedStorage: &req,
+		Labels:           &labels,
+	}
+
+	if _, _, err := pg.UpsertPersistentVolumeClaim(ctx, payload); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	_, outcome, err := pg.UpsertPersistentVolumeClaim(ctx, payload)
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if outcome != api.OutcomeNoChange {
+		t.Errorf("identical second upsert outcome = %v, want NoChange", outcome)
+	}
+}
+
+//nolint:gocyclo // table-driven covers a representative slice of PVC business fields
+func TestPG_UpsertPersistentVolumeClaim_OutcomeBusinessChanged_PerField(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "pvc-outcome-changed"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+	ns, err := pg.CreateNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "apps"})
+	if err != nil {
+		t.Fatalf("namespace: %v", err)
+	}
+
+	phase := "Bound"
+	sc := "gp3"
+	vol := "pv-a"
+	modes := []string{"ReadWriteOnce"}
+	req := "5Gi"
+	labels := map[string]string{"tier": "fast"}
+	base := api.PersistentVolumeClaimCreate{
+		NamespaceId:      *ns.Id,
+		Name:             "data-0",
+		Phase:            &phase,
+		StorageClassName: &sc,
+		VolumeName:       &vol,
+		AccessModes:      &modes,
+		RequestedStorage: &req,
+		Labels:           &labels,
+	}
+	if _, _, err := pg.UpsertPersistentVolumeClaim(ctx, base); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	phase2 := "Lost"
+	sc2 := "io2"
+	vol2 := "pv-b"
+	modes2 := []string{"ReadWriteMany"}
+	req2 := "10Gi"
+	labels2 := map[string]string{"tier": "slow"}
+
+	mutations := []struct {
+		name string
+		mut  func(p *api.PersistentVolumeClaimCreate)
+	}{
+		{"phase", func(p *api.PersistentVolumeClaimCreate) { p.Phase = &phase2 }},
+		{"storage_class_name", func(p *api.PersistentVolumeClaimCreate) { p.StorageClassName = &sc2 }},
+		{"volume_name", func(p *api.PersistentVolumeClaimCreate) { p.VolumeName = &vol2 }},
+		{"access_modes", func(p *api.PersistentVolumeClaimCreate) { p.AccessModes = &modes2 }},
+		{"requested_storage", func(p *api.PersistentVolumeClaimCreate) { p.RequestedStorage = &req2 }},
+		{"labels", func(p *api.PersistentVolumeClaimCreate) { p.Labels = &labels2 }},
+	}
+	for _, m := range mutations {
+		m := m
+		t.Run(m.name, func(t *testing.T) {
+			pl := base
+			m.mut(&pl)
+			_, outcome, err := pg.UpsertPersistentVolumeClaim(ctx, pl)
+			if err != nil {
+				t.Fatalf("upsert: %v", err)
+			}
+			if outcome != api.OutcomeBusinessChanged {
+				t.Errorf("touching %s gave outcome=%v, want BusinessChanged", m.name, outcome)
+			}
+			if _, _, err := pg.UpsertPersistentVolumeClaim(ctx, base); err != nil {
+				t.Fatalf("reset: %v", err)
+			}
+		})
+	}
+}
+
 // TestPGPodAndWorkloadContainersRoundTrip verifies the new containers JSONB
 // column survives an upsert + read cycle on both Pod and Workload. Each entity
 // type writes its own subset of fields into the generic map: Pod has

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -16,11 +16,21 @@ import (
 
 // Test-scoped string constants to satisfy goconst.
 const (
-	testPhaseActive    = "Active"
-	testKubeletVersion = "v1.30.3"
-	testOwner          = "team-platform"
-	testCriticality    = "critical"
-	testAnnotationSNC  = "snc"
+	testPhaseActive      = "Active"
+	testPhaseRunning     = "Running"
+	testPhaseTerminating = "Terminating"
+	testPhaseBound       = "Bound"
+	testKubeletVersion   = "v1.30.3"
+	testOwner            = "team-platform"
+	testCriticality      = "critical"
+	testAnnotationSNC    = "snc"
+	testIP1              = "10.0.0.1"
+	testImageNginx       = "nginx"
+	testRoleWorker       = "worker"
+	testQty15Gi          = "15Gi"
+	testQty10Gi          = "10Gi"
+	testQty5Gi           = "5Gi"
+	testStorageClassGP3  = "gp3"
 )
 
 // newTestPG returns a PG connected to PGX_TEST_DATABASE, or calls t.Skip
@@ -274,7 +284,7 @@ func TestPGNamespaceCRUD(t *testing.T) {
 		t.Errorf("unknown cluster should be ErrNotFound, got %v", err)
 	}
 
-	newPhase := "Terminating"
+	newPhase := testPhaseTerminating
 	updated, err := pg.UpdateNamespace(ctx, *ns.Id, api.NamespaceUpdate{Phase: &newPhase})
 	if err != nil {
 		t.Fatalf("update: %v", err)
@@ -686,7 +696,7 @@ func TestPGPodCRUD(t *testing.T) {
 		t.Fatalf("namespace: %v", err)
 	}
 
-	phase := "Running"
+	phase := testPhaseRunning
 	pod, err := pg.CreatePod(ctx, api.PodCreate{
 		NamespaceId: *ns.Id,
 		Name:        "coredns-abc",
@@ -795,7 +805,7 @@ func TestPG_UpsertPod_OutcomeInserted(t *testing.T) {
 		t.Fatalf("namespace: %v", err)
 	}
 
-	phase := "Running"
+	phase := testPhaseRunning
 	_, outcome, err := pg.UpsertPod(ctx, api.PodCreate{
 		NamespaceId: *ns.Id,
 		Name:        "pod-a",
@@ -822,7 +832,7 @@ func TestPG_UpsertPod_OutcomeNoChange_ClockOnly(t *testing.T) {
 		t.Fatalf("namespace: %v", err)
 	}
 
-	phase := "Running"
+	phase := testPhaseRunning
 	payload := api.PodCreate{NamespaceId: *ns.Id, Name: "pod-a", Phase: &phase}
 
 	if _, _, err := pg.UpsertPod(ctx, payload); err != nil {
@@ -852,7 +862,7 @@ func TestPG_UpsertPod_OutcomeBusinessChanged_PerField(t *testing.T) {
 
 	phaseRunning := "Running"
 	node1 := "node-1"
-	ip1 := "10.0.0.1"
+	ip1 := testIP1
 	base := api.PodCreate{
 		NamespaceId: *ns.Id, Name: "pod-a",
 		Phase: &phaseRunning, NodeName: &node1, PodIp: &ip1,
@@ -878,7 +888,6 @@ func TestPG_UpsertPod_OutcomeBusinessChanged_PerField(t *testing.T) {
 		{"containers", func(p *api.PodCreate) { p.Containers = &containers }},
 	}
 	for _, m := range mutations {
-		m := m
 		t.Run(m.name, func(t *testing.T) {
 			pl := base
 			m.mut(&pl)
@@ -1066,7 +1075,7 @@ func TestPGServiceCRUD(t *testing.T) {
 	}
 
 	svcType := api.ClusterIP
-	clusterIP := "10.0.0.1"
+	clusterIP := testIP1
 	svc, err := pg.CreateService(ctx, api.ServiceCreate{
 		NamespaceId: *ns.Id,
 		Name:        "web",
@@ -1168,7 +1177,7 @@ func TestPG_UpsertService_OutcomeInserted(t *testing.T) {
 		t.Fatalf("namespace: %v", err)
 	}
 
-	clusterIP := "10.0.0.1"
+	clusterIP := testIP1
 	svcType := api.ServiceType("ClusterIP")
 	_, outcome, err := pg.UpsertService(ctx, api.ServiceCreate{
 		NamespaceId: *ns.Id,
@@ -1197,7 +1206,7 @@ func TestPG_UpsertService_OutcomeNoChange_ClockOnly(t *testing.T) {
 		t.Fatalf("namespace: %v", err)
 	}
 
-	clusterIP := "10.0.0.1"
+	clusterIP := testIP1
 	svcType := api.ServiceType("ClusterIP")
 	payload := api.ServiceCreate{
 		NamespaceId: *ns.Id,
@@ -1231,7 +1240,7 @@ func TestPG_UpsertService_OutcomeBusinessChanged_PerField(t *testing.T) {
 		t.Fatalf("namespace: %v", err)
 	}
 
-	clusterIP := "10.0.0.1"
+	clusterIP := testIP1
 	svcType := api.ServiceType("ClusterIP")
 	sel1 := map[string]string{"app": "web"}
 	ports1 := []map[string]interface{}{{"port": float64(80), "protocol": "TCP"}}
@@ -1270,7 +1279,6 @@ func TestPG_UpsertService_OutcomeBusinessChanged_PerField(t *testing.T) {
 		{"labels", func(p *api.ServiceCreate) { p.Labels = &labels2 }},
 	}
 	for _, m := range mutations {
-		m := m
 		t.Run(m.name, func(t *testing.T) {
 			pl := base
 			m.mut(&pl)
@@ -1357,6 +1365,7 @@ func TestPG_UpsertWorkload_OutcomeNoChange_ClockOnly(t *testing.T) {
 	}
 }
 
+//nolint:gocyclo // table-driven covers a representative slice of workload business fields
 func TestPG_UpsertWorkload_OutcomeBusinessChanged_PerField(t *testing.T) {
 	pg := newTestPG(t)
 	ctx := context.Background()
@@ -1406,7 +1415,6 @@ func TestPG_UpsertWorkload_OutcomeBusinessChanged_PerField(t *testing.T) {
 		{"spec", func(p *api.WorkloadCreate) { p.Spec = &spec2 }},
 	}
 	for _, m := range mutations {
-		m := m
 		t.Run(m.name, func(t *testing.T) {
 			pl := base
 			m.mut(&pl)
@@ -1459,7 +1467,7 @@ func TestPG_UpsertIngress_OutcomeInserted(t *testing.T) {
 		t.Fatalf("namespace: %v", err)
 	}
 
-	cls := "nginx"
+	cls := testImageNginx
 	_, outcome, err := pg.UpsertIngress(ctx, api.IngressCreate{
 		NamespaceId:      *ns.Id,
 		Name:             "ing-a",
@@ -1486,7 +1494,7 @@ func TestPG_UpsertIngress_OutcomeNoChange_ClockOnly(t *testing.T) {
 		t.Fatalf("namespace: %v", err)
 	}
 
-	cls := "nginx"
+	cls := testImageNginx
 	rules := []map[string]interface{}{{"host": "a.example"}}
 	tls := []map[string]interface{}{{"secretName": "tls-a"}}
 	lb := []map[string]interface{}{{"ip": "1.2.3.4"}}
@@ -1526,7 +1534,7 @@ func TestPG_UpsertIngress_OutcomeBusinessChanged_PerField(t *testing.T) {
 		t.Fatalf("namespace: %v", err)
 	}
 
-	cls := "nginx"
+	cls := testImageNginx
 	rules1 := []map[string]interface{}{{"host": "a.example"}}
 	tls1 := []map[string]interface{}{{"secretName": "tls-a"}}
 	lb1 := []map[string]interface{}{{"ip": "1.2.3.4"}}
@@ -1561,7 +1569,6 @@ func TestPG_UpsertIngress_OutcomeBusinessChanged_PerField(t *testing.T) {
 		{"labels", func(p *api.IngressCreate) { p.Labels = &labels2 }},
 	}
 	for _, m := range mutations {
-		m := m
 		t.Run(m.name, func(t *testing.T) {
 			pl := base
 			m.mut(&pl)
@@ -1588,7 +1595,7 @@ func TestPG_UpsertNode_OutcomeInserted(t *testing.T) {
 		t.Fatalf("cluster: %v", err)
 	}
 
-	role := "worker"
+	role := testRoleWorker
 	_, outcome, err := pg.UpsertNode(ctx, api.NodeCreate{
 		ClusterId: *cluster.Id,
 		Name:      "node-a",
@@ -1611,11 +1618,11 @@ func TestPG_UpsertNode_OutcomeNoChange_ClockOnly(t *testing.T) {
 		t.Fatalf("cluster: %v", err)
 	}
 
-	role := "worker"
+	role := testRoleWorker
 	kubeletV := "v1.29.0"
 	providerID := "aws:///us-east-1a/i-0123456789abcdef"
 	capCPU := "8"
-	allocMem := "15Gi"
+	allocMem := testQty15Gi
 	unsched := false
 	ready := true
 	conditions := []map[string]interface{}{{"type": "Ready", "status": "True"}}
@@ -1648,7 +1655,6 @@ func TestPG_UpsertNode_OutcomeNoChange_ClockOnly(t *testing.T) {
 	}
 }
 
-//nolint:gocyclo // table-driven covers a representative slice of node business fields
 func TestPG_UpsertNode_OutcomeBusinessChanged_PerField(t *testing.T) {
 	pg := newTestPG(t)
 	ctx := context.Background()
@@ -1659,11 +1665,11 @@ func TestPG_UpsertNode_OutcomeBusinessChanged_PerField(t *testing.T) {
 	}
 
 	displayName := "node-a.example"
-	role := "worker"
+	role := testRoleWorker
 	kubeletV := "v1.29.0"
 	providerID := "aws:///us-east-1a/i-0123456789abcdef"
 	capCPU := "8"
-	allocMem := "15Gi"
+	allocMem := testQty15Gi
 	unsched := false
 	ready := true
 	conditions := []map[string]interface{}{{"type": "Ready", "status": "True"}}
@@ -1717,7 +1723,6 @@ func TestPG_UpsertNode_OutcomeBusinessChanged_PerField(t *testing.T) {
 		{"labels", func(p *api.NodeCreate) { p.Labels = &labels2 }},
 	}
 	for _, m := range mutations {
-		m := m
 		t.Run(m.name, func(t *testing.T) {
 			pl := base
 			m.mut(&pl)
@@ -1759,7 +1764,7 @@ func TestPG_UpsertNamespace_OutcomeInserted(t *testing.T) {
 		t.Fatalf("cluster: %v", err)
 	}
 
-	phase := "Active"
+	phase := testPhaseActive
 	_, outcome, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
 		ClusterId: *cluster.Id,
 		Name:      "default",
@@ -1783,7 +1788,7 @@ func TestPG_UpsertNamespace_OutcomeNoChange_ClockOnly(t *testing.T) {
 	}
 
 	displayName := "Default"
-	phase := "Active"
+	phase := testPhaseActive
 	labels := map[string]string{"team": "platform"}
 	payload := api.NamespaceCreate{
 		ClusterId:   *cluster.Id,
@@ -1815,7 +1820,7 @@ func TestPG_UpsertNamespace_OutcomeBusinessChanged_PerField(t *testing.T) {
 	}
 
 	displayName := "Default"
-	phase := "Active"
+	phase := testPhaseActive
 	labels := map[string]string{"team": "platform"}
 	base := api.NamespaceCreate{
 		ClusterId:   *cluster.Id,
@@ -1841,7 +1846,6 @@ func TestPG_UpsertNamespace_OutcomeBusinessChanged_PerField(t *testing.T) {
 		{"labels", func(p *api.NamespaceCreate) { p.Labels = &labels2 }},
 	}
 	for _, m := range mutations {
-		m := m
 		t.Run(m.name, func(t *testing.T) {
 			pl := base
 			m.mut(&pl)
@@ -1883,7 +1887,7 @@ func TestPG_UpsertPersistentVolume_OutcomeInserted(t *testing.T) {
 		t.Fatalf("cluster: %v", err)
 	}
 
-	capacity := "10Gi"
+	capacity := testQty10Gi
 	_, outcome, err := pg.UpsertPersistentVolume(ctx, api.PersistentVolumeCreate{
 		ClusterId: *cluster.Id,
 		Name:      "pv-a",
@@ -1906,11 +1910,11 @@ func TestPG_UpsertPersistentVolume_OutcomeNoChange_ClockOnly(t *testing.T) {
 		t.Fatalf("cluster: %v", err)
 	}
 
-	capacity := "10Gi"
+	capacity := testQty10Gi
 	modes := []string{"ReadWriteOnce"}
 	reclaim := "Retain"
-	phase := "Bound"
-	sc := "gp3"
+	phase := testPhaseBound
+	sc := testStorageClassGP3
 	driver := "ebs.csi.aws.com"
 	handle := "vol-abc"
 	claimNs := "apps"
@@ -1943,7 +1947,6 @@ func TestPG_UpsertPersistentVolume_OutcomeNoChange_ClockOnly(t *testing.T) {
 	}
 }
 
-//nolint:gocyclo // table-driven covers a representative slice of PV business fields
 func TestPG_UpsertPersistentVolume_OutcomeBusinessChanged_PerField(t *testing.T) {
 	pg := newTestPG(t)
 	ctx := context.Background()
@@ -1953,11 +1956,11 @@ func TestPG_UpsertPersistentVolume_OutcomeBusinessChanged_PerField(t *testing.T)
 		t.Fatalf("cluster: %v", err)
 	}
 
-	capacity := "10Gi"
+	capacity := testQty10Gi
 	modes := []string{"ReadWriteOnce"}
 	reclaim := "Retain"
-	phase := "Bound"
-	sc := "gp3"
+	phase := testPhaseBound
+	sc := testStorageClassGP3
 	driver := "ebs.csi.aws.com"
 	handle := "vol-abc"
 	claimNs := "apps"
@@ -2008,7 +2011,6 @@ func TestPG_UpsertPersistentVolume_OutcomeBusinessChanged_PerField(t *testing.T)
 		{"labels", func(p *api.PersistentVolumeCreate) { p.Labels = &labels2 }},
 	}
 	for _, m := range mutations {
-		m := m
 		t.Run(m.name, func(t *testing.T) {
 			pl := base
 			m.mut(&pl)
@@ -2039,7 +2041,7 @@ func TestPG_UpsertPersistentVolumeClaim_OutcomeInserted(t *testing.T) {
 		t.Fatalf("namespace: %v", err)
 	}
 
-	phase := "Bound"
+	phase := testPhaseBound
 	_, outcome, err := pg.UpsertPersistentVolumeClaim(ctx, api.PersistentVolumeClaimCreate{
 		NamespaceId: *ns.Id,
 		Name:        "data-0",
@@ -2066,11 +2068,11 @@ func TestPG_UpsertPersistentVolumeClaim_OutcomeNoChange_ClockOnly(t *testing.T) 
 		t.Fatalf("namespace: %v", err)
 	}
 
-	phase := "Bound"
-	sc := "gp3"
+	phase := testPhaseBound
+	sc := testStorageClassGP3
 	vol := "pv-a"
 	modes := []string{"ReadWriteOnce"}
-	req := "5Gi"
+	req := testQty5Gi
 	labels := map[string]string{"tier": "fast"}
 	payload := api.PersistentVolumeClaimCreate{
 		NamespaceId:      *ns.Id,
@@ -2095,7 +2097,6 @@ func TestPG_UpsertPersistentVolumeClaim_OutcomeNoChange_ClockOnly(t *testing.T) 
 	}
 }
 
-//nolint:gocyclo // table-driven covers a representative slice of PVC business fields
 func TestPG_UpsertPersistentVolumeClaim_OutcomeBusinessChanged_PerField(t *testing.T) {
 	pg := newTestPG(t)
 	ctx := context.Background()
@@ -2109,11 +2110,11 @@ func TestPG_UpsertPersistentVolumeClaim_OutcomeBusinessChanged_PerField(t *testi
 		t.Fatalf("namespace: %v", err)
 	}
 
-	phase := "Bound"
-	sc := "gp3"
+	phase := testPhaseBound
+	sc := testStorageClassGP3
 	vol := "pv-a"
 	modes := []string{"ReadWriteOnce"}
-	req := "5Gi"
+	req := testQty5Gi
 	labels := map[string]string{"tier": "fast"}
 	base := api.PersistentVolumeClaimCreate{
 		NamespaceId:      *ns.Id,
@@ -2148,7 +2149,6 @@ func TestPG_UpsertPersistentVolumeClaim_OutcomeBusinessChanged_PerField(t *testi
 		{"labels", func(p *api.PersistentVolumeClaimCreate) { p.Labels = &labels2 }},
 	}
 	for _, m := range mutations {
-		m := m
 		t.Run(m.name, func(t *testing.T) {
 			pl := base
 			m.mut(&pl)
@@ -2433,7 +2433,7 @@ func TestPGPersistentVolumeAndClaimFK(t *testing.T) {
 		t.Fatalf("namespace: %v", err)
 	}
 
-	capacity := "10Gi"
+	capacity := testQty10Gi
 	modes := []string{"ReadWriteOnce"}
 	pv, err := pg.CreatePersistentVolume(ctx, api.PersistentVolumeCreate{
 		ClusterId:   *cluster.Id,
@@ -2452,7 +2452,7 @@ func TestPGPersistentVolumeAndClaimFK(t *testing.T) {
 	}
 
 	// PVC bound to the PV — FK round-trip.
-	req := "5Gi"
+	req := testQty5Gi
 	pvc, err := pg.CreatePersistentVolumeClaim(ctx, api.PersistentVolumeClaimCreate{
 		NamespaceId:      *ns.Id,
 		Name:             "data-0",
@@ -2571,7 +2571,8 @@ func TestPGListFiltersForImageAndNode(t *testing.T) {
 	if _, _, err := pg.UpsertPod(ctx, api.PodCreate{NamespaceId: *ns.Id, Name: "api-1", NodeName: &node1, Containers: &log4jContainers}); err != nil {
 		t.Fatalf("api-1: %v", err)
 	}
-	if _, _, err := pg.UpsertPod(ctx, api.PodCreate{NamespaceId: *ns.Id, Name: "misc-1", NodeName: &node2, Containers: &otherContainers}); err != nil {
+	miscPod := api.PodCreate{NamespaceId: *ns.Id, Name: "misc-1", NodeName: &node2, Containers: &otherContainers}
+	if _, _, err := pg.UpsertPod(ctx, miscPod); err != nil {
 		t.Fatalf("misc-1: %v", err)
 	}
 
@@ -2715,7 +2716,7 @@ func TestPGAuthSubstrate(t *testing.T) {
 		CreatedAt: now,
 		ExpiresAt: expires,
 		UserAgent: "go-test/1.0",
-		SourceIP:  "10.0.0.1",
+		SourceIP:  testIP1,
 	}); err != nil {
 		t.Fatalf("create session: %v", err)
 	}
@@ -2805,7 +2806,7 @@ func TestPGNodeEnrichmentRoundTrip(t *testing.T) {
 		t.Fatalf("cluster: %v", err)
 	}
 
-	role := "worker"
+	role := testRoleWorker
 	kubeletV := testKubeletVersion
 	kubeProxyV := testKubeletVersion
 	runtimeV := "containerd://1.7.13"
@@ -2824,7 +2825,7 @@ func TestPGNodeEnrichmentRoundTrip(t *testing.T) {
 	capPods := "110"
 	capEph := "100Gi"
 	allocCPU := "3900m"
-	allocMem := "15Gi"
+	allocMem := testQty15Gi
 	allocPods := "110"
 	allocEph := "95Gi"
 	unschedulable := false
@@ -3095,7 +3096,7 @@ func TestPGAuditEventsRoundTrip(t *testing.T) {
 			ActorID: &userID, ActorKind: "user", ActorUsername: "alice", ActorRole: "admin",
 			Action: "cluster.create", ResourceType: "cluster", ResourceID: "c1",
 			HTTPMethod: "POST", HTTPPath: "/v1/clusters", HTTPStatus: 201,
-			SourceIP: "10.0.0.1", UserAgent: "curl/8",
+			SourceIP: testIP1, UserAgent: "curl/8",
 			Details: map[string]any{"body": map[string]any{"name": "prod"}},
 		},
 		{
@@ -3472,7 +3473,7 @@ func TestPGNodeCuratedMetadata(t *testing.T) {
 	// fields populated and every curated/hardware_model field nil. The
 	// PG DO UPDATE SET clause deliberately omits the curated columns
 	// and hardware_model, so the operator-set values must survive.
-	role := "worker"
+	role := testRoleWorker
 	kubelet := testKubeletVersion
 	osImage := "Ubuntu 22.04.4 LTS"
 	labels := map[string]string{"kubernetes.io/hostname": nodeName}

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -1446,6 +1446,139 @@ func TestPG_UpsertWorkload_OutcomeBusinessChanged_PerField(t *testing.T) {
 	})
 }
 
+func TestPG_UpsertIngress_OutcomeInserted(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "ing-outcome-inserted"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+	ns, err := pg.CreateNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "default"})
+	if err != nil {
+		t.Fatalf("namespace: %v", err)
+	}
+
+	cls := "nginx"
+	_, outcome, err := pg.UpsertIngress(ctx, api.IngressCreate{
+		NamespaceId:      *ns.Id,
+		Name:             "ing-a",
+		IngressClassName: &cls,
+	})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if outcome != api.OutcomeInserted {
+		t.Errorf("first upsert outcome = %v, want Inserted", outcome)
+	}
+}
+
+func TestPG_UpsertIngress_OutcomeNoChange_ClockOnly(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "ing-outcome-nochange"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+	ns, err := pg.CreateNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "default"})
+	if err != nil {
+		t.Fatalf("namespace: %v", err)
+	}
+
+	cls := "nginx"
+	rules := []map[string]interface{}{{"host": "a.example"}}
+	tls := []map[string]interface{}{{"secretName": "tls-a"}}
+	lb := []map[string]interface{}{{"ip": "1.2.3.4"}}
+	labels := map[string]string{"env": "prod"}
+	payload := api.IngressCreate{
+		NamespaceId:      *ns.Id,
+		Name:             "ing-a",
+		IngressClassName: &cls,
+		Rules:            &rules,
+		Tls:              &tls,
+		LoadBalancer:     &lb,
+		Labels:           &labels,
+	}
+
+	if _, _, err := pg.UpsertIngress(ctx, payload); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	_, outcome, err := pg.UpsertIngress(ctx, payload)
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if outcome != api.OutcomeNoChange {
+		t.Errorf("identical second upsert outcome = %v, want NoChange", outcome)
+	}
+}
+
+func TestPG_UpsertIngress_OutcomeBusinessChanged_PerField(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "ing-outcome-changed"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+	ns, err := pg.CreateNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "default"})
+	if err != nil {
+		t.Fatalf("namespace: %v", err)
+	}
+
+	cls := "nginx"
+	rules1 := []map[string]interface{}{{"host": "a.example"}}
+	tls1 := []map[string]interface{}{{"secretName": "tls-a"}}
+	lb1 := []map[string]interface{}{{"ip": "1.2.3.4"}}
+	labels1 := map[string]string{"k": "v"}
+	base := api.IngressCreate{
+		NamespaceId:      *ns.Id,
+		Name:             "ing-a",
+		IngressClassName: &cls,
+		Rules:            &rules1,
+		Tls:              &tls1,
+		LoadBalancer:     &lb1,
+		Labels:           &labels1,
+	}
+	if _, _, err := pg.UpsertIngress(ctx, base); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	cls2 := "traefik"
+	rules2 := []map[string]interface{}{{"host": "b.example"}}
+	tls2 := []map[string]interface{}{{"secretName": "tls-b"}}
+	lb2 := []map[string]interface{}{{"ip": "5.6.7.8"}}
+	labels2 := map[string]string{"k": "v2"}
+
+	mutations := []struct {
+		name string
+		mut  func(p *api.IngressCreate)
+	}{
+		{"ingress_class_name", func(p *api.IngressCreate) { p.IngressClassName = &cls2 }},
+		{"rules", func(p *api.IngressCreate) { p.Rules = &rules2 }},
+		{"tls", func(p *api.IngressCreate) { p.Tls = &tls2 }},
+		{"load_balancer", func(p *api.IngressCreate) { p.LoadBalancer = &lb2 }},
+		{"labels", func(p *api.IngressCreate) { p.Labels = &labels2 }},
+	}
+	for _, m := range mutations {
+		m := m
+		t.Run(m.name, func(t *testing.T) {
+			pl := base
+			m.mut(&pl)
+			_, outcome, err := pg.UpsertIngress(ctx, pl)
+			if err != nil {
+				t.Fatalf("upsert: %v", err)
+			}
+			if outcome != api.OutcomeBusinessChanged {
+				t.Errorf("touching %s gave outcome=%v, want BusinessChanged", m.name, outcome)
+			}
+			if _, _, err := pg.UpsertIngress(ctx, base); err != nil {
+				t.Fatalf("reset: %v", err)
+			}
+		})
+	}
+}
+
 // TestPGPodAndWorkloadContainersRoundTrip verifies the new containers JSONB
 // column survives an upsert + read cycle on both Pod and Workload. Each entity
 // type writes its own subset of fields into the generic map: Pod has

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -1288,6 +1288,164 @@ func TestPG_UpsertService_OutcomeBusinessChanged_PerField(t *testing.T) {
 	}
 }
 
+func TestPG_UpsertWorkload_OutcomeInserted(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "wl-outcome-inserted"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+	ns, err := pg.CreateNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "default"})
+	if err != nil {
+		t.Fatalf("namespace: %v", err)
+	}
+
+	replicas := 3
+	_, outcome, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{
+		NamespaceId: *ns.Id,
+		Kind:        api.Deployment,
+		Name:        "wl-a",
+		Replicas:    &replicas,
+	})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if outcome != api.OutcomeInserted {
+		t.Errorf("first upsert outcome = %v, want Inserted", outcome)
+	}
+}
+
+func TestPG_UpsertWorkload_OutcomeNoChange_ClockOnly(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "wl-outcome-nochange"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+	ns, err := pg.CreateNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "default"})
+	if err != nil {
+		t.Fatalf("namespace: %v", err)
+	}
+
+	replicas := 3
+	readyReplicas := 2
+	containers := api.ContainerList{{"name": "app", "image": "nginx:1.27"}}
+	labels := map[string]string{"k": "v"}
+	spec := map[string]interface{}{"strategy": "RollingUpdate"}
+	payload := api.WorkloadCreate{
+		NamespaceId:   *ns.Id,
+		Kind:          api.Deployment,
+		Name:          "wl-a",
+		Replicas:      &replicas,
+		ReadyReplicas: &readyReplicas,
+		Containers:    &containers,
+		Labels:        &labels,
+		Spec:          &spec,
+	}
+
+	if _, _, err := pg.UpsertWorkload(ctx, payload); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	_, outcome, err := pg.UpsertWorkload(ctx, payload)
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if outcome != api.OutcomeNoChange {
+		t.Errorf("identical second upsert outcome = %v, want NoChange", outcome)
+	}
+}
+
+func TestPG_UpsertWorkload_OutcomeBusinessChanged_PerField(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "wl-outcome-changed"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+	ns, err := pg.CreateNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "default"})
+	if err != nil {
+		t.Fatalf("namespace: %v", err)
+	}
+
+	replicas := 3
+	readyReplicas := 2
+	containers := api.ContainerList{{"name": "app", "image": "nginx:1.27"}}
+	labels := map[string]string{"k": "v"}
+	spec := map[string]interface{}{"strategy": "RollingUpdate"}
+	base := api.WorkloadCreate{
+		NamespaceId:   *ns.Id,
+		Kind:          api.Deployment,
+		Name:          "wl-a",
+		Replicas:      &replicas,
+		ReadyReplicas: &readyReplicas,
+		Containers:    &containers,
+		Labels:        &labels,
+		Spec:          &spec,
+	}
+	if _, _, err := pg.UpsertWorkload(ctx, base); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	replicas2 := 5
+	readyReplicas2 := 4
+	containers2 := api.ContainerList{{"name": "app", "image": "nginx:1.28"}}
+	labels2 := map[string]string{"k": "v2"}
+	spec2 := map[string]interface{}{"strategy": "Recreate"}
+
+	mutations := []struct {
+		name string
+		mut  func(p *api.WorkloadCreate)
+	}{
+		{"replicas", func(p *api.WorkloadCreate) { p.Replicas = &replicas2 }},
+		{"ready_replicas", func(p *api.WorkloadCreate) { p.ReadyReplicas = &readyReplicas2 }},
+		{"containers", func(p *api.WorkloadCreate) { p.Containers = &containers2 }},
+		{"labels", func(p *api.WorkloadCreate) { p.Labels = &labels2 }},
+		{"spec", func(p *api.WorkloadCreate) { p.Spec = &spec2 }},
+	}
+	for _, m := range mutations {
+		m := m
+		t.Run(m.name, func(t *testing.T) {
+			pl := base
+			m.mut(&pl)
+			_, outcome, err := pg.UpsertWorkload(ctx, pl)
+			if err != nil {
+				t.Fatalf("upsert: %v", err)
+			}
+			if outcome != api.OutcomeBusinessChanged {
+				t.Errorf("touching %s gave outcome=%v, want BusinessChanged", m.name, outcome)
+			}
+			if _, _, err := pg.UpsertWorkload(ctx, base); err != nil {
+				t.Fatalf("reset: %v", err)
+			}
+		})
+	}
+
+	// terminated_at restore: soft-delete then re-upsert should be BusinessChanged
+	// because terminated_at flips from non-NULL -> NULL.
+	t.Run("terminated_at_restore", func(t *testing.T) {
+		// Soft-delete by excluding this workload from the keep list.
+		if _, err := pg.DeleteWorkloadsNotIn(ctx, *ns.Id,
+			[]string{"OtherKind"}, []string{"never"}); err != nil {
+			t.Fatalf("soft-delete: %v", err)
+		}
+		// Re-upsert the same base payload — terminated_at flips NULL.
+		_, outcome, err := pg.UpsertWorkload(ctx, base)
+		if err != nil {
+			t.Fatalf("restore upsert: %v", err)
+		}
+		if outcome != api.OutcomeBusinessChanged {
+			t.Errorf("restore upsert outcome = %v, want BusinessChanged", outcome)
+		}
+		// Reset for any subsequent sub-tests (none here, but keeps invariant).
+		if _, _, err := pg.UpsertWorkload(ctx, base); err != nil {
+			t.Fatalf("reset after restore: %v", err)
+		}
+	})
+}
+
 // TestPGPodAndWorkloadContainersRoundTrip verifies the new containers JSONB
 // column survives an upsert + read cycle on both Pod and Workload. Each entity
 // type writes its own subset of fields into the generic map: Pod has

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -1155,6 +1155,139 @@ func TestPGUpsertServiceAndDeleteNotIn(t *testing.T) {
 	}
 }
 
+func TestPG_UpsertService_OutcomeInserted(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "svc-outcome-inserted"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+	ns, err := pg.CreateNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "default"})
+	if err != nil {
+		t.Fatalf("namespace: %v", err)
+	}
+
+	clusterIP := "10.0.0.1"
+	svcType := api.ServiceType("ClusterIP")
+	_, outcome, err := pg.UpsertService(ctx, api.ServiceCreate{
+		NamespaceId: *ns.Id,
+		Name:        "svc-a",
+		Type:        &svcType,
+		ClusterIp:   &clusterIP,
+	})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if outcome != api.OutcomeInserted {
+		t.Errorf("first upsert outcome = %v, want Inserted", outcome)
+	}
+}
+
+func TestPG_UpsertService_OutcomeNoChange_ClockOnly(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "svc-outcome-nochange"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+	ns, err := pg.CreateNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "default"})
+	if err != nil {
+		t.Fatalf("namespace: %v", err)
+	}
+
+	clusterIP := "10.0.0.1"
+	svcType := api.ServiceType("ClusterIP")
+	payload := api.ServiceCreate{
+		NamespaceId: *ns.Id,
+		Name:        "svc-a",
+		Type:        &svcType,
+		ClusterIp:   &clusterIP,
+	}
+
+	if _, _, err := pg.UpsertService(ctx, payload); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	_, outcome, err := pg.UpsertService(ctx, payload)
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if outcome != api.OutcomeNoChange {
+		t.Errorf("identical second upsert outcome = %v, want NoChange", outcome)
+	}
+}
+
+func TestPG_UpsertService_OutcomeBusinessChanged_PerField(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "svc-outcome-changed"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+	ns, err := pg.CreateNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "default"})
+	if err != nil {
+		t.Fatalf("namespace: %v", err)
+	}
+
+	clusterIP := "10.0.0.1"
+	svcType := api.ServiceType("ClusterIP")
+	sel1 := map[string]string{"app": "web"}
+	ports1 := []map[string]interface{}{{"port": float64(80), "protocol": "TCP"}}
+	lb1 := []map[string]interface{}{{"ip": "0.0.0.0"}}
+	labels1 := map[string]string{"env": "prod"}
+	base := api.ServiceCreate{
+		NamespaceId:  *ns.Id,
+		Name:         "svc-a",
+		Type:         &svcType,
+		ClusterIp:    &clusterIP,
+		Selector:     &sel1,
+		Ports:        &ports1,
+		LoadBalancer: &lb1,
+		Labels:       &labels1,
+	}
+	if _, _, err := pg.UpsertService(ctx, base); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	svcType2 := api.ServiceType("NodePort")
+	ip2 := "10.0.0.2"
+	sel2 := map[string]string{"app": "v2"}
+	ports2 := []map[string]interface{}{{"port": float64(8080), "protocol": "TCP"}}
+	lb2 := []map[string]interface{}{{"ip": "1.2.3.4"}}
+	labels2 := map[string]string{"k": "v"}
+
+	mutations := []struct {
+		name string
+		mut  func(p *api.ServiceCreate)
+	}{
+		{"type", func(p *api.ServiceCreate) { p.Type = &svcType2 }},
+		{"cluster_ip", func(p *api.ServiceCreate) { p.ClusterIp = &ip2 }},
+		{"selector", func(p *api.ServiceCreate) { p.Selector = &sel2 }},
+		{"ports", func(p *api.ServiceCreate) { p.Ports = &ports2 }},
+		{"load_balancer", func(p *api.ServiceCreate) { p.LoadBalancer = &lb2 }},
+		{"labels", func(p *api.ServiceCreate) { p.Labels = &labels2 }},
+	}
+	for _, m := range mutations {
+		m := m
+		t.Run(m.name, func(t *testing.T) {
+			pl := base
+			m.mut(&pl)
+			_, outcome, err := pg.UpsertService(ctx, pl)
+			if err != nil {
+				t.Fatalf("upsert: %v", err)
+			}
+			if outcome != api.OutcomeBusinessChanged {
+				t.Errorf("touching %s gave outcome=%v, want BusinessChanged", m.name, outcome)
+			}
+			if _, _, err := pg.UpsertService(ctx, base); err != nil {
+				t.Fatalf("reset: %v", err)
+			}
+		})
+	}
+}
+
 // TestPGPodAndWorkloadContainersRoundTrip verifies the new containers JSONB
 // column survives an upsert + read cycle on both Pod and Workload. Each entity
 // type writes its own subset of fields into the generic map: Pod has

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -206,7 +206,7 @@ func TestPGUpsertNode(t *testing.T) {
 	}
 
 	kv1 := "v1.29.5"
-	first, err := pg.UpsertNode(ctx, api.NodeCreate{
+	first, _, err := pg.UpsertNode(ctx, api.NodeCreate{
 		ClusterId:      *cluster.Id,
 		Name:           "node-a",
 		KubeletVersion: &kv1,
@@ -220,7 +220,7 @@ func TestPGUpsertNode(t *testing.T) {
 
 	// Second upsert with new kubelet version must mutate the SAME row.
 	kv2 := "v1.29.6"
-	second, err := pg.UpsertNode(ctx, api.NodeCreate{
+	second, _, err := pg.UpsertNode(ctx, api.NodeCreate{
 		ClusterId:      *cluster.Id,
 		Name:           "node-a",
 		KubeletVersion: &kv2,
@@ -242,7 +242,7 @@ func TestPGUpsertNode(t *testing.T) {
 	}
 
 	// Unknown cluster yields NotFound, not Conflict.
-	if _, err := pg.UpsertNode(ctx, api.NodeCreate{ClusterId: uuid.New(), Name: "x"}); !errors.Is(err, api.ErrNotFound) {
+	if _, _, err := pg.UpsertNode(ctx, api.NodeCreate{ClusterId: uuid.New(), Name: "x"}); !errors.Is(err, api.ErrNotFound) {
 		t.Errorf("upsert with unknown cluster: want ErrNotFound, got %v", err)
 	}
 }
@@ -310,7 +310,7 @@ func TestPGUpsertNamespace(t *testing.T) {
 	}
 
 	phaseA := testPhaseActive
-	first, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
+	first, _, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
 		ClusterId: *cluster.Id,
 		Name:      "default",
 		Phase:     &phaseA,
@@ -320,7 +320,7 @@ func TestPGUpsertNamespace(t *testing.T) {
 	}
 
 	phaseB := "Terminating"
-	second, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
+	second, _, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
 		ClusterId: *cluster.Id,
 		Name:      "default",
 		Phase:     &phaseB,
@@ -505,7 +505,7 @@ func TestPGUpsertNode_ResurrectsTerminated(t *testing.T) {
 		t.Fatalf("cluster: %v", err)
 	}
 
-	first, err := pg.UpsertNode(ctx, api.NodeCreate{ClusterId: *cluster.Id, Name: "node-a"})
+	first, _, err := pg.UpsertNode(ctx, api.NodeCreate{ClusterId: *cluster.Id, Name: "node-a"})
 	if err != nil {
 		t.Fatalf("first upsert: %v", err)
 	}
@@ -523,7 +523,7 @@ func TestPGUpsertNode_ResurrectsTerminated(t *testing.T) {
 		t.Fatalf("terminated_at should be non-NULL after soft-delete")
 	}
 
-	resurrected, err := pg.UpsertNode(ctx, api.NodeCreate{ClusterId: *cluster.Id, Name: "node-a"})
+	resurrected, _, err := pg.UpsertNode(ctx, api.NodeCreate{ClusterId: *cluster.Id, Name: "node-a"})
 	if err != nil {
 		t.Fatalf("resurrect upsert: %v", err)
 	}
@@ -551,7 +551,7 @@ func TestPGUpsertNamespace_ResurrectsTerminated(t *testing.T) {
 		t.Fatalf("cluster: %v", err)
 	}
 
-	first, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "default"})
+	first, _, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "default"})
 	if err != nil {
 		t.Fatalf("first upsert: %v", err)
 	}
@@ -569,7 +569,7 @@ func TestPGUpsertNamespace_ResurrectsTerminated(t *testing.T) {
 		t.Fatalf("terminated_at should be non-NULL after soft-delete")
 	}
 
-	resurrected, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "default"})
+	resurrected, _, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "default"})
 	if err != nil {
 		t.Fatalf("resurrect upsert: %v", err)
 	}
@@ -603,7 +603,7 @@ func TestPGUpsertWorkload_ResurrectsTerminated(t *testing.T) {
 		t.Fatalf("namespace: %v", err)
 	}
 
-	first, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{NamespaceId: *ns.Id, Kind: api.Deployment, Name: "web"})
+	first, _, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{NamespaceId: *ns.Id, Kind: api.Deployment, Name: "web"})
 	if err != nil {
 		t.Fatalf("first upsert: %v", err)
 	}
@@ -621,7 +621,7 @@ func TestPGUpsertWorkload_ResurrectsTerminated(t *testing.T) {
 		t.Fatalf("terminated_at should be non-NULL after soft-delete")
 	}
 
-	resurrected, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{NamespaceId: *ns.Id, Kind: api.Deployment, Name: "web"})
+	resurrected, _, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{NamespaceId: *ns.Id, Kind: api.Deployment, Name: "web"})
 	if err != nil {
 		t.Fatalf("resurrect upsert: %v", err)
 	}
@@ -744,12 +744,12 @@ func TestPGUpsertPodAndDeleteNotIn(t *testing.T) {
 	}
 
 	phaseA := "Pending"
-	first, err := pg.UpsertPod(ctx, api.PodCreate{NamespaceId: *ns.Id, Name: "a", Phase: &phaseA})
+	first, _, err := pg.UpsertPod(ctx, api.PodCreate{NamespaceId: *ns.Id, Name: "a", Phase: &phaseA})
 	if err != nil {
 		t.Fatalf("first upsert: %v", err)
 	}
 	phaseB := "Running"
-	second, err := pg.UpsertPod(ctx, api.PodCreate{NamespaceId: *ns.Id, Name: "a", Phase: &phaseB})
+	second, _, err := pg.UpsertPod(ctx, api.PodCreate{NamespaceId: *ns.Id, Name: "a", Phase: &phaseB})
 	if err != nil {
 		t.Fatalf("second upsert: %v", err)
 	}
@@ -761,7 +761,7 @@ func TestPGUpsertPodAndDeleteNotIn(t *testing.T) {
 	}
 
 	// Seed a second pod then reconcile to keep only one.
-	if _, err := pg.UpsertPod(ctx, api.PodCreate{NamespaceId: *ns.Id, Name: "b"}); err != nil {
+	if _, _, err := pg.UpsertPod(ctx, api.PodCreate{NamespaceId: *ns.Id, Name: "b"}); err != nil {
 		t.Fatalf("create b: %v", err)
 	}
 	deleted, err := pg.DeletePodsNotIn(ctx, *ns.Id, []string{"a"})
@@ -873,12 +873,12 @@ func TestPGUpsertWorkloadAndReconcileByKindName(t *testing.T) {
 
 	// Upsert (Deployment, web) twice — id preserved, updated_at advances.
 	r1 := 2
-	first, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{NamespaceId: *ns.Id, Kind: api.Deployment, Name: "web", Replicas: &r1})
+	first, _, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{NamespaceId: *ns.Id, Kind: api.Deployment, Name: "web", Replicas: &r1})
 	if err != nil {
 		t.Fatalf("first upsert: %v", err)
 	}
 	r2 := 4
-	second, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{NamespaceId: *ns.Id, Kind: api.Deployment, Name: "web", Replicas: &r2})
+	second, _, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{NamespaceId: *ns.Id, Kind: api.Deployment, Name: "web", Replicas: &r2})
 	if err != nil {
 		t.Fatalf("second upsert: %v", err)
 	}
@@ -890,10 +890,10 @@ func TestPGUpsertWorkloadAndReconcileByKindName(t *testing.T) {
 	}
 
 	// Seed a StatefulSet with the same name and a DaemonSet — reconcile keeping only Deployment/web.
-	if _, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{NamespaceId: *ns.Id, Kind: api.StatefulSet, Name: "web"}); err != nil {
+	if _, _, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{NamespaceId: *ns.Id, Kind: api.StatefulSet, Name: "web"}); err != nil {
 		t.Fatalf("sts: %v", err)
 	}
-	if _, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{NamespaceId: *ns.Id, Kind: api.DaemonSet, Name: "fluent-bit"}); err != nil {
+	if _, _, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{NamespaceId: *ns.Id, Kind: api.DaemonSet, Name: "fluent-bit"}); err != nil {
 		t.Fatalf("ds: %v", err)
 	}
 
@@ -1005,12 +1005,12 @@ func TestPGUpsertServiceAndDeleteNotIn(t *testing.T) {
 		t.Fatalf("namespace: %v", err)
 	}
 
-	first, err := pg.UpsertService(ctx, api.ServiceCreate{NamespaceId: *ns.Id, Name: "a"})
+	first, _, err := pg.UpsertService(ctx, api.ServiceCreate{NamespaceId: *ns.Id, Name: "a"})
 	if err != nil {
 		t.Fatalf("first: %v", err)
 	}
 	newType := api.LoadBalancer
-	second, err := pg.UpsertService(ctx, api.ServiceCreate{NamespaceId: *ns.Id, Name: "a", Type: &newType})
+	second, _, err := pg.UpsertService(ctx, api.ServiceCreate{NamespaceId: *ns.Id, Name: "a", Type: &newType})
 	if err != nil {
 		t.Fatalf("second: %v", err)
 	}
@@ -1021,7 +1021,7 @@ func TestPGUpsertServiceAndDeleteNotIn(t *testing.T) {
 		t.Errorf("updated_at did not advance")
 	}
 
-	if _, err := pg.UpsertService(ctx, api.ServiceCreate{NamespaceId: *ns.Id, Name: "b"}); err != nil {
+	if _, _, err := pg.UpsertService(ctx, api.ServiceCreate{NamespaceId: *ns.Id, Name: "b"}); err != nil {
 		t.Fatalf("b: %v", err)
 	}
 	deleted, err := pg.DeleteServicesNotIn(ctx, *ns.Id, []string{"a"})
@@ -1064,7 +1064,7 @@ func TestPGPodAndWorkloadContainersRoundTrip(t *testing.T) {
 		{"name": "app", "image": "nginx:1.25", "image_id": "docker.io/library/nginx@sha256:abc", "init": false},
 		{"name": "migrate", "image": "busybox:1.36", "init": true},
 	}
-	storedPod, err := pg.UpsertPod(ctx, api.PodCreate{
+	storedPod, _, err := pg.UpsertPod(ctx, api.PodCreate{
 		NamespaceId: *ns.Id,
 		Name:        "web-0",
 		Containers:  &podContainers,
@@ -1089,7 +1089,7 @@ func TestPGPodAndWorkloadContainersRoundTrip(t *testing.T) {
 	wlContainers := api.ContainerList{
 		{"name": "app", "image": "nginx:1.25", "init": false},
 	}
-	storedWL, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{
+	storedWL, _, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{
 		NamespaceId: *ns.Id,
 		Kind:        api.Deployment,
 		Name:        "web",
@@ -1180,7 +1180,7 @@ func TestPGPodWorkloadFK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second workload: %v", err)
 	}
-	upserted, err := pg.UpsertPod(ctx, api.PodCreate{
+	upserted, _, err := pg.UpsertPod(ctx, api.PodCreate{
 		NamespaceId: *ns.Id,
 		Name:        "web-abc-1",
 		WorkloadId:  wl2.Id,
@@ -1354,7 +1354,7 @@ func TestPGPersistentVolumeAndClaimFK(t *testing.T) {
 	}
 
 	// Upsert round-trips the FK too.
-	upserted, err := pg.UpsertPersistentVolumeClaim(ctx, api.PersistentVolumeClaimCreate{
+	upserted, _, err := pg.UpsertPersistentVolumeClaim(ctx, api.PersistentVolumeClaimCreate{
 		NamespaceId:      *ns.Id,
 		Name:             "data-0",
 		VolumeName:       &pv.Name,
@@ -1440,13 +1440,13 @@ func TestPGListFiltersForImageAndNode(t *testing.T) {
 	}
 	otherContainers := api.ContainerList{{"name": "misc", "image": "busybox:1.36", "init": false}}
 
-	if _, err := pg.UpsertPod(ctx, api.PodCreate{NamespaceId: *ns.Id, Name: "web-1", NodeName: &node1, Containers: &nginxContainers}); err != nil {
+	if _, _, err := pg.UpsertPod(ctx, api.PodCreate{NamespaceId: *ns.Id, Name: "web-1", NodeName: &node1, Containers: &nginxContainers}); err != nil {
 		t.Fatalf("web-1: %v", err)
 	}
-	if _, err := pg.UpsertPod(ctx, api.PodCreate{NamespaceId: *ns.Id, Name: "api-1", NodeName: &node1, Containers: &log4jContainers}); err != nil {
+	if _, _, err := pg.UpsertPod(ctx, api.PodCreate{NamespaceId: *ns.Id, Name: "api-1", NodeName: &node1, Containers: &log4jContainers}); err != nil {
 		t.Fatalf("api-1: %v", err)
 	}
-	if _, err := pg.UpsertPod(ctx, api.PodCreate{NamespaceId: *ns.Id, Name: "misc-1", NodeName: &node2, Containers: &otherContainers}); err != nil {
+	if _, _, err := pg.UpsertPod(ctx, api.PodCreate{NamespaceId: *ns.Id, Name: "misc-1", NodeName: &node2, Containers: &otherContainers}); err != nil {
 		t.Fatalf("misc-1: %v", err)
 	}
 
@@ -1500,12 +1500,12 @@ func TestPGListFiltersForImageAndNode(t *testing.T) {
 	}
 
 	// Same image filter works for workloads.
-	if _, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{
+	if _, _, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{
 		NamespaceId: *ns.Id, Kind: api.Deployment, Name: "api", Containers: &log4jContainers,
 	}); err != nil {
 		t.Fatalf("workload api: %v", err)
 	}
-	if _, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{
+	if _, _, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{
 		NamespaceId: *ns.Id, Kind: api.Deployment, Name: "web", Containers: &nginxContainers,
 	}); err != nil {
 		t.Fatalf("workload web: %v", err)
@@ -1745,7 +1745,7 @@ func TestPGNodeEnrichmentRoundTrip(t *testing.T) {
 		Labels:                      &labels,
 	}
 
-	stored, err := pg.UpsertNode(ctx, in)
+	stored, _, err := pg.UpsertNode(ctx, in)
 	if err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
@@ -1816,7 +1816,7 @@ func TestPGNodeEnrichmentRoundTrip(t *testing.T) {
 	in2.Conditions = &empty
 	in2.Unschedulable = &unschTrue
 	in2.Ready = &reDown
-	if _, err := pg.UpsertNode(ctx, in2); err != nil {
+	if _, _, err := pg.UpsertNode(ctx, in2); err != nil {
 		t.Fatalf("re-upsert: %v", err)
 	}
 	got2, err := pg.GetNode(ctx, *stored.Id)
@@ -2231,7 +2231,7 @@ func TestPGNamespaceCuratedMetadata(t *testing.T) {
 	// the ON CONFLICT DO UPDATE SET clause.
 	phase := testPhaseActive
 	colLabels := map[string]string{"kubernetes.io/metadata.name": nsName}
-	if _, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
+	if _, _, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
 		ClusterId: *cluster.Id,
 		Name:      nsName,
 		Phase:     &phase,
@@ -2352,7 +2352,7 @@ func TestPGNodeCuratedMetadata(t *testing.T) {
 	osImage := "Ubuntu 22.04.4 LTS"
 	labels := map[string]string{"kubernetes.io/hostname": nodeName}
 	ready := true
-	if _, err := pg.UpsertNode(ctx, api.NodeCreate{
+	if _, _, err := pg.UpsertNode(ctx, api.NodeCreate{
 		ClusterId:      *cluster.Id,
 		Name:           nodeName,
 		Role:           &role,
@@ -2432,7 +2432,7 @@ func TestPGSoftDeleteCluster_CascadesToChildren(t *testing.T) {
 	if err != nil {
 		t.Fatalf("node: %v", err)
 	}
-	wl, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{NamespaceId: *ns.Id, Kind: api.Deployment, Name: "web"})
+	wl, _, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{NamespaceId: *ns.Id, Kind: api.Deployment, Name: "web"})
 	if err != nil {
 		t.Fatalf("workload: %v", err)
 	}
@@ -2487,7 +2487,7 @@ func TestPGSoftDeleteNamespace_CascadesToWorkloads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("namespace: %v", err)
 	}
-	wl, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{NamespaceId: *ns.Id, Kind: api.Deployment, Name: "web"})
+	wl, _, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{NamespaceId: *ns.Id, Kind: api.Deployment, Name: "web"})
 	if err != nil {
 		t.Fatalf("workload: %v", err)
 	}

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -782,6 +782,118 @@ func TestPGUpsertPodAndDeleteNotIn(t *testing.T) {
 	}
 }
 
+func TestPG_UpsertPod_OutcomeInserted(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "pod-outcome-inserted"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+	ns, err := pg.CreateNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "default"})
+	if err != nil {
+		t.Fatalf("namespace: %v", err)
+	}
+
+	phase := "Running"
+	_, outcome, err := pg.UpsertPod(ctx, api.PodCreate{
+		NamespaceId: *ns.Id,
+		Name:        "pod-a",
+		Phase:       &phase,
+	})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if outcome != api.OutcomeInserted {
+		t.Errorf("first upsert outcome = %v, want Inserted", outcome)
+	}
+}
+
+func TestPG_UpsertPod_OutcomeNoChange_ClockOnly(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "pod-outcome-nochange"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+	ns, err := pg.CreateNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "default"})
+	if err != nil {
+		t.Fatalf("namespace: %v", err)
+	}
+
+	phase := "Running"
+	payload := api.PodCreate{NamespaceId: *ns.Id, Name: "pod-a", Phase: &phase}
+
+	if _, _, err := pg.UpsertPod(ctx, payload); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	_, outcome, err := pg.UpsertPod(ctx, payload)
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if outcome != api.OutcomeNoChange {
+		t.Errorf("identical second upsert outcome = %v, want NoChange", outcome)
+	}
+}
+
+func TestPG_UpsertPod_OutcomeBusinessChanged_PerField(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	cluster, _, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "pod-outcome-changed"})
+	if err != nil {
+		t.Fatalf("cluster: %v", err)
+	}
+	ns, err := pg.CreateNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: "default"})
+	if err != nil {
+		t.Fatalf("namespace: %v", err)
+	}
+
+	phaseRunning := "Running"
+	node1 := "node-1"
+	ip1 := "10.0.0.1"
+	base := api.PodCreate{
+		NamespaceId: *ns.Id, Name: "pod-a",
+		Phase: &phaseRunning, NodeName: &node1, PodIp: &ip1,
+	}
+	if _, _, err := pg.UpsertPod(ctx, base); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	phasePending := "Pending"
+	node2 := "node-2"
+	ip2 := "10.0.0.2"
+	labels := map[string]string{"k": "v"}
+
+	mutations := []struct {
+		name string
+		mut  func(p *api.PodCreate)
+	}{
+		{"phase", func(p *api.PodCreate) { p.Phase = &phasePending }},
+		{"node_name", func(p *api.PodCreate) { p.NodeName = &node2 }},
+		{"pod_ip", func(p *api.PodCreate) { p.PodIp = &ip2 }},
+		{"labels", func(p *api.PodCreate) { p.Labels = &labels }},
+	}
+	for _, m := range mutations {
+		m := m
+		t.Run(m.name, func(t *testing.T) {
+			pl := base
+			m.mut(&pl)
+			_, outcome, err := pg.UpsertPod(ctx, pl)
+			if err != nil {
+				t.Fatalf("upsert: %v", err)
+			}
+			if outcome != api.OutcomeBusinessChanged {
+				t.Errorf("touching %s gave outcome=%v, want BusinessChanged", m.name, outcome)
+			}
+			if _, _, err := pg.UpsertPod(ctx, base); err != nil {
+				t.Fatalf("reset: %v", err)
+			}
+		})
+	}
+}
+
 //nolint:gocyclo // integration test exercises multiple CRUD branches
 func TestPGWorkloadCRUD(t *testing.T) {
 	pg := newTestPG(t)

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -865,6 +865,7 @@ func TestPG_UpsertPod_OutcomeBusinessChanged_PerField(t *testing.T) {
 	node2 := "node-2"
 	ip2 := "10.0.0.2"
 	labels := map[string]string{"k": "v"}
+	containers := api.ContainerList{{"name": "app", "image": "nginx:1.99"}}
 
 	mutations := []struct {
 		name string
@@ -874,6 +875,7 @@ func TestPG_UpsertPod_OutcomeBusinessChanged_PerField(t *testing.T) {
 		{"node_name", func(p *api.PodCreate) { p.NodeName = &node2 }},
 		{"pod_ip", func(p *api.PodCreate) { p.PodIp = &ip2 }},
 		{"labels", func(p *api.PodCreate) { p.Labels = &labels }},
+		{"containers", func(p *api.PodCreate) { p.Containers = &containers }},
 	}
 	for _, m := range mutations {
 		m := m

--- a/internal/store/pg_timetravel_test.go
+++ b/internal/store/pg_timetravel_test.go
@@ -104,17 +104,17 @@ func TestTimeTravelCapture_SoftDeleteCascade(t *testing.T) {
 	require.NoError(t, err)
 	clusterID := *cluster.Id
 
-	ns, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
+	ns, _, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
 		ClusterId: clusterID, Name: "ns-" + uuid.New().String()[:8],
 	})
 	require.NoError(t, err)
 
-	node, err := pg.UpsertNode(ctx, api.NodeCreate{
+	node, _, err := pg.UpsertNode(ctx, api.NodeCreate{
 		ClusterId: clusterID, Name: "node-" + uuid.New().String()[:8],
 	})
 	require.NoError(t, err)
 
-	wl, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{
+	wl, _, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{
 		NamespaceId: *ns.Id,
 		Kind:        api.Deployment,
 		Name:        "wl-" + uuid.New().String()[:8],
@@ -149,7 +149,7 @@ func TestTimeTravelCapture_Resurrection(t *testing.T) {
 	clusterID := *cluster.Id
 
 	nsName := "resurrect-ns-" + uuid.New().String()[:8]
-	ns, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
+	ns, _, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
 		ClusterId: clusterID, Name: nsName,
 	})
 	require.NoError(t, err)
@@ -159,7 +159,7 @@ func TestTimeTravelCapture_Resurrection(t *testing.T) {
 	require.NoError(t, err)
 
 	// Resurrect via UpsertNamespace.
-	ns2, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
+	ns2, _, err := pg.UpsertNamespace(ctx, api.NamespaceCreate{
 		ClusterId: clusterID, Name: nsName,
 	})
 	require.NoError(t, err)

--- a/internal/store/pg_virtual_machines.go
+++ b/internal/store/pg_virtual_machines.go
@@ -44,7 +44,7 @@ const vmColumns = `id, cloud_account_id,
 // already known as a Kubernetes node.
 //
 //nolint:gocritic // hugeParam: Store interface requires value param; insert columns are inherently long
-func (p *PG) UpsertVirtualMachine(ctx context.Context, in api.VirtualMachineUpsert) (api.VirtualMachine, error) {
+func (p *PG) UpsertVirtualMachine(ctx context.Context, in api.VirtualMachineUpsert) (api.VirtualMachine, api.UpsertOutcome, error) {
 	// Server-side dedup. Outscale's CCM sets node.spec.providerID to a
 	// string containing the VmId, e.g. "aws:///<az>/i-96fff41b". A
 	// substring match catches every observed format.
@@ -61,17 +61,17 @@ func (p *PG) UpsertVirtualMachine(ctx context.Context, in api.VirtualMachineUpse
 	//     the validator, the SQL is still safe.
 	if in.ProviderVMID != "" {
 		if !validProviderVMID(in.ProviderVMID) {
-			return api.VirtualMachine{}, fmt.Errorf("provider_vm_id %q contains disallowed characters: %w", in.ProviderVMID, api.ErrConflict)
+			return api.VirtualMachine{}, api.OutcomeBusinessChanged, fmt.Errorf("provider_vm_id %q contains disallowed characters: %w", in.ProviderVMID, api.ErrConflict)
 		}
 		var existsCount int
 		if err := p.pool.QueryRow(ctx,
 			`SELECT COUNT(*) FROM nodes WHERE provider_id LIKE '%' || $1 || '%' ESCAPE '\'`,
 			escapeLIKE(in.ProviderVMID),
 		).Scan(&existsCount); err != nil {
-			return api.VirtualMachine{}, fmt.Errorf("dedup check against nodes: %w", err)
+			return api.VirtualMachine{}, api.OutcomeBusinessChanged, fmt.Errorf("dedup check against nodes: %w", err)
 		}
 		if existsCount > 0 {
-			return api.VirtualMachine{}, fmt.Errorf("provider_vm_id %q already inventoried as a node: %w", in.ProviderVMID, api.ErrConflict)
+			return api.VirtualMachine{}, api.OutcomeBusinessChanged, fmt.Errorf("provider_vm_id %q already inventoried as a node: %w", in.ProviderVMID, api.ErrConflict)
 		}
 	}
 
@@ -84,11 +84,11 @@ func (p *PG) UpsertVirtualMachine(ctx context.Context, in api.VirtualMachineUpse
 
 	tagsJSON, err := marshalStringMap(in.Tags)
 	if err != nil {
-		return api.VirtualMachine{}, fmt.Errorf("marshal tags: %w", err)
+		return api.VirtualMachine{}, api.OutcomeBusinessChanged, fmt.Errorf("marshal tags: %w", err)
 	}
 	labelsJSON, err := marshalStringMap(in.Labels)
 	if err != nil {
-		return api.VirtualMachine{}, fmt.Errorf("marshal labels: %w", err)
+		return api.VirtualMachine{}, api.OutcomeBusinessChanged, fmt.Errorf("marshal labels: %w", err)
 	}
 
 	const q = `
@@ -173,9 +173,13 @@ func (p *PG) UpsertVirtualMachine(ctx context.Context, in api.VirtualMachineUpse
 		now,
 	).Scan(&rowID)
 	if err != nil {
-		return api.VirtualMachine{}, fmt.Errorf("upsert virtual machine: %w", err)
+		return api.VirtualMachine{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert virtual machine: %w", err)
 	}
-	return p.GetVirtualMachine(ctx, rowID)
+	vm, err := p.GetVirtualMachine(ctx, rowID)
+	if err != nil {
+		return api.VirtualMachine{}, api.OutcomeBusinessChanged, err
+	}
+	return vm, api.OutcomeBusinessChanged, nil
 }
 
 // GetVirtualMachine fetches a VM by id.

--- a/internal/store/pg_virtual_machines.go
+++ b/internal/store/pg_virtual_machines.go
@@ -61,17 +61,17 @@ func (p *PG) UpsertVirtualMachine(ctx context.Context, in api.VirtualMachineUpse
 	//     the validator, the SQL is still safe.
 	if in.ProviderVMID != "" {
 		if !validProviderVMID(in.ProviderVMID) {
-			return api.VirtualMachine{}, api.OutcomeBusinessChanged, fmt.Errorf("provider_vm_id %q contains disallowed characters: %w", in.ProviderVMID, api.ErrConflict)
+			return api.VirtualMachine{}, api.OutcomeNoChange, fmt.Errorf("provider_vm_id %q contains disallowed characters: %w", in.ProviderVMID, api.ErrConflict)
 		}
 		var existsCount int
 		if err := p.pool.QueryRow(ctx,
 			`SELECT COUNT(*) FROM nodes WHERE provider_id LIKE '%' || $1 || '%' ESCAPE '\'`,
 			escapeLIKE(in.ProviderVMID),
 		).Scan(&existsCount); err != nil {
-			return api.VirtualMachine{}, api.OutcomeBusinessChanged, fmt.Errorf("dedup check against nodes: %w", err)
+			return api.VirtualMachine{}, api.OutcomeNoChange, fmt.Errorf("dedup check against nodes: %w", err)
 		}
 		if existsCount > 0 {
-			return api.VirtualMachine{}, api.OutcomeBusinessChanged, fmt.Errorf("provider_vm_id %q already inventoried as a node: %w", in.ProviderVMID, api.ErrConflict)
+			return api.VirtualMachine{}, api.OutcomeNoChange, fmt.Errorf("provider_vm_id %q already inventoried as a node: %w", in.ProviderVMID, api.ErrConflict)
 		}
 	}
 
@@ -84,80 +84,155 @@ func (p *PG) UpsertVirtualMachine(ctx context.Context, in api.VirtualMachineUpse
 
 	tagsJSON, err := marshalStringMap(in.Tags)
 	if err != nil {
-		return api.VirtualMachine{}, api.OutcomeBusinessChanged, fmt.Errorf("marshal tags: %w", err)
+		return api.VirtualMachine{}, api.OutcomeNoChange, fmt.Errorf("marshal tags: %w", err)
 	}
 	labelsJSON, err := marshalStringMap(in.Labels)
 	if err != nil {
-		return api.VirtualMachine{}, api.OutcomeBusinessChanged, fmt.Errorf("marshal labels: %w", err)
+		return api.VirtualMachine{}, api.OutcomeNoChange, fmt.Errorf("marshal labels: %w", err)
 	}
 
+	// AUDIT_BUSINESS_FIELDS: name, role, private_ip, public_ip,
+	// private_dns_name, vpc_id, subnet_id, nics, security_groups,
+	// instance_type, architecture, zone, region, image_id, image_name,
+	// keypair_name, boot_mode, provider_account_id, provider_creation_date,
+	// power_state, state_reason, ready, deletion_protection, kernel_version,
+	// operating_system, capacity_cpu, capacity_memory, block_devices,
+	// root_device_type, root_device_name, tags, labels, terminated_at
+	// (restore flips it). Excluded: applications (curator-only, never
+	// written by collector); last_seen_at and updated_at (clock fields);
+	// owner/criticality/notes/runbook_url/annotations/display_name
+	// (curator metadata, never overwritten by collector upsert).
 	const q = `
-		INSERT INTO virtual_machines (
-			id, cloud_account_id,
-			provider_vm_id, name, display_name, role,
-			private_ip, public_ip, private_dns_name, vpc_id, subnet_id,
-			nics, security_groups,
-			instance_type, architecture, zone, region,
-			image_id, image_name, keypair_name, boot_mode, provider_account_id, provider_creation_date,
-			power_state, state_reason, ready, deletion_protection,
-			kernel_version, operating_system,
-			capacity_cpu, capacity_memory,
-			block_devices, root_device_type, root_device_name,
-			tags, labels, annotations,
-			created_at, updated_at, last_seen_at
-		) VALUES (
-			$1, $2,
-			$3, $4, NULL, $5,
-			$6, $7, $8, $9, $10,
-			$11, $12,
-			$13, $14, $15, $16,
-			$17, $18, $19, $20, $21, $22,
-			$23, $24, $25, $26,
-			$27, $28,
-			$29, $30,
-			$31, $32, $33,
-			$34, $35, '{}'::jsonb,
-			$36, $36, $36
+		WITH old AS (
+		  SELECT name, role, private_ip, public_ip, private_dns_name,
+		         vpc_id, subnet_id, nics, security_groups,
+		         instance_type, architecture, zone, region,
+		         image_id, image_name, keypair_name, boot_mode,
+		         provider_account_id, provider_creation_date,
+		         power_state, state_reason, ready, deletion_protection,
+		         kernel_version, operating_system,
+		         capacity_cpu, capacity_memory,
+		         block_devices, root_device_type, root_device_name,
+		         tags, labels, terminated_at
+		    FROM virtual_machines
+		    WHERE cloud_account_id=$2 AND provider_vm_id=$3
+		),
+		upserted AS (
+		  INSERT INTO virtual_machines (
+		    id, cloud_account_id,
+		    provider_vm_id, name, display_name, role,
+		    private_ip, public_ip, private_dns_name, vpc_id, subnet_id,
+		    nics, security_groups,
+		    instance_type, architecture, zone, region,
+		    image_id, image_name, keypair_name, boot_mode, provider_account_id, provider_creation_date,
+		    power_state, state_reason, ready, deletion_protection,
+		    kernel_version, operating_system,
+		    capacity_cpu, capacity_memory,
+		    block_devices, root_device_type, root_device_name,
+		    tags, labels, annotations,
+		    created_at, updated_at, last_seen_at
+		  ) VALUES (
+		    $1, $2,
+		    $3, $4, NULL, $5,
+		    $6, $7, $8, $9, $10,
+		    $11, $12,
+		    $13, $14, $15, $16,
+		    $17, $18, $19, $20, $21, $22,
+		    $23, $24, $25, $26,
+		    $27, $28,
+		    $29, $30,
+		    $31, $32, $33,
+		    $34, $35, '{}'::jsonb,
+		    $36, $36, $36
+		  )
+		  ON CONFLICT (cloud_account_id, provider_vm_id) DO UPDATE
+		  SET name                  = EXCLUDED.name,
+		      role                  = COALESCE(virtual_machines.role, EXCLUDED.role),
+		      private_ip            = EXCLUDED.private_ip,
+		      public_ip             = EXCLUDED.public_ip,
+		      private_dns_name      = EXCLUDED.private_dns_name,
+		      vpc_id                = EXCLUDED.vpc_id,
+		      subnet_id             = EXCLUDED.subnet_id,
+		      nics                  = EXCLUDED.nics,
+		      security_groups       = EXCLUDED.security_groups,
+		      instance_type         = EXCLUDED.instance_type,
+		      architecture          = EXCLUDED.architecture,
+		      zone                  = EXCLUDED.zone,
+		      region                = EXCLUDED.region,
+		      image_id              = EXCLUDED.image_id,
+		      image_name            = EXCLUDED.image_name,
+		      keypair_name          = EXCLUDED.keypair_name,
+		      boot_mode             = EXCLUDED.boot_mode,
+		      provider_account_id   = EXCLUDED.provider_account_id,
+		      provider_creation_date= EXCLUDED.provider_creation_date,
+		      power_state           = EXCLUDED.power_state,
+		      state_reason          = EXCLUDED.state_reason,
+		      ready                 = EXCLUDED.ready,
+		      deletion_protection   = EXCLUDED.deletion_protection,
+		      kernel_version        = EXCLUDED.kernel_version,
+		      operating_system      = EXCLUDED.operating_system,
+		      capacity_cpu          = EXCLUDED.capacity_cpu,
+		      capacity_memory       = EXCLUDED.capacity_memory,
+		      block_devices         = EXCLUDED.block_devices,
+		      root_device_type      = EXCLUDED.root_device_type,
+		      root_device_name      = EXCLUDED.root_device_name,
+		      tags                  = EXCLUDED.tags,
+		      labels                = EXCLUDED.labels,
+		      updated_at            = EXCLUDED.updated_at,
+		      last_seen_at          = EXCLUDED.last_seen_at,
+		      terminated_at         = NULL
+		  RETURNING id, name, role, private_ip, public_ip, private_dns_name,
+		            vpc_id, subnet_id, nics, security_groups,
+		            instance_type, architecture, zone, region,
+		            image_id, image_name, keypair_name, boot_mode,
+		            provider_account_id, provider_creation_date,
+		            power_state, state_reason, ready, deletion_protection,
+		            kernel_version, operating_system,
+		            capacity_cpu, capacity_memory,
+		            block_devices, root_device_type, root_device_name,
+		            tags, labels, terminated_at, xmax
 		)
-		ON CONFLICT (cloud_account_id, provider_vm_id) DO UPDATE
-		SET name                  = EXCLUDED.name,
-		    role                  = COALESCE(virtual_machines.role, EXCLUDED.role),
-		    private_ip            = EXCLUDED.private_ip,
-		    public_ip             = EXCLUDED.public_ip,
-		    private_dns_name      = EXCLUDED.private_dns_name,
-		    vpc_id                = EXCLUDED.vpc_id,
-		    subnet_id             = EXCLUDED.subnet_id,
-		    nics                  = EXCLUDED.nics,
-		    security_groups       = EXCLUDED.security_groups,
-		    instance_type         = EXCLUDED.instance_type,
-		    architecture          = EXCLUDED.architecture,
-		    zone                  = EXCLUDED.zone,
-		    region                = EXCLUDED.region,
-		    image_id              = EXCLUDED.image_id,
-		    image_name            = EXCLUDED.image_name,
-		    keypair_name          = EXCLUDED.keypair_name,
-		    boot_mode             = EXCLUDED.boot_mode,
-		    provider_account_id   = EXCLUDED.provider_account_id,
-		    provider_creation_date= EXCLUDED.provider_creation_date,
-		    power_state           = EXCLUDED.power_state,
-		    state_reason          = EXCLUDED.state_reason,
-		    ready                 = EXCLUDED.ready,
-		    deletion_protection   = EXCLUDED.deletion_protection,
-		    kernel_version        = EXCLUDED.kernel_version,
-		    operating_system      = EXCLUDED.operating_system,
-		    capacity_cpu          = EXCLUDED.capacity_cpu,
-		    capacity_memory       = EXCLUDED.capacity_memory,
-		    block_devices         = EXCLUDED.block_devices,
-		    root_device_type      = EXCLUDED.root_device_type,
-		    root_device_name      = EXCLUDED.root_device_name,
-		    tags                  = EXCLUDED.tags,
-		    labels                = EXCLUDED.labels,
-		    updated_at            = EXCLUDED.updated_at,
-		    last_seen_at          = EXCLUDED.last_seen_at,
-		    terminated_at         = NULL
-		RETURNING id
+		SELECT id,
+		       (xmax = 0) AS inserted,
+		       (xmax <> 0 AND (
+		           o.name                  IS DISTINCT FROM upserted.name                  OR
+		           o.role                  IS DISTINCT FROM upserted.role                  OR
+		           o.private_ip            IS DISTINCT FROM upserted.private_ip            OR
+		           o.public_ip             IS DISTINCT FROM upserted.public_ip             OR
+		           o.private_dns_name      IS DISTINCT FROM upserted.private_dns_name      OR
+		           o.vpc_id                IS DISTINCT FROM upserted.vpc_id                OR
+		           o.subnet_id             IS DISTINCT FROM upserted.subnet_id             OR
+		           o.nics                  IS DISTINCT FROM upserted.nics                  OR
+		           o.security_groups       IS DISTINCT FROM upserted.security_groups       OR
+		           o.instance_type         IS DISTINCT FROM upserted.instance_type         OR
+		           o.architecture          IS DISTINCT FROM upserted.architecture          OR
+		           o.zone                  IS DISTINCT FROM upserted.zone                  OR
+		           o.region                IS DISTINCT FROM upserted.region                OR
+		           o.image_id              IS DISTINCT FROM upserted.image_id              OR
+		           o.image_name            IS DISTINCT FROM upserted.image_name            OR
+		           o.keypair_name          IS DISTINCT FROM upserted.keypair_name          OR
+		           o.boot_mode             IS DISTINCT FROM upserted.boot_mode             OR
+		           o.provider_account_id   IS DISTINCT FROM upserted.provider_account_id   OR
+		           o.provider_creation_date IS DISTINCT FROM upserted.provider_creation_date OR
+		           o.power_state           IS DISTINCT FROM upserted.power_state           OR
+		           o.state_reason          IS DISTINCT FROM upserted.state_reason          OR
+		           o.ready                 IS DISTINCT FROM upserted.ready                 OR
+		           o.deletion_protection   IS DISTINCT FROM upserted.deletion_protection   OR
+		           o.kernel_version        IS DISTINCT FROM upserted.kernel_version        OR
+		           o.operating_system      IS DISTINCT FROM upserted.operating_system      OR
+		           o.capacity_cpu          IS DISTINCT FROM upserted.capacity_cpu          OR
+		           o.capacity_memory       IS DISTINCT FROM upserted.capacity_memory       OR
+		           o.block_devices         IS DISTINCT FROM upserted.block_devices         OR
+		           o.root_device_type      IS DISTINCT FROM upserted.root_device_type      OR
+		           o.root_device_name      IS DISTINCT FROM upserted.root_device_name      OR
+		           o.tags                  IS DISTINCT FROM upserted.tags                  OR
+		           o.labels                IS DISTINCT FROM upserted.labels                OR
+		           o.terminated_at         IS DISTINCT FROM upserted.terminated_at
+		       )) AS business_changed
+		  FROM upserted LEFT JOIN old o ON true
 	`
 	var rowID uuid.UUID
+	var inserted, businessChanged bool
 	err = p.pool.QueryRow(ctx, q,
 		id, in.CloudAccountID,
 		in.ProviderVMID, in.Name, in.Role,
@@ -171,15 +246,15 @@ func (p *PG) UpsertVirtualMachine(ctx context.Context, in api.VirtualMachineUpse
 		bdJSON, in.RootDeviceType, in.RootDeviceName,
 		tagsJSON, labelsJSON,
 		now,
-	).Scan(&rowID)
+	).Scan(&rowID, &inserted, &businessChanged)
 	if err != nil {
-		return api.VirtualMachine{}, api.OutcomeBusinessChanged, fmt.Errorf("upsert virtual machine: %w", err)
+		return api.VirtualMachine{}, api.OutcomeNoChange, fmt.Errorf("upsert virtual machine: %w", err)
 	}
 	vm, err := p.GetVirtualMachine(ctx, rowID)
 	if err != nil {
-		return api.VirtualMachine{}, api.OutcomeBusinessChanged, err
+		return api.VirtualMachine{}, api.OutcomeNoChange, err
 	}
-	return vm, api.OutcomeBusinessChanged, nil
+	return vm, classifyOutcome(inserted, businessChanged), nil
 }
 
 // GetVirtualMachine fetches a VM by id.

--- a/internal/store/pg_virtual_machines.go
+++ b/internal/store/pg_virtual_machines.go
@@ -61,7 +61,11 @@ func (p *PG) UpsertVirtualMachine(ctx context.Context, in api.VirtualMachineUpse
 	//     the validator, the SQL is still safe.
 	if in.ProviderVMID != "" {
 		if !validProviderVMID(in.ProviderVMID) {
-			return api.VirtualMachine{}, api.OutcomeNoChange, fmt.Errorf("provider_vm_id %q contains disallowed characters: %w", in.ProviderVMID, api.ErrConflict)
+			return api.VirtualMachine{}, api.OutcomeNoChange, fmt.Errorf(
+				"provider_vm_id %q contains disallowed characters: %w",
+				in.ProviderVMID,
+				api.ErrConflict,
+			)
 		}
 		var existsCount int
 		if err := p.pool.QueryRow(ctx,
@@ -71,7 +75,11 @@ func (p *PG) UpsertVirtualMachine(ctx context.Context, in api.VirtualMachineUpse
 			return api.VirtualMachine{}, api.OutcomeNoChange, fmt.Errorf("dedup check against nodes: %w", err)
 		}
 		if existsCount > 0 {
-			return api.VirtualMachine{}, api.OutcomeNoChange, fmt.Errorf("provider_vm_id %q already inventoried as a node: %w", in.ProviderVMID, api.ErrConflict)
+			return api.VirtualMachine{}, api.OutcomeNoChange, fmt.Errorf(
+				"provider_vm_id %q already inventoried as a node: %w",
+				in.ProviderVMID,
+				api.ErrConflict,
+			)
 		}
 	}
 

--- a/internal/store/pg_virtual_machines_test.go
+++ b/internal/store/pg_virtual_machines_test.go
@@ -1,0 +1,149 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sthalbert/longue-vue/internal/api"
+)
+
+// vmTestAccount seeds a cloud_accounts row so VirtualMachineUpsert can
+// satisfy its FK. Each test gets its own (provider, name) pair.
+func vmTestAccount(t *testing.T, pg *PG, name string) api.CloudAccount {
+	t.Helper()
+	ctx := context.Background()
+	acct, err := pg.UpsertCloudAccount(ctx, api.CloudAccountUpsert{
+		Provider: "outscale",
+		Name:     name,
+		Region:   "eu-west-2",
+	})
+	if err != nil {
+		t.Fatalf("cloud account: %v", err)
+	}
+	return acct
+}
+
+func TestPG_UpsertVirtualMachine_OutcomeInserted(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	acct := vmTestAccount(t, pg, "vm-outcome-inserted")
+
+	_, outcome, err := pg.UpsertVirtualMachine(ctx, api.VirtualMachineUpsert{
+		CloudAccountID: acct.ID,
+		ProviderVMID:   "i-0123456789abcdef",
+		Name:           "vm-a",
+		Region:         strPtr("eu-west-2"),
+	})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if outcome != api.OutcomeInserted {
+		t.Errorf("first upsert outcome = %v, want Inserted", outcome)
+	}
+}
+
+func TestPG_UpsertVirtualMachine_OutcomeNoChange_ClockOnly(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	acct := vmTestAccount(t, pg, "vm-outcome-nochange")
+
+	payload := api.VirtualMachineUpsert{
+		CloudAccountID: acct.ID,
+		ProviderVMID:   "i-0123456789abcdef",
+		Name:           "vm-a",
+		PrivateIP:      strPtr("10.0.0.10"),
+		PublicIP:       strPtr("203.0.113.5"),
+		InstanceType:   strPtr("m5.large"),
+		Architecture:   strPtr("x86_64"),
+		Zone:           strPtr("eu-west-2a"),
+		Region:         strPtr("eu-west-2"),
+		ImageID:        strPtr("ami-12345"),
+		ImageName:      strPtr("ubuntu-22.04"),
+		PowerState:     "running",
+		Ready:          true,
+		CapacityCPU:    strPtr("2"),
+		CapacityMemory: strPtr("8Gi"),
+		Tags:           map[string]string{"env": "prod"},
+		Labels:         map[string]string{"team": "platform"},
+	}
+
+	if _, _, err := pg.UpsertVirtualMachine(ctx, payload); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	_, outcome, err := pg.UpsertVirtualMachine(ctx, payload)
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if outcome != api.OutcomeNoChange {
+		t.Errorf("identical second upsert outcome = %v, want NoChange (last_seen_at moved)", outcome)
+	}
+}
+
+//nolint:gocyclo // table-driven covers a representative slice of VM business fields
+func TestPG_UpsertVirtualMachine_OutcomeBusinessChanged_PerField(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	acct := vmTestAccount(t, pg, "vm-outcome-changed")
+
+	base := api.VirtualMachineUpsert{
+		CloudAccountID: acct.ID,
+		ProviderVMID:   "i-0123456789abcdef",
+		Name:           "vm-a",
+		PrivateIP:      strPtr("10.0.0.10"),
+		PublicIP:       strPtr("203.0.113.5"),
+		InstanceType:   strPtr("m5.large"),
+		Architecture:   strPtr("x86_64"),
+		Zone:           strPtr("eu-west-2a"),
+		Region:         strPtr("eu-west-2"),
+		ImageID:        strPtr("ami-12345"),
+		ImageName:      strPtr("ubuntu-22.04"),
+		PowerState:     "running",
+		Ready:          true,
+		CapacityCPU:    strPtr("2"),
+		CapacityMemory: strPtr("8Gi"),
+		Tags:           map[string]string{"env": "prod"},
+		Labels:         map[string]string{"team": "platform"},
+	}
+	if _, _, err := pg.UpsertVirtualMachine(ctx, base); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	mutations := []struct {
+		name string
+		mut  func(p *api.VirtualMachineUpsert)
+	}{
+		{"name", func(p *api.VirtualMachineUpsert) { p.Name = "vm-a-renamed" }},
+		{"private_ip", func(p *api.VirtualMachineUpsert) { p.PrivateIP = strPtr("10.0.0.11") }},
+		{"public_ip", func(p *api.VirtualMachineUpsert) { p.PublicIP = strPtr("203.0.113.6") }},
+		{"instance_type", func(p *api.VirtualMachineUpsert) { p.InstanceType = strPtr("m5.xlarge") }},
+		{"power_state", func(p *api.VirtualMachineUpsert) { p.PowerState = "stopped" }},
+		{"ready", func(p *api.VirtualMachineUpsert) { p.Ready = false }},
+		{"capacity_cpu", func(p *api.VirtualMachineUpsert) { p.CapacityCPU = strPtr("4") }},
+		{"capacity_memory", func(p *api.VirtualMachineUpsert) { p.CapacityMemory = strPtr("16Gi") }},
+		{"image_id", func(p *api.VirtualMachineUpsert) { p.ImageID = strPtr("ami-99999") }},
+		{"tags", func(p *api.VirtualMachineUpsert) { p.Tags = map[string]string{"env": "stage"} }},
+		{"labels", func(p *api.VirtualMachineUpsert) { p.Labels = map[string]string{"team": "infra"} }},
+	}
+	for _, m := range mutations {
+		m := m
+		t.Run(m.name, func(t *testing.T) {
+			pl := base
+			m.mut(&pl)
+			_, outcome, err := pg.UpsertVirtualMachine(ctx, pl)
+			if err != nil {
+				t.Fatalf("upsert: %v", err)
+			}
+			if outcome != api.OutcomeBusinessChanged {
+				t.Errorf("touching %s gave outcome=%v, want BusinessChanged", m.name, outcome)
+			}
+			if _, _, err := pg.UpsertVirtualMachine(ctx, base); err != nil {
+				t.Fatalf("reset: %v", err)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/internal/store/pg_virtual_machines_test.go
+++ b/internal/store/pg_virtual_machines_test.go
@@ -81,7 +81,6 @@ func TestPG_UpsertVirtualMachine_OutcomeNoChange_ClockOnly(t *testing.T) {
 	}
 }
 
-//nolint:gocyclo // table-driven covers a representative slice of VM business fields
 func TestPG_UpsertVirtualMachine_OutcomeBusinessChanged_PerField(t *testing.T) {
 	pg := newTestPG(t)
 	ctx := context.Background()
@@ -128,7 +127,6 @@ func TestPG_UpsertVirtualMachine_OutcomeBusinessChanged_PerField(t *testing.T) {
 		{"labels", func(p *api.VirtualMachineUpsert) { p.Labels = map[string]string{"team": "infra"} }},
 	}
 	for _, m := range mutations {
-		m := m
 		t.Run(m.name, func(t *testing.T) {
 			pl := base
 			m.mut(&pl)


### PR DESCRIPTION
## Summary

Implements ADR-0024: the audit log now records *state-changing* CMDB writes only. Reconcile ticks that touch nothing and idempotent upserts that change only clock fields no longer fill `audit_events` with millions of rows that auditors must filter past.

The pipeline:
- `internal/api/outcome.go` adds an `UpsertOutcome` enum (`Inserted` / `BusinessChanged` / `NoChange`) and threads it through every `Upsert*` store signature.
- Each upsert (Pod, Workload, Service, Ingress, Node, Namespace, PV, PVC, VM) now classifies its outcome in-SQL via a CTE that diffs an `old` snapshot against the `RETURNING` row — clock fields (`updated_at`, `last_seen_at`) are excluded so a reconcile-only tick is correctly `NoChange`.
- Handlers call `SetAuditSkip(ctx)` on `NoChange`; the audit middleware bypasses the `audit_events` insert and increments a new `audit_events_skipped_total{actor_kind,resource_type,reason}` Prom counter instead. Reconcile handlers do the same with `reason="reconcile_empty"`.
- Auth-endpoint paths and any non-2xx response remain unconditionally audited (forensic preservation).
- Time-travel history capture is unaffected — it sits below the audit layer and continues to record every state transition.

Final commit (`ed26a22`) is a CI fix surfaced when the branch was first run locally end-to-end: four CTE upserts had unqualified column refs (SQLSTATE 42702), `newTestEnv` wired Auth/Audit middleware in reverse order vs. production, and the TRUNCATE list missed `cloud_accounts`. All three are addressed.

Docs: new ADR-0024 plus amendments to ADR-0008 IMP-005 and ADR-0010.

## Test plan

- [x] `make check` (fmt + vet + lint + Go race tests + UI tests)
- [x] `internal/store` upsert outcome tests cover Inserted / NoChange / BusinessChanged per business field, per resource
- [x] `internal/api/upsert_handlers_audit_skip_test.go` — handler-level skip wiring
- [x] `internal/api/reconcile_handlers_audit_skip_test.go` — reconcile empty/non-empty bodies
- [x] `internal/integration/audit_noop_test.go` — three identical POST /v1/pods collapse to 1 audit row + 2 skipped-counter increments
- [x] govulncheck / gosec / gitleaks / trivy (fs + config) clean
- [x] helm lint + template (bundled PG + external DB)