### PR TITLE
chore(ci): add workflow_dispatch to CI and Security workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Manual re-trigger escape hatch for the occasional GitHub Actions push-event
+  # miss (PR #159's merge to main produced zero runs). Lets a maintainer fire
+  # the workflow from the Actions UI or `gh workflow run` without an empty
+  # commit on a protected branch.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
   schedule:
     - cron: "23 4 * * 1"
+  # Manual re-trigger escape hatch for missed push events (see ci.yml).
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

GitHub silently dropped the push-event webhook for the merge of #159, leaving `main` with zero CI / Security runs while every prior `main` merge fired cleanly. The repo workflows currently can't be re-triggered without an empty commit on `main`, which is impossible on a protected branch.

Adds `workflow_dispatch:` to `ci.yml` and `security.yml` so a maintainer can re-fire either from the Actions UI or `gh workflow run ci.yml --ref main` the next time GitHub misses a push event. No behavior change on `push` or `pull_request`.

## Test plan

- [x] `yaml` parses (verified via `git diff` review)
- [x] After merge: trigger the new dispatch from the Actions UI on `main` to confirm both workflows can be fired without a code change