### PR TITLE
ci(release-please): drop "component" from path "." to fix .-only release auto-tagging

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
   "packages": {
     ".": {
       "release-type": "go",
-      "component": "longue-vue",
       "include-component-in-tag": false,
       "extra-files": [
         {


### PR DESCRIPTION
## Summary

- **Root cause** : `release-please-action`'s `createReleases()` (in `src/strategies/base.ts → buildRelease()`) has a strict guard for "standalone" release PRs — when the PR body contains a single release section without a component label, it requires the branch component and the configured component to match. Branches named `release-please--branches--main` carry no component (`undefined`), but path `.` had `"component": "longue-vue"` configured, so the comparison `undefined !== "longue-vue"` silently returns without creating the `v<X.Y.Z>` GitHub release. PR keeps the `autorelease: pending` label, all subsequent workflow runs abort with `There are untagged, merged release PRs outstanding`.
- **Symptom** : every binary-only release PR since #146 (#146, #158, #161, #164) has needed manual recovery — tag + release creation by hand, then relabel. PRs that also bumped a chart escaped the guard because `releaseData.length === 2`.
- **Fix** : drop the explicit `"component": "longue-vue"` from path `.`. Now both sides of the equality are `undefined` → the guard passes, the action creates the release, and the label flips to `autorelease: tagged` automatically.

Tag naming is unchanged (`include-component-in-tag: false` already strips the component prefix), and the PR body format is unchanged too (the body section was already rendered without component prefix).

PR #164 has already been recovered manually (release v0.21.0 published, label relabelled). This PR only prevents recurrence.

## Test plan

- [x] CI green on this PR
- [x] Merge → release-please creates a new `chore: release main` PR (or updates the existing manifest state cleanly)
- [x] Next binary-only release PR auto-tags without manual intervention