### PR TITLE
feat: bulk extract for Search and EOL Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 — the REST and database contracts may still change incompatibly before
 `v1.0.0`.
 
+## [Unreleased]
+
+### Added
+
+- Bulk extract endpoints `/v1/search/extract`, `/v1/search/extract.zip`, `/v1/eol/extract` with CSV / JSON output and `LONGUE_VUE_EXTRACT_MAX_ROWS` (default 50 000) cap; every extract recorded in `audit_events`.
+- "Extract" buttons on the Search page (per table + ZIP bundle) and EOL Dashboard.
+
 ## [0.21.0](https://github.com/sthalbert/Longue-Vue/compare/v0.20.0...v0.21.0) (2026-05-15)
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Guidance for Claude Code working in this repo. For deep design rationale, read `
 
 ## Audit log
 
-`AuditMiddleware` (mounted after auth) records all non-GET + every `/v1/admin/*` read and the credentials-fetch path into `audit_events`. Body scrubber redacts password / token / OIDC-secret / `access_key` / `secret_key`. Insert failures log at ERROR but never 5xx. `audit_events.source ∈ {api, ingest_gw, system}`.
+`AuditMiddleware` (mounted after auth) records all non-GET + every `/v1/admin/*` read and the credentials-fetch path into `audit_events`. Body scrubber redacts password / token / OIDC-secret / `access_key` / `secret_key`. Insert failures log at ERROR but never 5xx. `audit_events.source ∈ {api, ingest_gw, system}`. Extract endpoints (`/v1/search/extract`, `/v1/search/extract.zip`, `/v1/eol/extract`) are GET-but-audited via the `shouldAudit` allowlist; each request gets a row with `details.action="extract"`, plus page/format/filters/`row_count`/`truncated`.
 
 ## Listeners (ADR-0016, ADR-0017)
 
@@ -117,6 +117,10 @@ Cluster carries `owner` / `criticality` / `notes` / `runbook_url` / `annotations
 ## EOL enricher (ADR-0012, ADR-0019)
 
 `internal/eol/` — periodic endoflife.date queries; writes `longue-vue.io/eol.<product>` annotations on clusters, nodes, and (per VM `applications` entry) VMs. Stale keys reaped per tick. `latest_available` field shows newest published version. Centralised on the server — push collectors are unaffected.
+
+## Extracts (search & EOL)
+
+**Extracts (search & EOL):** bulk download of Search results (`/v1/search/extract?kind=workloads|pods|virtual_machines&format=csv|json` and `/v1/search/extract.zip?q=...`) and the EOL Dashboard (`/v1/eol/extract?format=csv|json`). Capped at `LONGUE_VUE_EXTRACT_MAX_ROWS` (default 50 000); `X-Longue-Vue-Truncated: true` header signals the cap. Audit-logged. Aggregation lives in `internal/eolagg` (shared fixtures with the UI dashboard).
 
 ## Idempotency
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A Configuration Management Database (CMDB) for Kubernetes environments, aligned 
 - **VM application inventory and EOL enrichment** -- operators declare platform software running on each non-Kubernetes VM (Vault, BIND, Cyberwatch, …); the EOL enricher evaluates declared versions against endoflife.date and writes `longue-vue.io/eol.<product>` annotations; the EOL dashboard surfaces VMs alongside clusters and nodes (ADR-0019).
 - **Helm chart per deployable binary** -- every longue-vue binary (`longue-vue`, `longue-vue-ingest-gw`, `longue-vue-collector`, `longue-vue-vm-collector`) ships with a sibling chart under `charts/`. Independent versioning, shared hardening defaults (ADR-0018).
 - **Audit log** -- every state-changing call is recorded; passwords and tokens are scrubbed; `source` column distinguishes public-listener (`api`) from DMZ-gateway (`ingest_gw`) traffic.
+- **CSV / JSON / ZIP extracts** -- bulk download of Search results and the EOL Dashboard (audit-logged, capped at 50 000 rows).
 - **Embedded web UI** -- React SPA shipped inside the binary at `/ui/`.
 
 ## Quick start

--- a/api/openapi/oapi-codegen.yaml
+++ b/api/openapi/oapi-codegen.yaml
@@ -2,6 +2,14 @@ package: api
 output: api.gen.go
 output-options:
   skip-prune: true
+  exclude-operation-ids:
+    # The extract endpoints are hand-written handlers mounted directly on
+    # the mux in cmd/longue-vue/main.go. Documented in openapi.yaml so
+    # they appear in Swagger UI, but excluded from the strict-server
+    # interface to avoid double registration on the same mux pattern.
+    - eolExtract
+    - searchExtract
+    - searchExtractZip
 generate:
   models: true
   std-http-server: true

--- a/api/openapi/openapi.yaml
+++ b/api/openapi/openapi.yaml
@@ -2310,6 +2310,166 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /v1/eol/extract:
+    get:
+      tags: [eol]
+      summary: Download EOL Dashboard rows as CSV or JSON
+      description: |
+        Flattens longue-vue.io/eol.* annotations from clusters, nodes
+        and virtual machines into one row per (entity, product). Optional
+        `entity_type` and `status` filters mirror the dashboard's chips.
+      operationId: eolExtract
+      security:
+        - BearerAuth: [read]
+        - SessionCookie: [read]
+      parameters:
+        - in: query
+          name: format
+          required: true
+          schema:
+            type: string
+            enum: [csv, json]
+        - in: query
+          name: entity_type
+          schema:
+            type: string
+            enum: [cluster, node, vm]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [eol, approaching_eol, supported, unknown]
+      responses:
+        '200':
+          description: Extract body.
+          headers:
+            X-Longue-Vue-Truncated:
+              schema:
+                type: string
+                enum: ['true']
+            Content-Disposition:
+              schema: { type: string }
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EolExtractRow'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /v1/search/extract:
+    get:
+      tags: [search]
+      summary: Download Search results as CSV or JSON
+      description: |
+        Returns every Workload / Pod / Virtual Machine matching the
+        cross-entity search query `q`, restricted to the entity kind
+        named in `kind`. The full filtered result set is streamed, capped
+        at `LONGUE_VUE_EXTRACT_MAX_ROWS` (default 50 000). When the cap
+        is hit the response carries `X-Longue-Vue-Truncated: true` and
+        the file is still well-formed CSV / JSON.
+      operationId: searchExtract
+      security:
+        - BearerAuth: [read]
+        - SessionCookie: [read]
+      parameters:
+        - in: query
+          name: q
+          required: true
+          schema:
+            type: string
+            maxLength: 256
+        - in: query
+          name: kind
+          required: true
+          schema:
+            type: string
+            enum: [workloads, pods, virtual_machines]
+        - in: query
+          name: format
+          required: true
+          schema:
+            type: string
+            enum: [csv, json]
+      responses:
+        '200':
+          description: Extract body. CSV is UTF-8 with a BOM and CRLF endings; JSON is a flat array.
+          headers:
+            X-Longue-Vue-Truncated:
+              schema:
+                type: string
+                enum: ['true']
+              description: Present and "true" when the row cap was hit.
+            Content-Disposition:
+              schema: { type: string }
+              description: 'attachment; filename="longue-vue-search-<kind>-<q-slug>-<ts>.<csv|json>"'
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+            application/json:
+              schema:
+                oneOf:
+                  - type: array
+                    items:
+                      $ref: '#/components/schemas/WorkloadExtractRow'
+                  - type: array
+                    items:
+                      $ref: '#/components/schemas/PodExtractRow'
+                  - type: array
+                    items:
+                      $ref: '#/components/schemas/VirtualMachineExtractRow'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /v1/search/extract.zip:
+    get:
+      tags: [search]
+      summary: Download Search results as a ZIP bundle
+      description: |
+        Bundles the three Search result tables (workloads.csv, pods.csv,
+        virtual_machines.csv) and a README.txt into a single ZIP.
+      operationId: searchExtractZip
+      security:
+        - BearerAuth: [read]
+        - SessionCookie: [read]
+      parameters:
+        - in: query
+          name: q
+          required: true
+          schema:
+            type: string
+            maxLength: 256
+      responses:
+        '200':
+          description: ZIP bundle.
+          headers:
+            X-Longue-Vue-Truncated:
+              schema:
+                type: string
+                enum: ['true']
+            Content-Disposition:
+              schema: { type: string }
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
 components:
 
   securitySchemes:
@@ -4702,3 +4862,65 @@ components:
           type: boolean
         already_running:
           type: boolean
+
+    EolExtractRow:
+      type: object
+      required: [entity_type, entity_id, entity_name, product, cycle, status]
+      properties:
+        entity_type: { type: string, enum: [cluster, node, vm] }
+        entity_id: { type: string }
+        entity_name: { type: string }
+        cluster: { type: string }
+        product: { type: string }
+        cycle: { type: string }
+        status: { type: string, enum: [eol, approaching_eol, supported, unknown] }
+        eol_date: { type: string }
+        latest: { type: string }
+        latest_available: { type: string }
+        support: { type: string }
+        checked_at: { type: string }
+
+    PodExtractRow:
+      type: object
+      required: [cluster, namespace, name]
+      properties:
+        id: { type: string, format: uuid }
+        cluster: { type: string }
+        namespace: { type: string }
+        name: { type: string }
+        workload_kind: { type: string }
+        workload_name: { type: string }
+        image_matches: { type: string }
+        phase: { type: string }
+        node: { type: string }
+        updated_at: { type: string, format: date-time }
+
+    VirtualMachineExtractRow:
+      type: object
+      required: [name]
+      properties:
+        id: { type: string, format: uuid }
+        cloud_account: { type: string }
+        region: { type: string }
+        name: { type: string }
+        display_name: { type: string }
+        role: { type: string }
+        power_state: { type: string }
+        image_id: { type: string }
+        image_name: { type: string }
+        applications_matched: { type: string }
+        updated_at: { type: string, format: date-time }
+
+    WorkloadExtractRow:
+      type: object
+      required: [cluster, namespace, kind, name]
+      properties:
+        id: { type: string, format: uuid }
+        cluster: { type: string }
+        namespace: { type: string }
+        kind: { type: string }
+        name: { type: string }
+        image_matches: { type: string }
+        replicas: { type: integer }
+        ready_replicas: { type: integer }
+        updated_at: { type: string, format: date-time }

--- a/api/openapi/openapi.yaml
+++ b/api/openapi/openapi.yaml
@@ -2417,7 +2417,7 @@ paths:
                 format: binary
             application/json:
               schema:
-                oneOf:
+                anyOf:
                   - type: array
                     items:
                       $ref: '#/components/schemas/WorkloadExtractRow'

--- a/cmd/longue-vue/main.go
+++ b/cmd/longue-vue/main.go
@@ -63,6 +63,7 @@ var (
 	errTransportPostureRefused = errors.New("LONGUE_VUE_REQUIRE_HTTPS=true but neither native TLS " +
 		"(LONGUE_VUE_PUBLIC_LISTEN_TLS_CERT + _KEY) nor a trusted-proxy + always-secure-cookie posture " +
 		"(LONGUE_VUE_TRUSTED_PROXIES non-empty AND LONGUE_VUE_SESSION_SECURE_COOKIE=always) is configured — see ADR-0017 §3")
+	errExtractMaxRowsInvalid = errors.New("LONGUE_VUE_EXTRACT_MAX_ROWS is not a positive integer")
 )
 
 func main() {
@@ -161,7 +162,7 @@ func loadRunConfig() (runConfig, error) {
 	if v := os.Getenv("LONGUE_VUE_EXTRACT_MAX_ROWS"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n <= 0 {
-			return runConfig{}, fmt.Errorf("LONGUE_VUE_EXTRACT_MAX_ROWS=%q is not a positive integer", v)
+			return runConfig{}, fmt.Errorf("%w: LONGUE_VUE_EXTRACT_MAX_ROWS=%q", errExtractMaxRowsInvalid, v)
 		}
 		extractMaxRows = n
 	}

--- a/cmd/longue-vue/main.go
+++ b/cmd/longue-vue/main.go
@@ -103,6 +103,9 @@ type runConfig struct {
 	// refuses to come up unless either native TLS is configured or a
 	// trusted-proxy + always-secure-cookie posture is set.
 	requireHTTPS bool
+	// extractMaxRows caps the number of rows returned by the /v1/*/extract
+	// endpoints. Defaults to 50 000; overridden via LONGUE_VUE_EXTRACT_MAX_ROWS.
+	extractMaxRows int
 }
 
 // ingestListenerConfig captures the env-var surface for the ADR-0016
@@ -154,6 +157,15 @@ func loadRunConfig() (runConfig, error) {
 		return runConfig{}, err
 	}
 
+	extractMaxRows := 50000
+	if v := os.Getenv("LONGUE_VUE_EXTRACT_MAX_ROWS"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			return runConfig{}, fmt.Errorf("LONGUE_VUE_EXTRACT_MAX_ROWS=%q is not a positive integer", v)
+		}
+		extractMaxRows = n
+	}
+
 	cfg := runConfig{
 		addr:            envOr("LONGUE_VUE_ADDR", ":8080"),
 		dsn:             dsn,
@@ -166,6 +178,7 @@ func loadRunConfig() (runConfig, error) {
 		publicTLSKey:    os.Getenv("LONGUE_VUE_PUBLIC_LISTEN_TLS_KEY"),
 		trustedProxies:  trustedProxies,
 		requireHTTPS:    requireHTTPS,
+		extractMaxRows:  extractMaxRows,
 	}
 	if err := checkTransportPosture(&cfg); err != nil {
 		return runConfig{}, err
@@ -312,6 +325,9 @@ func run() error { //nolint:gocyclo // daemon bootstrap; flat structure is clear
 		return fmt.Errorf("build ingest listener: %w", err)
 	}
 
+	slog.Info("longue-vue config",
+		slog.Int("extract_max_rows", cfg.extractMaxRows),
+	)
 	return serveAndShutdown(rootCtx, srv, ingestSrv, cfg.shutdownTimeout)
 }
 
@@ -511,6 +527,15 @@ func buildHTTPServer(
 	mux.Handle("GET /v1/virtual-machines/{id}", requireScope(auth.ScopeRead)(cloudAuth(auditWrap(api.HandleGetVirtualMachine(pg)))))
 	mux.Handle("PATCH /v1/virtual-machines/{id}", requireScope(auth.ScopeWrite)(cloudAuth(auditWrap(api.HandlePatchVirtualMachine(pg)))))
 	mux.Handle("DELETE /v1/virtual-machines/{id}", requireScope(auth.ScopeDelete)(cloudAuth(auditWrap(api.HandleDeleteVirtualMachine(pg)))))
+
+	// Extract endpoints — audited via the shouldAudit allowlist (ADR-0024 / SNC ch.8).
+	extractAuth := auth.Middleware(pg, cfg.cookiePolicy, cfg.trustedProxies)
+	mux.Handle("GET /v1/search/extract",
+		requireScope(auth.ScopeRead)(extractAuth(auditWrap(api.HandleSearchExtract(pg, cfg.extractMaxRows)))))
+	mux.Handle("GET /v1/search/extract.zip",
+		requireScope(auth.ScopeRead)(extractAuth(auditWrap(api.HandleSearchExtractZip(pg, cfg.extractMaxRows)))))
+	mux.Handle("GET /v1/eol/extract",
+		requireScope(auth.ScopeRead)(extractAuth(auditWrap(api.HandleEolExtract(pg, cfg.extractMaxRows)))))
 
 	loginLimiter := api.NewLoginRateLimiter()
 	verifyLimiter := api.NewVerifyRateLimiter()

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -12,7 +12,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -119,22 +118,22 @@ func (e EolExtractRowEntityType) Valid() bool {
 
 // Defines values for EolExtractRowStatus.
 const (
-	EolExtractRowStatusApproachingEol EolExtractRowStatus = "approaching_eol"
-	EolExtractRowStatusEol            EolExtractRowStatus = "eol"
-	EolExtractRowStatusSupported      EolExtractRowStatus = "supported"
-	EolExtractRowStatusUnknown        EolExtractRowStatus = "unknown"
+	ApproachingEol EolExtractRowStatus = "approaching_eol"
+	Eol            EolExtractRowStatus = "eol"
+	Supported      EolExtractRowStatus = "supported"
+	Unknown        EolExtractRowStatus = "unknown"
 )
 
 // Valid indicates whether the value is a known member of the EolExtractRowStatus enum.
 func (e EolExtractRowStatus) Valid() bool {
 	switch e {
-	case EolExtractRowStatusApproachingEol:
+	case ApproachingEol:
 		return true
-	case EolExtractRowStatusEol:
+	case Eol:
 		return true
-	case EolExtractRowStatusSupported:
+	case Supported:
 		return true
-	case EolExtractRowStatusUnknown:
+	case Unknown:
 		return true
 	default:
 		return false
@@ -318,108 +317,6 @@ func (e ListAuditEventsParamsSource) Valid() bool {
 	case IngestGw:
 		return true
 	case System:
-		return true
-	default:
-		return false
-	}
-}
-
-// Defines values for EolExtractParamsFormat.
-const (
-	EolExtractParamsFormatCsv  EolExtractParamsFormat = "csv"
-	EolExtractParamsFormatJson EolExtractParamsFormat = "json"
-)
-
-// Valid indicates whether the value is a known member of the EolExtractParamsFormat enum.
-func (e EolExtractParamsFormat) Valid() bool {
-	switch e {
-	case EolExtractParamsFormatCsv:
-		return true
-	case EolExtractParamsFormatJson:
-		return true
-	default:
-		return false
-	}
-}
-
-// Defines values for EolExtractParamsEntityType.
-const (
-	EolExtractParamsEntityTypeCluster EolExtractParamsEntityType = "cluster"
-	EolExtractParamsEntityTypeNode    EolExtractParamsEntityType = "node"
-	EolExtractParamsEntityTypeVm      EolExtractParamsEntityType = "vm"
-)
-
-// Valid indicates whether the value is a known member of the EolExtractParamsEntityType enum.
-func (e EolExtractParamsEntityType) Valid() bool {
-	switch e {
-	case EolExtractParamsEntityTypeCluster:
-		return true
-	case EolExtractParamsEntityTypeNode:
-		return true
-	case EolExtractParamsEntityTypeVm:
-		return true
-	default:
-		return false
-	}
-}
-
-// Defines values for EolExtractParamsStatus.
-const (
-	EolExtractParamsStatusApproachingEol EolExtractParamsStatus = "approaching_eol"
-	EolExtractParamsStatusEol            EolExtractParamsStatus = "eol"
-	EolExtractParamsStatusSupported      EolExtractParamsStatus = "supported"
-	EolExtractParamsStatusUnknown        EolExtractParamsStatus = "unknown"
-)
-
-// Valid indicates whether the value is a known member of the EolExtractParamsStatus enum.
-func (e EolExtractParamsStatus) Valid() bool {
-	switch e {
-	case EolExtractParamsStatusApproachingEol:
-		return true
-	case EolExtractParamsStatusEol:
-		return true
-	case EolExtractParamsStatusSupported:
-		return true
-	case EolExtractParamsStatusUnknown:
-		return true
-	default:
-		return false
-	}
-}
-
-// Defines values for SearchExtractParamsKind.
-const (
-	Pods            SearchExtractParamsKind = "pods"
-	VirtualMachines SearchExtractParamsKind = "virtual_machines"
-	Workloads       SearchExtractParamsKind = "workloads"
-)
-
-// Valid indicates whether the value is a known member of the SearchExtractParamsKind enum.
-func (e SearchExtractParamsKind) Valid() bool {
-	switch e {
-	case Pods:
-		return true
-	case VirtualMachines:
-		return true
-	case Workloads:
-		return true
-	default:
-		return false
-	}
-}
-
-// Defines values for SearchExtractParamsFormat.
-const (
-	SearchExtractParamsFormatCsv  SearchExtractParamsFormat = "csv"
-	SearchExtractParamsFormatJson SearchExtractParamsFormat = "json"
-)
-
-// Valid indicates whether the value is a known member of the SearchExtractParamsFormat enum.
-func (e SearchExtractParamsFormat) Valid() bool {
-	switch e {
-	case SearchExtractParamsFormatCsv:
-		return true
-	case SearchExtractParamsFormatJson:
 		return true
 	default:
 		return false
@@ -2484,22 +2381,6 @@ type ListClustersParams struct {
 	Name *string `form:"name,omitempty" json:"name,omitempty"`
 }
 
-// EolExtractParams defines parameters for EolExtract.
-type EolExtractParams struct {
-	Format     EolExtractParamsFormat      `form:"format" json:"format"`
-	EntityType *EolExtractParamsEntityType `form:"entity_type,omitempty" json:"entity_type,omitempty"`
-	Status     *EolExtractParamsStatus     `form:"status,omitempty" json:"status,omitempty"`
-}
-
-// EolExtractParamsFormat defines parameters for EolExtract.
-type EolExtractParamsFormat string
-
-// EolExtractParamsEntityType defines parameters for EolExtract.
-type EolExtractParamsEntityType string
-
-// EolExtractParamsStatus defines parameters for EolExtract.
-type EolExtractParamsStatus string
-
 // ListImageVersionsParams defines parameters for ListImageVersions.
 type ListImageVersionsParams struct {
 	Limit             *int       `form:"limit,omitempty" json:"limit,omitempty"`
@@ -2606,24 +2487,6 @@ type ListPodsParams struct {
 	// WorkloadId Filter pods by their controlling workload. Returns only pods whose
 	// `workload_id` FK matches the given UUID.
 	WorkloadId *PodWorkloadIdFilter `form:"workload_id,omitempty" json:"workload_id,omitempty"`
-}
-
-// SearchExtractParams defines parameters for SearchExtract.
-type SearchExtractParams struct {
-	Q      string                    `form:"q" json:"q"`
-	Kind   SearchExtractParamsKind   `form:"kind" json:"kind"`
-	Format SearchExtractParamsFormat `form:"format" json:"format"`
-}
-
-// SearchExtractParamsKind defines parameters for SearchExtract.
-type SearchExtractParamsKind string
-
-// SearchExtractParamsFormat defines parameters for SearchExtract.
-type SearchExtractParamsFormat string
-
-// SearchExtractZipParams defines parameters for SearchExtractZip.
-type SearchExtractZipParams struct {
-	Q string `form:"q" json:"q"`
 }
 
 // ListServicesParams defines parameters for ListServices.
@@ -2858,9 +2721,6 @@ type ServerInterface interface {
 	// Update mutable fields of a cluster
 	// (PATCH /v1/clusters/{id})
 	UpdateCluster(w http.ResponseWriter, r *http.Request, id ClusterId)
-	// Download EOL Dashboard rows as CSV or JSON
-	// (GET /v1/eol/extract)
-	EolExtract(w http.ResponseWriter, r *http.Request, params EolExtractParams)
 	// List enriched container images with their latest tags
 	// (GET /v1/image-versions)
 	ListImageVersions(w http.ResponseWriter, r *http.Request, params ListImageVersionsParams)
@@ -2978,12 +2838,6 @@ type ServerInterface interface {
 	// Update mutable fields of a pod
 	// (PATCH /v1/pods/{id})
 	UpdatePod(w http.ResponseWriter, r *http.Request, id PodId)
-	// Download Search results as CSV or JSON
-	// (GET /v1/search/extract)
-	SearchExtract(w http.ResponseWriter, r *http.Request, params SearchExtractParams)
-	// Download Search results as a ZIP bundle
-	// (GET /v1/search/extract.zip)
-	SearchExtractZip(w http.ResponseWriter, r *http.Request, params SearchExtractZipParams)
 	// List services
 	// (GET /v1/services)
 	ListServices(w http.ResponseWriter, r *http.Request, params ListServicesParams)
@@ -3936,64 +3790,6 @@ func (siw *ServerInterfaceWrapper) UpdateCluster(w http.ResponseWriter, r *http.
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.UpdateCluster(w, r, id)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
-// EolExtract operation middleware
-func (siw *ServerInterfaceWrapper) EolExtract(w http.ResponseWriter, r *http.Request) {
-
-	var err error
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"read"})
-
-	ctx = context.WithValue(ctx, SessionCookieScopes, []string{"read"})
-
-	r = r.WithContext(ctx)
-
-	// Parameter object where we will unmarshal all parameters from the context
-	var params EolExtractParams
-
-	// ------------- Required query parameter "format" -------------
-
-	if paramValue := r.URL.Query().Get("format"); paramValue != "" {
-
-	} else {
-		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "format"})
-		return
-	}
-
-	err = runtime.BindQueryParameterWithOptions("form", true, true, "format", r.URL.Query(), &params.Format, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "format", Err: err})
-		return
-	}
-
-	// ------------- Optional query parameter "entity_type" -------------
-
-	err = runtime.BindQueryParameterWithOptions("form", true, false, "entity_type", r.URL.Query(), &params.EntityType, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "entity_type", Err: err})
-		return
-	}
-
-	// ------------- Optional query parameter "status" -------------
-
-	err = runtime.BindQueryParameterWithOptions("form", true, false, "status", r.URL.Query(), &params.Status, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "status", Err: err})
-		return
-	}
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.EolExtract(w, r, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -5281,120 +5077,6 @@ func (siw *ServerInterfaceWrapper) UpdatePod(w http.ResponseWriter, r *http.Requ
 	handler.ServeHTTP(w, r)
 }
 
-// SearchExtract operation middleware
-func (siw *ServerInterfaceWrapper) SearchExtract(w http.ResponseWriter, r *http.Request) {
-
-	var err error
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"read"})
-
-	ctx = context.WithValue(ctx, SessionCookieScopes, []string{"read"})
-
-	r = r.WithContext(ctx)
-
-	// Parameter object where we will unmarshal all parameters from the context
-	var params SearchExtractParams
-
-	// ------------- Required query parameter "q" -------------
-
-	if paramValue := r.URL.Query().Get("q"); paramValue != "" {
-
-	} else {
-		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "q"})
-		return
-	}
-
-	err = runtime.BindQueryParameterWithOptions("form", true, true, "q", r.URL.Query(), &params.Q, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "q", Err: err})
-		return
-	}
-
-	// ------------- Required query parameter "kind" -------------
-
-	if paramValue := r.URL.Query().Get("kind"); paramValue != "" {
-
-	} else {
-		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "kind"})
-		return
-	}
-
-	err = runtime.BindQueryParameterWithOptions("form", true, true, "kind", r.URL.Query(), &params.Kind, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "kind", Err: err})
-		return
-	}
-
-	// ------------- Required query parameter "format" -------------
-
-	if paramValue := r.URL.Query().Get("format"); paramValue != "" {
-
-	} else {
-		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "format"})
-		return
-	}
-
-	err = runtime.BindQueryParameterWithOptions("form", true, true, "format", r.URL.Query(), &params.Format, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "format", Err: err})
-		return
-	}
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.SearchExtract(w, r, params)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
-// SearchExtractZip operation middleware
-func (siw *ServerInterfaceWrapper) SearchExtractZip(w http.ResponseWriter, r *http.Request) {
-
-	var err error
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"read"})
-
-	ctx = context.WithValue(ctx, SessionCookieScopes, []string{"read"})
-
-	r = r.WithContext(ctx)
-
-	// Parameter object where we will unmarshal all parameters from the context
-	var params SearchExtractZipParams
-
-	// ------------- Required query parameter "q" -------------
-
-	if paramValue := r.URL.Query().Get("q"); paramValue != "" {
-
-	} else {
-		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "q"})
-		return
-	}
-
-	err = runtime.BindQueryParameterWithOptions("form", true, true, "q", r.URL.Query(), &params.Q, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "q", Err: err})
-		return
-	}
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.SearchExtractZip(w, r, params)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
 // ListServices operation middleware
 func (siw *ServerInterfaceWrapper) ListServices(w http.ResponseWriter, r *http.Request) {
 
@@ -5937,7 +5619,6 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("DELETE "+options.BaseURL+"/v1/clusters/{id}", wrapper.DeleteCluster)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/clusters/{id}", wrapper.GetCluster)
 	m.HandleFunc("PATCH "+options.BaseURL+"/v1/clusters/{id}", wrapper.UpdateCluster)
-	m.HandleFunc("GET "+options.BaseURL+"/v1/eol/extract", wrapper.EolExtract)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/image-versions", wrapper.ListImageVersions)
 	m.HandleFunc("POST "+options.BaseURL+"/v1/image-versions/refresh", wrapper.RefreshImageVersions)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/image-versions/{image_repo}", wrapper.GetImageVersion)
@@ -5977,8 +5658,6 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("DELETE "+options.BaseURL+"/v1/pods/{id}", wrapper.DeletePod)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/pods/{id}", wrapper.GetPod)
 	m.HandleFunc("PATCH "+options.BaseURL+"/v1/pods/{id}", wrapper.UpdatePod)
-	m.HandleFunc("GET "+options.BaseURL+"/v1/search/extract", wrapper.SearchExtract)
-	m.HandleFunc("GET "+options.BaseURL+"/v1/search/extract.zip", wrapper.SearchExtractZip)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/services", wrapper.ListServices)
 	m.HandleFunc("POST "+options.BaseURL+"/v1/services", wrapper.CreateService)
 	m.HandleFunc("POST "+options.BaseURL+"/v1/services/reconcile", wrapper.ReconcileServices)
@@ -7327,77 +7006,6 @@ type UpdateCluster404ApplicationProblemPlusJSONResponse struct {
 func (response UpdateCluster404ApplicationProblemPlusJSONResponse) VisitUpdateClusterResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(404)
-
-	return json.NewEncoder(w).Encode(response)
-}
-
-type EolExtractRequestObject struct {
-	Params EolExtractParams
-}
-
-type EolExtractResponseObject interface {
-	VisitEolExtractResponse(w http.ResponseWriter) error
-}
-
-type EolExtract200ResponseHeaders struct {
-	ContentDisposition  string
-	XLongueVueTruncated string
-}
-
-type EolExtract200JSONResponse struct {
-	Body    []EolExtractRow
-	Headers EolExtract200ResponseHeaders
-}
-
-func (response EolExtract200JSONResponse) VisitEolExtractResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Content-Disposition", fmt.Sprint(response.Headers.ContentDisposition))
-	w.Header().Set("X-Longue-Vue-Truncated", fmt.Sprint(response.Headers.XLongueVueTruncated))
-	w.WriteHeader(200)
-
-	return json.NewEncoder(w).Encode(response.Body)
-}
-
-type EolExtract200TextcsvResponse struct {
-	Body          io.Reader
-	Headers       EolExtract200ResponseHeaders
-	ContentLength int64
-}
-
-func (response EolExtract200TextcsvResponse) VisitEolExtractResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "text/csv")
-	if response.ContentLength != 0 {
-		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
-	}
-	w.Header().Set("Content-Disposition", fmt.Sprint(response.Headers.ContentDisposition))
-	w.Header().Set("X-Longue-Vue-Truncated", fmt.Sprint(response.Headers.XLongueVueTruncated))
-	w.WriteHeader(200)
-
-	if closer, ok := response.Body.(io.ReadCloser); ok {
-		defer closer.Close()
-	}
-	_, err := io.Copy(w, response.Body)
-	return err
-}
-
-type EolExtract400ApplicationProblemPlusJSONResponse struct {
-	BadRequestApplicationProblemPlusJSONResponse
-}
-
-func (response EolExtract400ApplicationProblemPlusJSONResponse) VisitEolExtractResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(400)
-
-	return json.NewEncoder(w).Encode(response)
-}
-
-type EolExtract403ApplicationProblemPlusJSONResponse struct {
-	ForbiddenApplicationProblemPlusJSONResponse
-}
-
-func (response EolExtract403ApplicationProblemPlusJSONResponse) VisitEolExtractResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(403)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -9586,136 +9194,6 @@ func (response UpdatePod404ApplicationProblemPlusJSONResponse) VisitUpdatePodRes
 	return json.NewEncoder(w).Encode(response)
 }
 
-type SearchExtractRequestObject struct {
-	Params SearchExtractParams
-}
-
-type SearchExtractResponseObject interface {
-	VisitSearchExtractResponse(w http.ResponseWriter) error
-}
-
-type SearchExtract200ResponseHeaders struct {
-	ContentDisposition  string
-	XLongueVueTruncated string
-}
-
-type SearchExtract200JSONResponse struct {
-	Body struct {
-		union json.RawMessage
-	}
-	Headers SearchExtract200ResponseHeaders
-}
-
-func (response SearchExtract200JSONResponse) VisitSearchExtractResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Content-Disposition", fmt.Sprint(response.Headers.ContentDisposition))
-	w.Header().Set("X-Longue-Vue-Truncated", fmt.Sprint(response.Headers.XLongueVueTruncated))
-	w.WriteHeader(200)
-
-	return json.NewEncoder(w).Encode(response.Body.union)
-}
-
-type SearchExtract200TextcsvResponse struct {
-	Body          io.Reader
-	Headers       SearchExtract200ResponseHeaders
-	ContentLength int64
-}
-
-func (response SearchExtract200TextcsvResponse) VisitSearchExtractResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "text/csv")
-	if response.ContentLength != 0 {
-		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
-	}
-	w.Header().Set("Content-Disposition", fmt.Sprint(response.Headers.ContentDisposition))
-	w.Header().Set("X-Longue-Vue-Truncated", fmt.Sprint(response.Headers.XLongueVueTruncated))
-	w.WriteHeader(200)
-
-	if closer, ok := response.Body.(io.ReadCloser); ok {
-		defer closer.Close()
-	}
-	_, err := io.Copy(w, response.Body)
-	return err
-}
-
-type SearchExtract400ApplicationProblemPlusJSONResponse struct {
-	BadRequestApplicationProblemPlusJSONResponse
-}
-
-func (response SearchExtract400ApplicationProblemPlusJSONResponse) VisitSearchExtractResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(400)
-
-	return json.NewEncoder(w).Encode(response)
-}
-
-type SearchExtract403ApplicationProblemPlusJSONResponse struct {
-	ForbiddenApplicationProblemPlusJSONResponse
-}
-
-func (response SearchExtract403ApplicationProblemPlusJSONResponse) VisitSearchExtractResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(403)
-
-	return json.NewEncoder(w).Encode(response)
-}
-
-type SearchExtractZipRequestObject struct {
-	Params SearchExtractZipParams
-}
-
-type SearchExtractZipResponseObject interface {
-	VisitSearchExtractZipResponse(w http.ResponseWriter) error
-}
-
-type SearchExtractZip200ResponseHeaders struct {
-	ContentDisposition  string
-	XLongueVueTruncated string
-}
-
-type SearchExtractZip200ApplicationzipResponse struct {
-	Body          io.Reader
-	Headers       SearchExtractZip200ResponseHeaders
-	ContentLength int64
-}
-
-func (response SearchExtractZip200ApplicationzipResponse) VisitSearchExtractZipResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/zip")
-	if response.ContentLength != 0 {
-		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
-	}
-	w.Header().Set("Content-Disposition", fmt.Sprint(response.Headers.ContentDisposition))
-	w.Header().Set("X-Longue-Vue-Truncated", fmt.Sprint(response.Headers.XLongueVueTruncated))
-	w.WriteHeader(200)
-
-	if closer, ok := response.Body.(io.ReadCloser); ok {
-		defer closer.Close()
-	}
-	_, err := io.Copy(w, response.Body)
-	return err
-}
-
-type SearchExtractZip400ApplicationProblemPlusJSONResponse struct {
-	BadRequestApplicationProblemPlusJSONResponse
-}
-
-func (response SearchExtractZip400ApplicationProblemPlusJSONResponse) VisitSearchExtractZipResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(400)
-
-	return json.NewEncoder(w).Encode(response)
-}
-
-type SearchExtractZip403ApplicationProblemPlusJSONResponse struct {
-	ForbiddenApplicationProblemPlusJSONResponse
-}
-
-func (response SearchExtractZip403ApplicationProblemPlusJSONResponse) VisitSearchExtractZipResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(403)
-
-	return json.NewEncoder(w).Encode(response)
-}
-
 type ListServicesRequestObject struct {
 	Params ListServicesParams
 }
@@ -10490,9 +9968,6 @@ type StrictServerInterface interface {
 	// Update mutable fields of a cluster
 	// (PATCH /v1/clusters/{id})
 	UpdateCluster(ctx context.Context, request UpdateClusterRequestObject) (UpdateClusterResponseObject, error)
-	// Download EOL Dashboard rows as CSV or JSON
-	// (GET /v1/eol/extract)
-	EolExtract(ctx context.Context, request EolExtractRequestObject) (EolExtractResponseObject, error)
 	// List enriched container images with their latest tags
 	// (GET /v1/image-versions)
 	ListImageVersions(ctx context.Context, request ListImageVersionsRequestObject) (ListImageVersionsResponseObject, error)
@@ -10610,12 +10085,6 @@ type StrictServerInterface interface {
 	// Update mutable fields of a pod
 	// (PATCH /v1/pods/{id})
 	UpdatePod(ctx context.Context, request UpdatePodRequestObject) (UpdatePodResponseObject, error)
-	// Download Search results as CSV or JSON
-	// (GET /v1/search/extract)
-	SearchExtract(ctx context.Context, request SearchExtractRequestObject) (SearchExtractResponseObject, error)
-	// Download Search results as a ZIP bundle
-	// (GET /v1/search/extract.zip)
-	SearchExtractZip(ctx context.Context, request SearchExtractZipRequestObject) (SearchExtractZipResponseObject, error)
 	// List services
 	// (GET /v1/services)
 	ListServices(ctx context.Context, request ListServicesRequestObject) (ListServicesResponseObject, error)
@@ -11498,32 +10967,6 @@ func (sh *strictHandler) UpdateCluster(w http.ResponseWriter, r *http.Request, i
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(UpdateClusterResponseObject); ok {
 		if err := validResponse.VisitUpdateClusterResponse(w); err != nil {
-			sh.options.ResponseErrorHandlerFunc(w, r, err)
-		}
-	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
-	}
-}
-
-// EolExtract operation middleware
-func (sh *strictHandler) EolExtract(w http.ResponseWriter, r *http.Request, params EolExtractParams) {
-	var request EolExtractRequestObject
-
-	request.Params = params
-
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.EolExtract(ctx, request.(EolExtractRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "EolExtract")
-	}
-
-	response, err := handler(r.Context(), w, r, request)
-
-	if err != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(EolExtractResponseObject); ok {
-		if err := validResponse.VisitEolExtractResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -12645,58 +12088,6 @@ func (sh *strictHandler) UpdatePod(w http.ResponseWriter, r *http.Request, id Po
 	}
 }
 
-// SearchExtract operation middleware
-func (sh *strictHandler) SearchExtract(w http.ResponseWriter, r *http.Request, params SearchExtractParams) {
-	var request SearchExtractRequestObject
-
-	request.Params = params
-
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.SearchExtract(ctx, request.(SearchExtractRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "SearchExtract")
-	}
-
-	response, err := handler(r.Context(), w, r, request)
-
-	if err != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(SearchExtractResponseObject); ok {
-		if err := validResponse.VisitSearchExtractResponse(w); err != nil {
-			sh.options.ResponseErrorHandlerFunc(w, r, err)
-		}
-	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
-	}
-}
-
-// SearchExtractZip operation middleware
-func (sh *strictHandler) SearchExtractZip(w http.ResponseWriter, r *http.Request, params SearchExtractZipParams) {
-	var request SearchExtractZipRequestObject
-
-	request.Params = params
-
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.SearchExtractZip(ctx, request.(SearchExtractZipRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "SearchExtractZip")
-	}
-
-	response, err := handler(r.Context(), w, r, request)
-
-	if err != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(SearchExtractZipResponseObject); ok {
-		if err := validResponse.VisitSearchExtractZipResponse(w); err != nil {
-			sh.options.ResponseErrorHandlerFunc(w, r, err)
-		}
-	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
-	}
-}
-
 // ListServices operation middleware
 func (sh *strictHandler) ListServices(w http.ResponseWriter, r *http.Request, params ListServicesParams) {
 	var request ListServicesRequestObject
@@ -13046,334 +12437,321 @@ func (sh *strictHandler) UpdateWorkload(w http.ResponseWriter, r *http.Request, 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+y963IbN7Yw+iqreHaVpYSkZMfxJHZNTSmyM9FEtlWS7OyadI4IdoMkRk2gA6BJMzmu",
-	"2r/OA5zaz3D2e+xHmSf5CmsB3U2ySTZ1801/EquJbgALC+t++bMVq3GmJJfWtJ7+2cqYZmNuuca/DtPc",
-	"WK6PEvdHwk2sRWaFkq2nrTOuJ1x3mDFiKHkCMQ0FkXBpxUBw3W21W8INzZgdtdotyca89bQlkla7pfnv",
-	"udA8aT21OuftlolHfMzcLAOlx8y2nrbyHEfaWebeMlYLOWy9f99uHebaKL28otcZ+z3nEOPPoLnNtVvY",
-	"QKsxMMg0nwiVG0iFsaC5yZQ0vFjj7znXs3KR9JFWdWFj9u6Yy6EdtZ5++/BR3cKOZJzmCT/neiwks7wG",
-	"ar+MuATcMggaDVpNDUxHynDo2eLVC2Z7IAwYbmHHqIHtJDzllifQn0XSjjjEKk15bHGrsZKxSDlkzJjd",
-	"LjznA5an1oBVMGCp4U9ByXQGqZhwcMdjBTeRZJoXYOrCwfPTzv7+o4fwv//zLezB//7Pk24kV4DHr/2i",
-	"XO8cqBKav/UUJy9A1Vcq5Ux6WA01N6YJZgkaegeY5Rf1io25yVjMj5IfRWp5Da6dItgIqn593ECfp0oO",
-	"hRw6wNuRMCDDp1YhWjHgQszDcPNqj8VY2OWlvWTvxDgfg8zHfa5BDUBYPkZcoMPuAkEY4pSNM/zh14dt",
-	"eLS//9uqVaY4Ve0Rf7vfdlfDTdl6+mjf/SUk/fWwWLWQlg+5xmUX0C2ISxMgF3Cqg7KnPSsvM/28PYQr",
-	"iLAZTYsV3gGivlLJluBTyd1CTiXNgKaSu4DXCddGGMulfavSfMwPUybGTdaXFS/CBN90l0aMP9SSt6RM",
-	"K1Z/14RqeStbYO7SHu4SjRdXfjWUuQNkUUmjpankjhYzZkO+6nQPmeEdIQ2XRlgnkZi8T6/DmNl4BGzI",
-	"hDQWmJxBrKRlQnL9wEBPuM/2IjkQPHVyATg5KFPJA1OOM/CPs9evYEdIYatPvciS7HYj+ROTyQwGSgOT",
-	"Zspx6qg1HYl45D5nQOcSeqkaPv7X00fdh99293t/i1rw7//6bydIMm0FSyOZikteHdWDqUhTv4f5t9tz",
-	"fz/stYHbeI145fa5Svh89O03K6C+LXVwO71jSqASxxncQlet8MU7FtsFRCiPuecYxoVbQa8Lx9yJuCMO",
-	"7puQcMtEGsmJ4FN/rvOH6sTdkTJOhlbS71Ul3J3sVNiRym0kMzZ08qyDB59wPaMrQ4gWiMzKYyvWtv3R",
-	"/aL0ZapYsvrk6Lk/tJlbkNCI31qlqVvv1H+iC3TIpnLKqF5EshfGXIikBz/+TGDmBMShmHAJb94cPV+9",
-	"w8r7W568I0WimSBlaOgdUCq/qC3vjV/fXd+dM26MULIegvhTBWKwQyqiuhQcJizN+e7VgFjB3ieP65Z1",
-	"ri65bHKsBydHYN3gOzjYN6aZ0SI3d2KxKG/35iWFK3aXy7pDbh22ty3Lfim0Vpoo1byAAUZBX9kRXArp",
-	"qDxRfjfOsDGPZOABzBjHLxxrJ5kx2L1g4iQ2JR0j+D3nxm38ZnlzAPTPQjaiMAFIxmnvuFi3t1U0xf02",
-	"t6D/0HzQetr6v/ZK094e/Wr2qkuZW9uWRLBc4l1SwfcO4clyh/bJH1hyyvHM3F8OdbjEf7IsS0XM3ML3",
-	"Mq36KR9//S/jdvFnQ0Cd0Fs06aKFJXUL5Qlomrzbet9uHSo5SEV8pysJc6IAA3GutcNnY5nlsMO7w24b",
-	"kpzm53gsu7jUH5XuiyTh8i7Xek603zh2JBLo5xZSFl/SlTaxyjgEYuYFHFAZ17gaXPUrZX9UuUzuctGn",
-	"3KhcxxyksjBws+NS3kiW25HS4g9+p8t5KYxxN01pENLDkTPt6J2DbhdvtP+Om+YgEwj2GishtyxhlpEW",
-	"BGMWj4Tk/jNw7gTulAlp+Tvrzkw6aZhouDCRDJcQVSJhH3hZs7C5Kxlzd4i9WHNmeVhGj8hqpt3BWkF3",
-	"mIYkF8zOUYCEWd6xAoVpzVnyWqazwOQWyEK7+EZ/duFYuiMrNdRk42f4u0xobtYtReZpyvopX/mNK06d",
-	"MmPd2pNtJt/4VaK3i2f/Uz5mshM7nUBCyvo8DcSiF7Vi0dE85Y7rZyLjqZA8avVQepxjdE9qpss0H4h3",
-	"dbqLNha+g3jENIut4+3I2KpI5jHvuTBZymY8AebYihEJJ3cHiY5uQ47hE2VwAkHMCoFyBsTpbaA0QjoJ",
-	"L5JevQPNJ5yhsuS+OMjTlGRjQsuN0NR8oi5v+ISQ8OE9QCu9+8fSGP+Aac1mLeKBQej7laRAr3R6+Bdf",
-	"rb0Y7eqN+634uur/i8fWTRdu6yEOWz7NEzZDAdUqGAtpgYHk0wUKsnTL56/WouPO/YOlgINmXTgaAOsb",
-	"Lm0byqMvOEcurUjBH4ab6WoXNdyNjVhdHtGC5I7PHRiGmknbhYNkLKRnZTGTjmX0Of3IEVy4EeOIZiSZ",
-	"G9xBssllkikhLZkoDClz9BNS5zhWubSsL1JhZ14yDcjCZT52aOAQrdVuTbWwbvfkLKwcb7mdsZBH9PbD",
-	"DahVmDJw/+tQ5VgYW4coQ56Qv9Vdd9z8MmYUWyn+sY45Fhxt6V60W5K/sxdx4R3egAGL9whnX7fJl8Jz",
-	"+DR9PWg9/bXxQv9c2LGtZ8kn87SwDYTX0EsnFxmzF1G+v/9N/J0jogb/zf0jzWSixvTIsdgTzd3l4Qnw",
-	"dyy26Qz5cRfOrNLcEUUGhsfaaUNjJtmQ62eQqAgRNlbjsXArAC/4eBMTod16ENK+lkH4W41UReJDITDU",
-	"yQoohfTwoz0gJTJmWqPruqDfJQNxokisshkIC1JN2+7/UyUfWGBZxpl2Cup0xDUHnhok+e5s80TYFxMv",
-	"uy2QJcnRta4Tb71gMcqi8IsW1nIZpFTmvgFjkSQpn7obzAaWa1rjVLvJExgxmaRco9LpbqZ55kWqPHNE",
-	"C9XjLHUqU42ERPMuL/C5sh3DM6bxCxOu+2By1HSh56h9lyDaa0Mv2C5pul47kj0nwXZTNRSya/I45sa4",
-	"gZWnAybSXPNe7dG33apUkLTm1/XKHYyjXDmKyY43x7hEry4ZEjfATeAIhJvN7M5Rci82bSTitAjUgCvE",
-	"0G3eLRnxsd1iUsnZWOWOIZqZsXxcSxjpW1qlvAH1CMPdVIGTbHyFTNR0pkkiiOudVM6a3puH5gGefsdk",
-	"PBYDEUNG7LcLB+mUzQwwCXTRYDriEjK6/N3V0Csp28ja7GLM7UgltYIH/o5Gp5W/Ol0zr4othat/lSi8",
-	"9B0Vo+K6Vq6qkcWIPtUi4BkOEwPhLlYSZE3L9JATnRizGXj2zNDkTYw2TcmI1G2CesUK6JfFNfws5OLM",
-	"GHkz88gfrqS7dA6J8PJl4oLo3W6jJdAC6qKMnBicoheSazRYOwFkxAuDBc6FAUZOys55Z5LzBwayvJ+K",
-	"OJLFqzsjpyuYNqC4YtpgtVt10vlDyUoIktntQk/IITf2YjjtRVKQWj8+Pz7rhCAZbmy5poFW0paa/vOX",
-	"/4Qhs3zKZpHcoVCkh0/cV+nC4lLdGZmZo6tWxMAd1TbAx44Y44fKrURSWMPTQRtPOdHo2ujP3F356fz8",
-	"pAADUrZANVgm0F7ld7GeWATsyxpdfJS92dCzmS0FE3dpqndkjuq1A3eYv83Vuzt/U2slnIILNhHkiN8R",
-	"+NtO9ncHO3Aq3rWFu5Ib36F4l9vRoZIDMazZuOYdZE/gGJmThQZimJNNCiTnSYnBb466cIRWIKTq6SyS",
-	"TiZ3KwzuRfqIUTiePpuxIeoKoLlMvNn69dHzw0j2c2uVhD4fOKHNPUdnxYgZFN9QR6gTFpRIYgzknFe/",
-	"pFtIlcoXwXjtFpoAljf/A62ADARKLqy6DUjGotaZGEonvrhNRvL1pWVRqwuH3jPpZbvj16/+/ubFxds3",
-	"Ly7c9i6OD354cdxrIlSGlS8f3cJA3HjdAR+OmBzyE2bMVOmqvXjBluqtp5kfCF+jXhv+XMZtb269CCMW",
-	"lMmH+48e16mdfDr3xqKBD2Pn4OGjqrEk4xpeHZ2dw3f7+50n3/wAw1wkDGX6VwqUHTlxE++TQaECdJ5y",
-	"4+MVHFXEXWQjzQx3hJTFMc8soiaTSSQzzQfckRdQTiY1I6WtF1XfAS3d0Fkt7W8sZPHg0aazXILYAjhq",
-	"T4/YZHPFy7/wMscN1qhfN2FwvLKVb7bNVo5x+LL+5CW/npADzYzVeWxzzS/c5YxZ2kNG6cHQhTNuA41C",
-	"QQDdifMrrbeGPJk/3kftVsas5dqt4P/+lXX+2O98/5v/f+e3P/fbTx69D4//o05m87rONQC/xvZFoJ0z",
-	"bs3N2EAtPYCf8z7X0ulnRTy75kMns2heuDAPXz7/oVtBzdJOdkMIWm+1PaMLa9J82MHQo9JB3IZcit9z",
-	"DizWyphylZE8Go9zf9OdVgoInoJ13N5p15mSGhxBxbYYAO/ti0WIXwn4JsKKf+3adqdAhjbLJeuSEqxC",
-	"Sowa+t/o2V97GKXPbTzCc3NfQwbbjeQBGkFBaXDCDul3UsHYSQRuiAHNx0z4w7wpgWgBP2us+TxNjJMI",
-	"WKAyYEfMQpwKFMmddmW4dbwFUmYLK8fyGaCRFPFxjVLchKsurFBz3nH0BS73JkgNx8Hd5fSBqdJ2BMIa",
-	"UFPplJh8LLvwlqV5yIoIPA8OiyQLtKwGR5hVOR6XU0ocNIrbVF13JV6mBK5T8YK9t0ZpLOnPwcmRp9fw",
-	"5vQYdoQkgongWTCWaNGqdYoJ6/iBsLOaQyxAZAXXJOS57Y7HSpJTxDyFXviEU05HYjhCw9GYJyIfU0zj",
-	"tOdEEKfa5uMOd0uMebLsoDGpsiAk2sSERrBb9k5JNZ7Bzsn+3snDvX//1/+/u0SUvnlUd9bkIrpY59wa",
-	"aMFlks5oY20YhO028mNxORFayXGtWbCEXGUYWDYsPO580gZj2VDIYRsyrZJF79mTOhS+LM7+wgek1Mio",
-	"/rpVkMOPBc0zpb0iXEGjHS+lP+w++r77bdRaXEothBFoTW9kPQgXOKvuC6uZnqES0zF5lqXCIQoFEl3y",
-	"2R7iHB2X6Ta8TFLZOsfMsZJDOqFMK8O7cCBnMGb6MnGIJ4xXtjBpzVGsjhEJX4DLdw+/r4OMmsra4MwC",
-	"J8jQizQHLT+cjWEPlOzELE2JTKqpNN6PHhdCWq4HLA6RqSGYldRDo0DIGLm9z1tLuDaRvJRqCtORcvxj",
-	"yi455NnSBVrlp1UTkdRt5I37djpzh1JBokS4d/s56hZKYxStGxK+043k64zLjgNr8gx9CBUqMrx0yuKl",
-	"aQNz/1EZl2YkBrYN2v3i8J4l4zYop4e4/zt9plY+qbHBDf092Tgyl32lLi9yXaPpHgt5SdFL3J0OOog5",
-	"Gz/AaDH3mj/P+UyDBfq7iUm9X81q3yB7vLoEuSRGveR6yDsZxuf1VTLrghOqIYiCyLPMM+hhIDV6yoOY",
-	"6I7SW9RoFPokUz6wkMsYNenE+04OQ6RevRx2WAbyMWNULNAFgIFKZIkkE1oXflQaTlRCdwI0HziOi0Js",
-	"JDFjUefSqQew45bbBozA8/+7ED7BswgbPEMzFzdtEFLYSA5SNtx9hgf4SxGzhiErPqocLB9nTkx5YCDh",
-	"ccqQMBSLj+TCtFLY3S54uU5ImDx8CpzFI+DS6tkDA2bEMlKzkXhOeDuSRpEQG8SJDn9nUbsvwJygq8pL",
-	"aMDAZDyGfj7OFhy+6xwHS/i1KKoWZ/KWuMaRHKhlY5EwF30+8j6VOnORsRfxiMeXW9rsHZCNvbBsWONP",
-	"WBBPK2PblQUtz14nwb5Q6QuC76maLu9vfu3LclNpcVj+bRaTSFwjM1hhZ94dserXILKs+j24EoJJOiyl",
-	"jbkFrXZrUm+N5iq9CCRkBdjX/HTBJkykQdiv4xZJHtd/oHT/hCVzlbacmJtphREhwwt64ng+CihOLUfe",
-	"JesN6zRuM4ZUQVYF/zywy+WHwysWXYc5P3GWkrtrHmWW96kua5e/UnT7IRdpUkhr3jGkc4ncpvRcdDeq",
-	"0mtWj1HRp6g361kN3m82fNUg5hrDsZMD6qVwyuIJvzuZ4cFXFKxg8sFAvKNghQcwFWkSM13rFyyku82u",
-	"OGb5BeYoX2RcXxgez21wkCq0BhWJyfvd/TL2hfKkG9qn1h9NAY/aJZXA3MZKtXCqJ46nb2nfv2NAvt+0",
-	"hzeZ4XTDt9hEFddWo8qt7aj5Ma88wrclaVjgtyjJOAWufguVC71Mb5gWzNfuaGTIqi7lLb28OcawXGBl",
-	"OZXJN+05SIjXscDNwXCzGe6q1q/qNKd8oLkZhXCl5R2wVHOWzC48Ha/H3N9zntdj9cKi/MD20mc3rTOc",
-	"4/L6Cvva1qLjNaQ8Yy+41o28tNXh1wq7npctt4icKAMoPVrXcvUSwAt8bpzZWTBjOB0jyzGEczyhCKS1",
-	"SBi+WiynmXTrq5Q0Vxf9C1+CR6zIvphwcoP5vXfhjHNf4mb/cWMP2DfzDs5an8jOrx3/r6/Co92/1fq/",
-	"5tKemkRG3Z7DrJJ9dUv+Mw/4df4zP2Rb/9lGdK4XSStrCxWFUDbdef7qrENBDsbOUr7bhTfkTcu4ruSy",
-	"beNLu128WfR3YdhCtfxMF1Yt9Rn5mMLYSI5zY8HzG+Dv0GtGpktCBB+ia+Dx/mPa5+a80kXH3yKyXcsP",
-	"GM4ux3gZVk02LFGqiWewKNt0XddgoMdfgGtw4eqtcw3KggJc0Tfoz+ciTpkxK5w9gYK4IXSbKe3dxx5p",
-	"6GNOsFXBNxO15FDId1HL/dNqxgfictkpUpfG++l4RbBAQ5+lTMb1BTYcJWIpuHGdMA5YktB1aMMYc62F",
-	"HEayR9aGrhv7gx/a9Sfz62+9LrwoLJ8gTCR7f4rsb+1C8f9bGzKlrfnb+14XTlSWp8y7qKYjZtGVOsjT",
-	"gUhTnlDAfEAail2KU5Un1fNU0qcsFAUHTRuUjuRLbll6/APsIQ/qvD06gT1gMGI6wZh8pCbFZpXsZJqP",
-	"u3AQSSPkMOXFHsDOMhGz9BmM89SKDj033OaZCZkEFOqW5CztGMviS9iZPP568mQXsBhfksuESQtvj07M",
-	"dYy3Y/bOJ+pUnHQFacEQr5U3ArTK0UWDw1abq0NGRXkeaHYvawtiliASJyprBDvubNuQMTui/6IFrg19",
-	"Fl9yWVTviCRexz08/92btGHbtGbb58dnC9GZbnui0dbdhkwkHUUix8SAay5jnsAZZskgYbm5HbxfTVe3",
-	"9QMtSkLX8gMFLt1D2uxdQ0zzSJbOIWjqGzoOYv0CxXt1dnbkAG/VULNsNAMUOymNxji+QNUEHMmeE9kf",
-	"BY9qJC+FTDpWdejNMcsyh+fF6fkICQ7kMaC4N/EuDFcJT+fDvnmsfJx3u9XPjZCOl7dbFU3C/ZWMhXT6",
-	"IfPB1vWhd8s/ZKOZwV/q1MpjNRRyZUDqG59aAl8XQahtqnQRmPUy09wuFrWavLKBdy2ICMWb7dba6M2X",
-	"vK6iCJJyCl+zszZolfI2niAfDHhMVUYw6bBGKkjqAQUiISHIocdf3fLaRbWZyg9FdupG3SvkFM1PRaka",
-	"9MH53KaJKMKyfd2ddpG85oZH0o3oHfi6AYhHT+EHzN7vdeHNUQhLwHxPnTiuNJvH1Lm0ptrUzhytB+4i",
-	"rokx9umBC+DqwrnOKXChr5R1qJ75rA88GjfGRJIK1RYx0lPmlm0oxJRJegGZN8XEQz9V8aWhYlqRdFyJ",
-	"A38X88xCb4+W2glf6/nUXvQDo6/dQSeZixKv2NVCplYzWnmqainkCmCsy/t9sYCkXsVyy/n3//v/Ufpv",
-	"IEvKV2bwnmVfzKLdONnbn/YK8Xd58QV+r73rzUCwiQYUdWdWpgcXNWWaH1PxyhprVVnNsYkR5csI9y7g",
-	"dp2A75s1W9yO9Wquluct2a5KW8oa61VZx3hL+9XWKF5r7ynrrW+y9oSRjjtE8iZtPe3NprYSlA2MbWWF",
-	"xQ9jaltMV1lCtWtZrkpQBNtVNaa9wIomtquyGvZ1jVclif4CzFdLN29tbHsx+nOIbj+fV+spjN3HtF8l",
-	"jr1hcHlRwYullUBz2GkSWb6L1YCskLGlGL/nR4fn4PbZQZugGPg6W20nllLG84Tj4c3v3nwsceWfWVz1",
-	"h4iYlhU5p1nMdKhWlnBt4Box0yNmmrI6HOtIYcocve77BPwQi3+A2gPZoEOzECGHUWt3LpDardHpguOx",
-	"cvQFC2yWeEOTGJhza1mMdeMNEf6mYqLn6j3eQFR0QXi3tYctS1ZXtoiVvP9G7GGvVLLNPlRyr/9s1H+C",
-	"ac0rQCq5ju6DLp+N+Y+FINn9nLUflaxXfFSyvc6zBUZ/0uqOg12p6Zi8nygnx96QtnPDWHrL+o6DRa2q",
-	"o5JmWo5KbkDBcZT3S9BtKjdsvVrjjqWZRgMvVcKxhoeSkWTgLU4dn3oY7PeY01NegrJUVZBWDOygjT/C",
-	"7BNr2hAr6X9ql7U4X58BulN3u3CYY1GzSIY80o6TIws+u9NDsRIrm5WKiPsTRVdUJirSDdZWKpUx1Dm8",
-	"Y/gCPUK9XWTdWcVDHUmeCExg3QtmcDvSKh+OFoVNT3bmdatIFsoVH9cWdUtTFTM8r4s4y2vcJCdvwCFx",
-	"kiN+LOR1EqEgxxVa4PWENtckv7M6N89GfMw1Sy+MVZoNFxnjxg+M+VhRcPI2b2UqMY3e+Yx1aKbjkbAc",
-	"pZn686+O6MKaHEs2Tp48bgPTY/e/LIufPE55G8w33++/a6YMxCxjsbCzemQ8V5al4JaE1I4kBAztIMcX",
-	"RYmEb3TjLIed33OGBKJRynEx/ZXwsXi7OTIWrzTFxJJk1dbmsLmpUDUyWBS9aXZOnRDShpe4vBPNjcm1",
-	"o4fPhbks/oSTo+flH6+4nSp9+UYW2Vm71XAbrNqDhJgyGSu0gRIQjWPIDLXemEkYULMER9h6bm+9PR/b",
-	"04OyPHLGtOG3F7NSZFVe+JTO1ZnuvkZeeCF5urf3sPuX7sNvek1y6e/EOvWxFCvw8Vy+Fl1d5e0Q8nV0",
-	"Qnjpr2sl5EsMgMnZwnyPv62Zbp5xroNun2necWQ1DbUK8JXCDPKcpymcqCnXL5Ihj+Tpk8f7UWsXq1Bk",
-	"KR+jbEISvcqTDmJ14rRAY5n0dRd7TnCJpFf5Ctr8DOblhoY2nrlPL28NK4SE1D3sRNUtizZ0hdoL73do",
-	"aXickfT1HsdPRPddyvQQC7KeWSYTppOL54/NxeTbGnR6+Oi72iWuOe0TLcZMz7AOnT9vf8b1597kvC/d",
-	"/tLqRd24RgeUi0yrd7MVr9XeFPdWyu1qkvAzDYChKFq2AIYfrC18MfmSK180s9ASFZTDCx8HtawOncGA",
-	"jUU6WwfvXipk/s7h9lTIRE1NrxHElbmgljrLZYQd53x9Ron3AWDhWN/0c2lzePSou/+4+w0cn5/VhfE+",
-	"uQODNNmd7rZ+h0ouYpHoJoUvQo2OWuPKIcbXhiHV/mFELzIed8OvR88LUsam5une3h7PO1NubOch2xOd",
-	"fdaPHz765vG3T/7y3ff7CR/UkLT63aCBprZ+xIRLwbGVCEX9QMK1mISe3kiFUbDqecpWCmDdSJ4HtbJ4",
-	"CDuoqWrOjJJ7KTP2XDNJJRPPxZjv+p4RGGbYK4W5HqAEsykOqQZ73U/zi0a20XHPF3jHV71AAiK5VIaJ",
-	"AqA7Wcokcg8nGJL6y22c9O7Y3K+Sq1j62y1S/usaKaCWi3PikAr20YO5OPMRw0DzSz5rE4jaPm7wfS+0",
-	"6FQJpEwmBrDeOxUgHoCwkbQqddSO+5A0mtC3X6evOCR4pfya+N4r9eIdj3N7Q2Jx5Y4WYnEuK3r+MngQ",
-	"DnNjigA7h0KxTR2G6ETJHgxSNuzWYukfSm4UaazKVKqGswXUdK8uSjPl3a+5508a+nlUsr2Lp2pI/li8",
-	"O4ttgptvZ/HNe6/Pdl6fRfjdoAfo4ZfrAVqE6jpvUG2f8qtfAHz9i8xUroXEx4TPX1T6cu1pbH0PtnWT",
-	"bnkbNrojT94eNvRGzkXWXNkfeeM49kWnOrvTq09zrsWTJi7VrHgRJkTaY/fqtb2s9VzgC3C7rr2xa/2w",
-	"7nSvGliK7ZrQAjt/RJtUwFIP+W75aPoql8kFoUXt9fvx56AhLgkIqBi6HQkD+B1M4AuNoCJ5wmXi9LuT",
-	"t4cGu5eSxnHyFrSaYlOLPscsmZSj23fn9St4/uL4xfkLOHtxDq/eHB/v1t/JBpVhPg2T3uYAQwff+tDC",
-	"p+AB3IYfHPTbcKxCe5uNZgHKP+RJ1eG22K/NDwEj/uCwgxppKOBpuqGtV9d/YLeNzciYFeNCX4xa3/5d",
-	"YCPRRovyX1pI/t+You+Rt54vnrIp9HDpNOwV6nxBlT55GwoIYOaZ4/ZVXI7koU8XRkmMjppPuCRCQ94H",
-	"7c17hOkBteUDG0lEb+otxBOYcVvPSxtozbUUZ1s1er2gceN5xFRV/QY06+sKVF9CDJrH5G4ozt/BDL2k",
-	"DUaFPhE3FH728GMOP1sWdepi0RYR5EpC1I2LT1+i5NRMaFoWPG5Eglp5mWggeq5N4BP8XaZM6K8kZ6AG",
-	"kURHxC9aWP5axmijP/Wq7UsmZ+FvHEAPFl85UcGOfzPSXIhvqWkbWhS59kM2elF7UevhfsG+sY1sUrD4",
-	"ZxArGfyxVkF/hrkIBpiPP3G/x1zLhnFIjhNdaD5YwcVfYT1ZEh+JOzuxiEQSfPeUD7ru1WZFfeanK5KV",
-	"l+ckhbPJxDiy4exGXGB3wporfXh2RJ0LqQhZKWecvHXQPTw76mDNlSSswYgujXeHVPRgFbJjNeewBykf",
-	"sngWiGEQ3pqIIZ+XEL1Zhj4IEVdBnI7kKfXET9rwI3atbSpbE35lKhXxrE6wtkxI2IPnqPjAHpxyrFK9",
-	"gD0Pn9y4jExe7lq3a6zdWhxyuaPw0wS3eIls9KGf8PFukKMjWeLtAzPnUfaCT162mEiEuYQ9MCOm+RJA",
-	"v63vJ7eRj1xXFP74vEvUnbfhblTyZVrPVXJvK/9AtvJMJWst4yrZWm1bh8UbFSC3noY5OFcq73lv9b5N",
-	"q7c7vRVWb5Wsbeuxpm9Hw1tIhc7HjsKvqCe/ugR9VXysKVCfrGiuEQSWq1CEpXemvsNN0RF/9YgVG6nX",
-	"yaukZPUh4wk1UqBVcn2VWSVfhJZcUsL1irFKrqoLl72ONjbBnOv4VA3oL3rWrdURGn272ppoSW14yTLs",
-	"6hkGe5utwlwdqgHfCbqokAPVhZ/5jGQr1i+rXLmzpbBSjGezMMP2/FrEI6dPSSU7mAqBBNayYRtCeXgc",
-	"LSSwNFVTh89txAj/iUyrmBvDqeNfTU39TyW6OOEN1G9JmYTURUuYkK2GUbCN1N/N2pr78kZ17ZTaJLTh",
-	"LI9jbMrejiSpaXg6b6jdUDWBqlFthWY6XqaS+mB8lUAlAH/n6GTy2K3m6GTyZLcLR9V+ns8QgyYsFUjz",
-	"3WaZjOTRCaTCcs3SpaXUxuoXxL1OjDhXWSflE54WfdA8waDgUp/C5gC+85xnqZphX8u9SJ5ZZvkgT510",
-	"vQfPGR8recbtLibEVfIepyy99LlI35lIYpz1aSimCvGI+cqATlwvZ/CJnVmlAZxR6YSbSDoIdqhTEJxy",
-	"FPjdGsKj8hulp5G+g2G+UkWyWjmYyvYCk4Arw0p3lcZLkChu5APrk1Rm3HrfVRv+ofptONRK/kP1r+aF",
-	"fF9P2bdWVSti8cdT6/VEq35alzZw+uMh/OW7/b84suhG+Kj4GtZPP9R3RtNaabOC+XmE9hcHy/7i8Lav",
-	"0ElaYp/sKYVYMT83bq926jE3xvtD17Nv+kT5wm8NyhiHXKF5ubS+k2/ZfWzM3lGfom+//77Stejh/n7x",
-	"mpCWD32namFX9HQrE5wGLE/d1Kyvcvu0nzJ5ubG38ML2fQs2mm1te7VTHisZi5R719QZeqZWivJNledL",
-	"zjOy386Jjxtqa65zP1W+uHYfhWV41U6utrStDQjrlbKmuznlBpHhz6XriWEZc+sQ0j553FrGuoWVhFfX",
-	"zls05lwBP0eqt4TfxwN3WvzmQ1D1Iv47nlAaiRPmM65DRey/+JwI/G3MMuxywGCAL1ARWvfGv//rv6mw",
-	"Pj3C1kLBQuPEoYOTI+gZHuda2FkvlOsVpqTybTLrhtrGY5EkKcea+v9C04K1zGnLUExi5jNeMNdlro4x",
-	"llNwf2OBhVa7xfLwr4ngU65rixufUWH55tzSv/BFmkP93j+eYrBflEHUQ3+dUdQP2dYwuhGnNxpHfX+G",
-	"+95Hn6BpNJxdvXnU40YTA5z/0LWNcIEmfwGGuIWbt9YYF+7/VQ1yQRKtsSocGCOGTmH2EvTRCexwbELo",
-	"yP5PnCUpNwb2ipoPaLAJ573bJOP/vs9RTZ8j1KX9uRo0gM0yHsneceWFXugdlFJzmVloQvMMlB1xje8Y",
-	"SDmbcBLK8LYAnp+bApsSzVWhgrq+RpEs2hod//BsqSFS4PeLzZNur64LFgKqyev11wB/vtEeRNSR3323",
-	"DZbpIbcX9EemlVWxSttonLy48eZDhtOabvB2nGCyMrJg//EunKjEEQyLDdR9pnJ5TRi2GHVjqQVMk8sS",
-	"FP4G1PzcDa01WVUHrJMxCvo3y3gXDplxu/BeNURNpwnMVa61hqeDSPKxIEwp7LTMesXCLTF0C5q33Q5y",
-	"m2teFpt75u6HTFKu5wxDcqB07OefPAST902Iwg6KSUFTW5ScfKK0kwSrd7zVblUp6zpNZVvr3qJs9/FY",
-	"+M5I96vhRhIYtUIZ5WMmQwOcGpZ2ldbz7zKhudnqnToh0a++EovkAYeuC80H4h16L0ZqigGMVO3vGVFo",
-	"rCAh0L1B9d5Szi5JnmckTmnfHXquPMRCf+PcbLl3is7zEsDGFBfHVi/YkFOH4mbDm6phK9vGPOfSvZwK",
-	"4zBIad/7Jy7LdmxuIYNzhuUs6F9zgJvDhnrxzFQbja8Tfj3Gely9ARnYNGxJflOi6BtT21vN30EHzgXN",
-	"s/RyXOlmbrRmJMJg5/5tOnhv/OgAHXjY5UZexCqva7996C5enON50viyNZXTOseZNWCEjDk5D02O4dyD",
-	"PMVaprILpxwLiFkF+052XxwABV7nMlXxpXuBzF3uL5U77qS5Gak0ieTOk93COdVzvyNEekhcioSfYLLf",
-	"XwmCigH/ytYlYz3gbvJEii0tH8QvwavuGHMuLbDcqg694NVw/i7mHFOjkK7iaXUIyAUMnXYH4S3/pRhL",
-	"gM51W8Oak+Ggu3BIfcKqLch8t7WTg/PDn2Bv8nAPn+5hE7O9P0XynqoeQo+O9a9ux70u5hnCX9EZS6tY",
-	"UPuvBb5V3dlWVxTa3M/sJuxk1+kDWBBwb0nDlW9jSCNqVprBVppCvEmGDCElpVsmaM2a4D0nxxc4iBQ5",
-	"gMYX5YOIbNRUGctQmWKiq8pi8SAlIznA2oqIwVELBqmakrl1wFJD5cMMBiNQ6zyUGHKrxhWz2fLJr+3f",
-	"WDWr1Uabb4M2a458rfnuoPPP/c733YvOb19vTumqaxPp17kKFZpwcATodfk2ctG7ZdqlRrBJsD/jFtv3",
-	"9sreiJqPmHGcxwn0pMtEsleH7YGaFR8J/Jl+AM0n6tK9TYrlvDxUxuljU8jiG1VCSZ0ZDUnIgREadzN8",
-	"6+9Au+cYgFUKxkzOPO2PJBH/wKfrimSHhdeTyeYE9e6uFUJpFX90CORhNycguBPFLpoGestiD5pC97uR",
-	"fKVCiTJVgNi3V3eqW4VrwSGT0OcQq3FfSJ4Qs0MjVCQJz7zO5/0ShmGVH8zjhk4HWJoCQRabXqczYFaN",
-	"vW3LsVclObw5eX5w/qKelNWZD95yLQazc3XJVze9pYaovmmmVTDBdyjU6PnLf/oUahgyy6dsBjvkDX34",
-	"ZNfhK2KkQE+oGSltO7HQcS4sCImWAPqsgT4fKI2hazOItcIe9RwJOp+yNHVYLy0oLFl7fnxGBeQckygF",
-	"6QcGsryfihiJEpdcYwBRhLIKetqgd/L67JyEj9yO9mgnvTo0p46uq6zkJwfnsNNLJxcZsxcoXsaktZKo",
-	"6R+ZfFA86jmx1ad79ZgeKrPFu02qaC4GgCx0pF1x5KQn10WmucNG+PiOXu425Kl10rbNtcSIwnRWxm76",
-	"zr6GDDzPIhkOeA9yCvaDPSCN0T0jglcc/5BbYPB4/2EZKOZtA5SVRLU7d5hfEtdBBhVywDVQr7G+sNj9",
-	"dqqVHO7WnSrV00Ar7IW/rRf19gm80H5xwpg8XFgsyjcZdwpTaM+78QPaf7vrC13WXA2sZWnJiuZo+s/f",
-	"mTJYzyBAn0Vy4fN+EWhhDCVNsYaiocIf4eMxk5HU3B0zdjgIdrrYKUfeTKcZGb1HDJnKlGFT4ytW8Yix",
-	"afSKwEbf5nkHG4CrqbubvhLyJXfkCnosExe0N8LvjXYP/i5bNRPiFSbNMngjxTvgmYpHYHisZFIa1eaR",
-	"NZKOPCCNJrwkklbCE5VKohEe+03Z8zzlxkmfaoBxzqHRPU/g/PyYDHw7/F0GHZBquttbAPGqSJ1VPa7d",
-	"uvxCuEwyJeS89kW4A/0KpTZdOMSe10WciAl3ps/DNUoqDTSEgdOTQ6+aIx1OlKeduZ44ccR6rB6pbN5I",
-	"u7r99aqGzXhsD4zvwRzCY8z8CaAzOFbSoFYw4oZH0vOJEnmXOYvqT4TKjb+XY2G8mXvB6XCtNs+Hyoy5",
-	"FXERPZuqIaRCelkQo2eCqykUIA7bMiLhtf2gkV7WWJF8RAnJeWjlfLS/Xxo50WCC3ezcQrzpPTe8Wy8D",
-	"VLkEzdhu0Df6rdA2Z+lLFo+E5OtyforAFyWNz9upj+WcI8O1IxYr9V8vh0jUL4N+XJtEVJ8mpKZcX6CI",
-	"Xfu75kNvoF8pvt5AglFNfEPt+YV4vua+j/DGRxmsFchkkw387MbeQYBXmO8+6XVTjJcnN7cU6hVSLip+",
-	"9nVhX+HYto372nw/ApJu9z1C16UtFhkimCSRCPcbtilVen11yCb1iQqQNa1MuVOcaBsXtHtfofJGAtKq",
-	"N+NacWnFidYHpgVs+uDJuyuzYq+Y1YsHdaEpNak6ZUXGXv/rtXlwfYLu+pMtT+TnWgVgA3lzH6+N6ui5",
-	"X3pkWYrkUngH+OiOgzLPDmPjYaeaYNWupHph3ZVCwDsslrCLwXR9XnY8xpQ5h4oYWUKNE4q+ViySPn5k",
-	"LIbU8Al2DOchlP6b3XkNo0wsa7Vbley3VrtVZL/VKiABrE1s2AGy17ZjF8LWFxCEucgG10ZhLqQ53udF",
-	"3+dFXzPidJneL9yo0OmdOLgfCKhzUo4qAi6XVqRA7kPfuKbEwWqAwHpusujQNGjtXDHpszJxF8vtSgUm",
-	"ZinTkPgX6YWNKzAZjzeFUS6wEyGTsies9zvMt0yNRwor6lVjPLHynLGaWT6cRXI+a7gdQppRl6aUl5JQ",
-	"7873yjRYsC6SzMA/zl6/+mHOYxFO9/0acrNtJN+StH4zoXxtz2HbjnhFsgzq276yKoayUtLXmVs03TJy",
-	"vhzk7pr92SID349BJiG729JNOzkqrPFouFa57ahBp88k6qYSOXPPfVNp8Qcy36fgvTzkfSD7KDkfupGM",
-	"5BllkQ01k9an6tMcTyMJ0IGeu149AHLJOGRxxHzIbdnQ0fiR2J21RyNDBIFM/HWDHTF2dMGELxZGbCdk",
-	"PDCk+HD3vV3/PUpnpKrBmo/VhENRB9kPwcgBPyVL01AsgfXVhD/zrXrnzWf4RgeNqsHgahwczskYj6Hk",
-	"IW4mfJ7sjbj+WNh0BoZZYQYzrGRAPwaWiu0RmSyBg0A+qaQStmFMpraq/d9ryNWomqDOvjmKJApQFRcX",
-	"xtcEE/uc7V/If2GocmH+5XICE6a9jRQvDdoNESnKmzmyNquE9pGBeUUPzcJ7HeMo5PD92aILDp2qvS78",
-	"ZG3m7ls7kmdszM+E5X89s1rEtg3fdUYq12BSgQZfMvZ3oQouhN8L9J0XMMVCoZk1wAXuvFfeJfTG9eZ2",
-	"0aO8TDonH5k8pv5wLKk0jy0wEbM8dyimhOzru6B0JOnq+bRL/J2guNsOHhs7dYKdHRkqs1d4eyOZqKk0",
-	"VnM2RvO+0sLQVjBJ1BuwHYQJpkGfeNoiL+jFJOcXfjXlobFM/MxnrffvMcV9oGqqArw4OwdHNtxqv/qq",
-	"dKl+9VUbGJpKyF9V6g9cToRWkjqCspQSYIKHLJIHr87OjuCMx6/yMXW02zl7dbgLv+csLV2KA83G3End",
-	"eHznI2GKLpI7+92H3f1dKlo6ZSnVPbx0dx1RasKd2OCpz7GYcMmN8V57lgj8K9OqX9AAH0jeK4gDHJ6+",
-	"eY60Le8b/nuOtYO9ZAhTkabAkgR7BbfhVWntCIykDScqQbIfnPhz0LHCzrwuNWZZhu5SX6mfYBMzbdVQ",
-	"s2w0I+ecIRzGYgkwUE5og6Jcw06vYlbf88Ubvv6XURLrv0YS+4v6sBF3komKc3c4BGgHxVBA05HU3l6i",
-	"YrNHdsuqI6nS3t08AyOGSGAwcG8vF/62ejnJKifKQdQ61zMQ1rGZqOUJSD4eMz2bU1w7MfpDYkKnRZSB",
-	"ZYwpsaOoZBAQHauD4HcOTo5a7VbRoLSFaONbaEqWidbT1jf4CI1MI+SpeyPOUjv6w/17yFEtLIjGUdJ6",
-	"2vo7tz/5IU6+Iz8Lvvpofz/oIT60u3ou7jzcMxI6NqkRNAXdy/osHYFXa8K7c9JB6+mvv1VBXGA/4ruD",
-	"FRsap7TRNlu/uZf3UP6tbnmh6xw5BA1USFDCMyeuydg930mYZX1mOPXl15zFo1DGYwl6pzTZhwYeyfxW",
-	"+egPq9lgIGI0gH27/82atVQvWPM1haor6xflFDBc2PpTPZ0nY6uOteDz6HJcebxo6GiD5Ngh0IdJerOH",
-	"5rHSCU+QbjgSoqTpwimJKj4Op4ef9zJOuyoH9pUdFSIQ+r196YAeckhDbNU/o0APt3uSrSbCiL5IHa0M",
-	"liESzOiZVT6TLpIUsKkK57ajeT9i/3QSjQ5ePe+E0Kou9NCL3YM96KFm1wtdI3AvKo5zrX2gl3YSOOyM",
-	"WDroOJrxFHq/4tttUgp3Q3+MeSQ/FsYeuE29mDgcQPLi6JVF28QKZaQcsncsxsKiz2DDwEMyFbmRi3aV",
-	"lEL4sOeFE3O8moGeJ2GKWFwUGH7PuZ6V8gJzOh6ZnEvc3mi53rgEhrFwjlUzKNTLguGi58KXL/dGUqdA",
-	"uXVSCEjdSsPbF76kTbncm16eSDauYQFgW6ygMiFdMSzWHqCBR0XS/WpI0HvXBIFXdZwGUa4oxMt14Y1x",
-	"+jo1CGLSTFHKgqg1RXsdNWMJASN1IU5RqxL/F8lwqTGir6N95TEU5QjmRyemItUubJjGzG24qFeSCXzJ",
-	"zX0xnLox1Cj7t1q0rf26u+T1+L/W1l//NaQV23/tt1tkkSV5IhvoMldaSMKioBXEE+SRj/cfrpqjWPTe",
-	"G+k1lT94Qi99s/mlH5XuiyThcpEFzhs8fqUyNK3fHNQXdM7ytwVhyNi5nVQYJxW5WeCbaFsNhli3RjSe",
-	"ehtnrXTopjhyb52WY695jNdxNlSXMttYUmuVIX8ZOV7//LHggD+2Whzwvy3jACrVeeZbaJTHWprDlzDD",
-	"+ysLZHBztjJlanCAggXmQV/07fpBUfP0G7nFc3O8yQzX/rTKU/XxJAsY+PB2llCHKgQNf/T7m4/+B5aE",
-	"aPO7QjH3xveb3zhUcpAKb3y+SZw8SBLsvuJdM94UsBUuNiNbe3+OlLGOK70v68QtIzB1t1hE4AUZFhmd",
-	"U5tLPhc+3lpEwHViyTKXe1zXnR8OPbbeJVI83vzGK2V/dOrDjSPFKZmrK3hRmBm3pVLMxqPlUz5xj+/y",
-	"kG+Z/uF+mpG//bsjf3fIKT80xpLbrYKxDwxo9yR1+mwbuMTkMBikbBjczdxsTd2CRX2tDHYWBt267n2b",
-	"Unq1SsJGEb0skPApi2Z19Uk2yulhHKaKz3O2Ra97ijZ4n3nyrIyTCcl0fc40Oe+w1jZ6p4bcGni8/9Cp",
-	"vYn3qIHmidA8tugFp+oENaagU0xlOivcLptZHb2RdL8gRuc2TGmo1czWmkPf9jL7BRwlrfe/zSEMGQrX",
-	"UpCDTJBD99MmIWEbzWiIN6B+0hRkwTe+M+aWJcyyMi00S5mQ1t36okbQhJsizne3HvNUXZDgqY/wLWoP",
-	"ld+2PvuMxTadgZIxD/74SgmiisvKR9L4dC1hDTA9VPKRSGDEzMhXPaAkypyX+VqR1NxJ9xPuI+S6cDSA",
-	"VBnb9pmUaHofY14YBl0qyetoFWlqAWFuSWUNn/cR9XesrYbZXwpZexsoY9CBiifPKmdJxaaqZ4hRQB+z",
-	"UnvDV+tliT5zF2wTa6ZbuJExn2EyvU/8vWC294wqvpHrPXQsr3DnkFSseczFhEfy8f5DEOMxTwSzPJ11",
-	"gc5Sqyk5gS55Zr1LOxHURkPIXFgiCbnxJR6REhZ5lBg7PxF8ChnD2mET5bPXVjP7uQt0z+1XcPuNWLQt",
-	"10WYL3N69A2uZfRvcMQnzeSLQiwbGbwvxfIp8/eymJBZy6jrmBsWkbkdxlapi3THTI0q4yyfvHsewgK7",
-	"9/bX1Wh1GGpVlai1ia2VlcnWcbVDZmKWUKB0qNHzwBRqLcplr4+eH/pal1Zw04UiRNcX7MFCViSS+Oga",
-	"zBlIYOf1K3j+4vjF+Qs4fXF2fnp0eL7rI12RxtoRH0eSvytiTjG0o03FRhjl7I+D0hXKCKEyjHvEMIpT",
-	"PsiNz82Bx/vfV8okYB1fECT7osxKKSToQsePRpLCULHQQ8qM7YSw1AnTgkm7i4spPknhkzBVeZqgYItw",
-	"9fxeaHAymE8Jr2O/pNwXV3wT66XhHzPr/dD3wne5ZqtuRHtlhFz9IezfCcn7cmSpv2NhnJWHs51A40B3",
-	"RMnFhcNgdRKE4WMmrYjNbdU+w1w2rPbXpPwZsx+i/tk68khgIlJWUFtIyk597pVI/sG1CluiQsZIwUWX",
-	"dyHhY4Wb2elplXKEiFSSiCjFkxO0aMx81bjd1WS5IO9LFJQs+FsJSeMSKb7e/g77TJ07dtqspB6U3euD",
-	"4z5ygemT4iSFa8hLQA6f20VJ2DYE3CXhpHpD1whiuR3tETnpVAsG1hvqihhmFDRyjXn/5QI8vSIJCC1k",
-	"sBPMb7vtSIYqgHU0jBK8QtE6rLhEpMrH/q8o2Ig1/IhqEXQ7ZNEgKYiiYR/vf+NbgoXcIjT60QJKcBa1",
-	"deusejj2pFLO8xaUn/lJiuvQ5Fo/rgtI9jWhQwrcp2RnW7wQi7oGHV0VCxcOsYrx+VwsNyI8FhNbGcsd",
-	"7NGXUvUJnYlrZWzoMJsnhmxaWPgBLcoqYTNsDRfJ6YhjMhSpJHOFy5hM2iAGYFSbzJ+5tUpSPm6XMkwk",
-	"pZemM19pEZvkYkMMHaoCYmk6LK8tjXCXog5h/86tozOHtNFbjYEsZqlhBu7XAgKUh7c2Jv+EykuypdeC",
-	"w5Cgn2lOVbTXHzMNWUnNXrwrqn1CKNoLX5fF1NHOuZBkF6ozeldm0V2XygqEnq99lcxIKiLBJ9ccdqRy",
-	"FNoKSdHJfW6nnMtIhuKNqKI6GthnZUX3XZTGsHLqYv5ZD5gpsvrg66W0PvLL9rWaognD95sRlkq+F2Zh",
-	"R0E7SouhwOqG3kYcqjZj8dPa8HwP/tsghPjt69K/0AGjsN20WyPOEm/IPOO2syq58mz+xNfGg7+/S6L6",
-	"6Pu7zKg5D6L7gsgO506BGDIhvads7Y0+s0zbwipU45WuvbYqt6vvbTX+gKp/dYxIStlAqyneIy9uUNY9",
-	"HmUkfbd0A0akXKI9R+lCWqgk6jmSOxFsruJjJHcCNSafhrrku2AwcsHJWsKASPg4U+58Vlwat7Ot0Jfq",
-	"/Hc3SJO1YuQC13zh4y4Cy9ziSKhS0FpmOZe6601xs7YXUqmEMwpwmLZLwh4lC9VKgxjfRMUqMUyEhU7p",
-	"BeONpPt0h2FLMMkmYuhzkjFDlcJKgskQteek4yU+X82ljme+5LfJK1/y2theMtgFkF3V8nJt9PhlpICN",
-	"4YjOxuejSDiCRK1HDiWSeK9YykpEeSkwQwgGmpsR6SVtOPn58AXEKuEXoe6w00bSlNNBCe3rPkglY/6s",
-	"dO/bES8rFX8NMniVe24xF24xVDjS9J5F8pv9R4X1uCKOHSUnDwwUCy8cllUe/xgFOllIc6g4FJ+ow6LX",
-	"IokPCmAsYNM3+4/qbtA8th4lJwvc6tg7TOdRbUO/8velhrsQTVm7FyqiKkyl3jeEfu1NSDw2V3ZfZtWy",
-	"Fx13ttgnogEOOfLRZ1RKvhaFDpU0+TiQfrQ97REKFbiw53HBWKeMYi+14oQjacXYUaNC8COMSHiZJX2U",
-	"nLTD1+j3o+cF9cdyHw4l8wSbPbUxgZvZXPM2zbvbhgHmpKvgNfL5nWbEEjUlIe+SzwjeveKLJu/v9tro",
-	"oTCl0NkGj7qRxOzwXhd+JHHSQIqJ8bKSNv43xH2utdJ/pSojmjOjKmVGapH1MEC9PnB5IQ3LQWurqOVV",
-	"yWHeLnH1GPdGd+nNUaOrtHx31uD7oRpnaNO/HspTuenVYg4WHJAsxaLRuQl5p+tbAsD//s+3u4gw2zcD",
-	"gNALAIR0X0AHlc6N5Qn8oSTHgiCO6JjS9FJEV1GTddQ4kPFEstI0XefSYHflECBKTLoUHKj4txOsSIQI",
-	"xemdBFGVGHwZ8pD1OFaJr1/v5NSfzs9PCot0NSrsgaGS0JGM5FdfYRWMIjhFFBmbaOZVcr7fwfj8+Iwy",
-	"qQnikQypnF99BTshGBvLNxy/fvX3Ny8u3r55cXH06u8vzs4vjo/Ozl+8ujh4/vy0t9ud+3Ak6zop+NR1",
-	"X2dSWBKAsB3DiMnEjNgl987CSBqV8jmJVUkYc0fZhBl7A5kwCNDQ7Ef7/PhIztUmArofoYx2OCSqYPjM",
-	"91UVTmSMubZF44DCEEgCDDPVItxdOJAztLTj8v0YYUIF/bLN5fzuPI4HsDhI9Xym/IFMqLXCIS7mkGvb",
-	"A0O+Cl/fhM8drGaWdzBunmarcDZKGB472GROf8BE2M7RSST7eYK9EhwZdmTRWJU5ySJmhlc3+KCoXE/1",
-	"/93W+jMnwIbs334+HM6gn4u0VlCotIm4JT26pvfIHTsJ6lphrIwYLFpbFNiyjgYEe9gd2jXX8ATaKMzr",
-	"iyvpf+havDak6jAMuovKBxtGHsk4zRN+zjVWREZ7xLI5jcU2NGSmWowDTI7vAnYCMhxjaYnoM0e8jUUf",
-	"gbB8vCol3ydJbZP5dnPY60+gWVBYONNPOJ7Vqdm10WJxiYoBoYtHq8O6jwpbCMqpWLkPw6qlKtCkkLuH",
-	"YsIlYQ0WgXaXHSSfOjV/Sn1dDMdMYyyB8mj/Ifik2B4VovHUwH2fLX0+kiit4Ofnak0bssTjv9HKTpMV",
-	"xnZqmPhofx9e/9wrU1eKRBeVUNOZoVROh8KSe96YNGXSelORL71H5QkjSf7yYs6wWDNCR7evTJVnfvKy",
-	"n2OAOTVzXB19fljUR74VNxV9fZswvRu/krV2lPkzd4LO8nE/W3vca3SFBSf36VGocbh4jN0VFV9W6ug3",
-	"GcXYADz19vBGW5V8ms6KGolX3e+nSRuxqOZyHLYX1ZUGLg3WtYSyOnkNrVwQAGqCH+vC8aoXepPhOJxz",
-	"8tFH5q0HuIfIqmi6tVBeHVO3EpJ3SqKo25r5ZM+mTlCgOLoNx7KdIOvBdYWAuqehFLAKlYFD2j9ybKb5",
-	"XG1gX1XYMfK1PTbqAr22ZbZXj/XyM32YcK81WB0ivgqG8DkFfV2BK/g4rfm61lj/qRFv4Crd49Q1ZKUh",
-	"/MeUWctl1VjfFcq92v0KMLyJEqwI78McbZAq4YbE2An1GwspRNg4UaE+5oSijGvYCdp3hv0mqMI4xadE",
-	"skc/YtE4X5aQyrr3vNZnYCy09mFaCTOjvmI6eWAgHomsNvPrhUp9t5Rmpmgva6yzIYdqZrGZtNotxPjm",
-	"9csqO6wtkVZpQ0JG8clW1dEQWrUf5ipttd1d1QoPZ3hBT4pqS612y0eN1E14XZW4UVGs8rBO1bS2KJbl",
-	"7+yeA3y906ovJEN4LMmI7SXDAs7js0XnxFZfz6bzXJhMGbHZsN9u/WfnmO7M25x3znUusSrv/FtF20Wd",
-	"8zoIX1mMvQVtvS58tI4/P1dTiZ1BXrw+hufhPvrUTgOHZ2+dFPuPs9evKtTJ4V1BmBYqimys3vY2jGx0",
-	"m9FOO3cdEmpX33r67T62qqAGDY/2a1o0rLpkvg3MFfxTuizns/W71JRJ80xd5W2f1nOVV0fMkP+v7uVK",
-	"i8oVJ8AwEINji27yEH1c9RarWLXKKPfRFNVbaUwrWsuUjWsQYUxhrRLat68BvIfldVxV02epVhnGWFRd",
-	"i4s51jhg8ZYuHNyjWzk4P/c6d8ABthUIh/IF5E6eazEcYvRnmX3v8QTTXOJZnHLYocQ/JdPZ7mqkaC+G",
-	"+C8gx58ldXq/rj579cwa1TSbo3rXKV13OwTj86ortkoDR3+K2/UDU0WgHZam4BmL2W1CUeRQc2M2FWkt",
-	"Rn0UPipcTNFJ4iih2sy3WzXAz9rMR1RA9XN0EokKMhToVTzbWOmVRt5WjVf6+ocpLRC2VoMe/qebM8p7",
-	"gH82RvkPnaS33uyPjZ4C3tbh/CI13dM8VjIW1MZxfXg7pb/5V8Npl25SarU7HSnj/Zo+olPISPYuOc+w",
-	"S5zp1dfY8auoEvDbuHfFRAVVxj5nyV1bL4t1nGKgWd1VDEOE7wflg/w+YUpdeFDq5NB690oBp5Ka+zSo",
-	"aqfdRpjezLNVJfubPFuBWH7enq1NJGW1b2slLPfvkpV9tr6tzQeznQjsAXZH3q2ioSbZ6mvaaDb2eG0r",
-	"ql3d4+Vn+jAerzW4HjxehbR17/Fa4fFqKCAVGLpe33xVDvtogyI3vFRsoXBu34WWWszaTE8tj+NzVFRl",
-	"FYsCUlYeblJVX1VEodsQmksU+SDqarm9Gjwpfrw5lbWA/L3SejdKa60sP4f/S1R5e721VFHnNNciMPd6",
-	"euscI7hVxdWT6Xu19dNQW0uU9XrrcsTNBkxvprfO84CNnXeKy/CZR2VupCyrtdc1EN2/a972+cZnNjig",
-	"7eTqirvl1vVYf5dvRovdXoq7uh5bzPVhNNm1WB902YoYdq/NrorfbCw5qWSTKosjPlktViV3rMCqpKnu",
-	"6gD7WaqtHmMKvMO/NyqrZb2GG9dTHRJ8GBXVbaqOg6vkJhVTldzrpHemkxKeLiJ3lZ5eQQl1+HBV/RPe",
-	"VGpuZLkZQazSlMcWe+TDkOk+G/KOfxjJ0MPcUCnlRBiWZVi8q5RrUjHh8HPe51riMlPKHVyv6/p7f6/m",
-	"3qu5hZrrcGK1hlt3eRrqtYFdbG4mm3z+2mw9TVqjw9ZCb/9u+N5nrLSuOoctVVWVfHpa6jbi2zUUVJV8",
-	"KN10BUoXaikKYfca6UqNdK3c5OslcmknKs3HPE6ZGK9XTE+KV97iK4f0ykegqdau7I7DfWvX0EwxLc8C",
-	"6DCATuNz1FVX7bWCqStQc5M+W3sAtyQd1871YTTe+m3X4VzdwJvTiVcc7L2afEdq8gr4N7lXa1nC9rr1",
-	"ydvDWwpKXsmB7iOU73XgUgc+eXu4Ljj5ivegmZq8mgttbMtSS58/c0X6GlRrtbLd8Az2PxYe/Pnq59c6",
-	"3u3UilrQfnoh1NeTYq+u59fO+2EU/8a3KVgCVoqe98aBVcaBm5cWt7MdfKRmgzv0Wy9OfkVTwZdhJFhn",
-	"HtjeMnBXRoGPwh7QRAy5RSvAvf7/ofT/DVdmFRm/ir5/K5HcdSzj3tN9r+UHLX+ZSax0e2+F/1fT86+k",
-	"4n9x2v1GNt5Upb9Lbb4RB/2CdPjNsti1FPdPzRF/Zeny5pT1j0NP30pFv1fOt1DOG7IylWxQwt2Aj0Hv",
-	"VkmNc77Re1i3bas3XqkEPThbvfSL0pepYskdmQJU0lD7V8nnqe8TYhY47v7cqNSr2+q2f6KSD6S6q6QW",
-	"B1Rygwq6Su5V8rtSyRFFF7C6Qqy3V7UzldyWa52u4L0j/V7FrqjYKlnrSF/G6IbKs6fdG/VllXz2KnId",
-	"jVijB9dBbv8uONBnrODWH8GWWqxKPkFn8xYy1DW0VZV8IAW1HpsLnVQl91roGi10jfRiONPxaGMzmtAt",
-	"n4SXoFTBHjiCsgdvfaOZl9RoBsYOubAx4ohHErtPd6jVCtCEgH0JoPd7rw2aOxkV2wX7jt5+6KWQSSTd",
-	"tUiw77/7u0f9kgd5mvomNDzxraXBcOr1bDV377QhZlnGk0gyO9e6+cV/np8eHJ5fvDz4z4vT17+c9WDH",
-	"96GAb/dhf39/17czpc7HWSSFgZGwoY01HhfETGvBDfTqu408BXcp8GpTm+0Bltx0yxNpClOeph0nsfME",
-	"+3LsYVuOugt+hgDbqmvO72urs4/Zu2Muhw6XHn37pHEzGwf9Ro14ph470EJBwqhvRHQRGhFt0UPnxjoA",
-	"XVfvZ3L2ekAgb9I8J9yRdR102g2/daJu5DP+lvpLuu6Lv91ecx/EdmHgzfmPne+oHQaDH16/RB54eHr8",
-	"I3CZCDk0z/BGuKEMBimzgGtr1hxofn5mLaMi+c/wFjrM+mvUKvtqdYgodaJ8f/+bGMmO+xf3D37vmDQf",
-	"zj2yhv7s0p+xmfw/DmPoYdRa39hlTX+iBWlNc8MltdKPsFNR1IJpoExaTR11gilD6tSt7TP1WbY3IpLo",
-	"yf6a1kZ0rKuYXfcPka1keD/kMkl983s70pzPTwrIZQ3sFMSuG5tJm+x67l+RXKR57vEuHiWD0xcHz1++",
-	"6Np3llqyMTBCDlMO/zw62cgD/imyu2AD29FLD8tr0Yl/Hp1AH+F+3wLsFu4IgxLAay+JnohNVVrPwqCP",
-	"wAnh13LHWYJ+1mbm/gDTz9Hkb0pUKFHKP9pk+vdAvCVzpf/6h3EBhK3V4Ib/6eZcAR7e9+6AO3IHmAJt",
-	"azB+gYxu7xrwb96Se6BCue9dBPcugtJFEBB2jZtgDZY3cxdU6f0ml0Ggkp+522AtLVntPlgJyf275GCf",
-	"rythw7FsJ/R6cH16boVt5bOruxb8TB/GvbAG04OLoRCx7t0Mq9wMTaSi0ja8Trv8pWpB/iSLp4YdXCk6",
-	"Lrz8s5BXeGsusO42NeAwYTMVuDSUfYY6cNXlEZC/fLZJCw6AvCWRPHz+w+jBxeZqMKTwI96YJhyAfq8K",
-	"35EqPC1xtw7xF8n+9tpweHW9OrxzKWTSxse7kbR5lla0Y6ruyjRLU54CacpuvOnBHlQVZ3IxmbX6c5U3",
-	"3aoCXU50rzp/5Kpzgd5rdOe1t6KZ9jzHJzapzwVt/cz15w0EaLUGvRqa+3fL/D5fJXrj2Wwn3Je5HHer",
-	"R7d96FH7+gr11qLe1TXqMNWHUanXYX7QqUth7V6pXqVUb5Kv1s5Wy81obq4n4dbNH85hrjWXFpQWQyFh",
-	"xwls4zGXibs0SkNfq6nhutNnhicQtc71DIQFlduoBRPBYC9RsdnbbbVbuU5bT1t7qLzOT+Ik+xQSPuGp",
-	"ysYO2cLokbXZ07291A0YKWOffrf/3T5ed7/9pU85eZAbg3fTkSKBf2Va9bmBnRyPnzsi4HBut1uGR4w4",
-	"S+2oZnWV4v0+v9SA9iIvhSI6wnH48vkPla+Fkeu/R0XdMWqEa9gDd9e0SjtZyjBskkJFdjEuSsgyBb4y",
-	"EZX/XT9L2SFt3YfKpjZrv4a5A//+r//GXTOrxiKGgjBMSukHcimsqUyAwX9rP1286uGQOlDvPOdZqmYO",
-	"LdpwZpnlgzw947YNzxkfK3nG7W43kgchZsZ3Z3CCaKbS2VjpbCRiUHRMRLohEW4JaMFR+hkYzuHg+Wln",
-	"f3//G6LWfs3l5Vq78OBFK+E71+LSf6ywf639VtGgvwuHKTNGDESJZb0KpHuQshnXkHEdFv/4GQWXRq3p",
-	"iNkHBoS0+N0Of5cpw5O/RS1geSIsINl0QBLurpgp4rK7sIPc5ppHksfKzIzl4w5No3mKlN+MRGbaqEu5",
-	"4fTjmI/7XLuf5sBX9v1d3rKvytEx6BCEpcT7srmGQzYlKcLNbTYe5fLS0cM+iy+FHEbSWKXZkFOErq9S",
-	"EjMJI0cFVG67cIzL7Ak50MxYncdukxfZaGZEzNIe7Bg25pFkBl6phO8+xU+dvIUxywwoaRWEsQ53LmEP",
-	"Ds+OQokt47BybuPL2bzLACiMgatAQEUE5+HglhWQsmNEwiPpJQckxx4Qbeg77gMYS7YEWSVjAlUAW+zw",
-	"LJKZVhPhmAPXMGIGDLPCEPaVEKwi4Not+7piy/v+KR8zCRU67LDQ7S03XKMjew8yZsxU6QRSNRSyDYa4",
-	"FoyZZEOOtCCSxSCS1Lpup+Em/GVubW6ympUcJGMhO0qmM+AyyZSQ1jzFZVQnCnS4Y9Uld/fF5EzGvB1J",
-	"FjswdMLiNJ8IPu3C31GcCQSHuUl6gGcMO1ql/K/4aHd+he5R6/1v7/9PAAAA//+gMgN2qtYBAA==",
+	"H4sIAAAAAAAC/+y965LbNrYw+iqrdL4qdyeSuu04nsSuqSmn7Ux6x5cud9tTtYc5LYiEJEyTAAOAkpWU",
+	"q/av8wCn9jOc/R77UeZJTmEtgKQkSqL65lv/SdwiSAALC+t++bMTqyxXkktrOo//7ORMs4xbrvGvo7Qw",
+	"luvjxP2RcBNrkVuhZOdx55TrKdc9ZowYS55ATENBJFxaMRJc9zvdjnBDc2YnnW5Hsox3HndE0ul2NP+9",
+	"EJonncdWF7zbMfGEZ8zNMlI6Y7bzuFMUONLOc/eWsVrIcefDh27nqNBG6dUVvc7Z7wWHGB+D5rbQbmEj",
+	"rTJgkGs+FaowkApjQXOTK2l4ucbfC67n1SLpI536wjL2/gWXYzvpPP7+/oOmhR3LOC0SfsZ1JiSzvAFq",
+	"/5hwCbhlEDQatJoZmE2U4TCw5avnzA5AGDDcwp5RI9tLeMotT2A4j6SdcIhVmvLY4lZjJWORcsiZMft9",
+	"eMZHrEitAatgxFLDH4OS6RxSMeXgjscKbiLJNC/B1Ienz970Dg8f3If//Z/v4QD+938e9SO5Bjx+7efV",
+	"ehdAldD8ncc4eQmqoVIpZ9LDaqy5MW0wS9DQW8Asv6hXLOMmZzE/Tn4WqeUNuPYGwUZQ9evjBoY8VXIs",
+	"5NgB3k6EARk+tQ7RygHnYhGG21f7QmTCri7tJXsvsiIDWWRDrkGNQFieIS7QYfeBIAxxyrIcH/zzfhce",
+	"HB7+tm6VKU7VeMTfH3bd1XBTdh4/OHR/CUl/3S9XLaTlY65x2SV0S+LSBsglnJqg7GnP2stMj3eHcA0R",
+	"tqNpucJbQNRXKtkRfCq5XcippB3QVHIb8Drh2ghjubTvVFpk/ChlImuzvrx8Eab4prs0IvtYS96RMq1Z",
+	"/W0TqtWt7IC5K3u4TTReXvnlUOYWkEUlrZamkltaTMbGfN3pHjHDe0IaLo2wTiIxxZBeh4zZeAJszIQ0",
+	"FpicQ6ykZUJyfc/AQLjPDiI5Ejx1cgE4OShXyT1TjTPwH6evX8GekMLWf/UiS7Lfj+QvTCZzGCkNTJoZ",
+	"x6mjzmwi4on7nAFdSBikavzwX48f9O9/3z8c/C3qwL//67+dIMm0FSyNZCoueH3UAGYiTf0eFt/uLvx9",
+	"f9AFbuMN4pXb5zrh88H3362B+q7Uwe30limBShxncAtdt8Ln71lslxChOuaBYxjnbgWDPrzgTsSdcHDf",
+	"hIRbJtJITgWf+XNdPFQn7k6UcTK0kn6vKuHuZGfCTlRhI5mzsZNnHTz4lOs5XRlCtEBk1h5bubbdj+4f",
+	"Sl+kiiXrT45+94c2dwsSGvFbqzR16535T/SBDtnUThnVi0gOwphzkQzg518JzJyAOBZTLuHt2+Nn63dY",
+	"e3/Hk3ekSLQTpAwNvQVK5Re1473x67vtu3PKjRFKNkMQH9UgBnukIqoLwWHK0oLvXw6INex99LBpWWfq",
+	"gss2x/r05BisG3wLB/vWtDNaFOZWLBbV7d6+pHDFbnNZt8itw/Z2ZdkvhdZKE6VaFDDAKBgqO4ELIR2V",
+	"J8rvxhmW8UgGHsCMcfzCsXaSGYPdC6ZOYlPSMYLfC27cxq+XNwdA/ypkKwoTgGSc9o6LdXtbR1Pcs4UF",
+	"/R/NR53Hnf/roDLtHdBTc1BfysLadiSC1RJvkwp+cAhPlju0T/7Ekjccz8z95VCHS/wny/NUxMwt/CDX",
+	"apjy7Nt/GbeLP1sC6oTeokmXLSypWyhPQNPk/c6HbudIyVEq4ltdSZgTBRiIC60dPhvLLIc93h/3u5AU",
+	"ND/HY9nHpf6s9FAkCZe3udYzov3GsSORwLCwkLL4gq60iVXOIRAzL+CAyrnG1eCqXyn7sypkcpuLfsON",
+	"KnTMQSoLIzc7LuWtZIWdKC3+4Le6nJfCGHfTlAYhPRw5047eOej28Ub777hpnuYCwd5gJeSWJcwy0oIg",
+	"Y/FESO4/A2dO4E6ZkJa/t+7MpJOGiYYLE8lwCVElEvaelzVLm7uSMXeHOIg1Z5aHZQyIrObaHawVdIdp",
+	"SHLO7AIFSJjlPStQmNacJa9lOg9MboksdMtvDOfnjqU7stJATbZ+hr/PheZm01JkkaZsmPK137jk1Ckz",
+	"1q092WXyrV8lert89r8UGZO92OkEElI25GkgFoOoE4ue5il3XD8XOU+F5FFngNLjAqN71DBdrvlIvG/S",
+	"XbSx8APEE6ZZbB1vR8ZWRzKPec+EyVM25wkwx1aMSDi5O0h0dBtyDJ8ogxMIYlYKlHMgTm8DpRHSSXiR",
+	"9OodaD7lDJUl98VRkaYkGxNaboWm5lN1cc0nhIQP7wFa6d0/Vsb4H5jWbN4hHhiEvn+SFOiVTg//8quN",
+	"F6Nbv3G/lV9Xw3/x2Lrpwm09wmGrp3nC5iigWgWZkBYYSD5boiArt3zxai077tw/WAo4aN6H4xGwoeHS",
+	"dqE6+pJzFNKKFPxhuJkud1HD3diK1dURLUnu+LsDw1gzafvwNMmE9KwsZtKxjCGnhxzBhRsxjmhGkrnB",
+	"PSSbXCa5EtKSicKQMkePkDrHsSqkZUORCjv3kmlAFi6LzKGBQ7ROtzPTwrrdk7OwdrzVdjIhj+nt+1tQ",
+	"qzRl4P43ocoLYWwToox5Qv5Wd91x86uYUW6l/Mcm5lhytJV70e1I/t6ex6V3eAsGLN8jnH3TJl8Kz+HT",
+	"9PWo8/ifrRf659KObTNLPlmkhV0gvIZBOj3PmT2PisPD7+IfHBE1+G/uf9JMJiqjnxyLPdHcXR6eAH/P",
+	"YpvOkR/34dQqzR1RZGB4rJ02lDHJxlw/gURFiLCxyjLhVgBe8PEmJkK7zSCkfa2C8LcGqYrEh1JgaJIV",
+	"UAoZ4EcHQEpkzLRG13VJvysG4kSRWOVzEBakmnXd/2dK3rPA8pwz7RTU2YRrDjw1SPLd2RaJsM+nXnZb",
+	"IkuSo2tdJ956wWKUReEfWljLZZBSmfsGZCJJUj5zN5iNLNe0xpl2kycwYTJJuUal091M88SLVEXuiBaq",
+	"x3nqVKYGCYnmXV3gM2V7hudM4xemXA/BFKjpwsBR+z5BdNCFQbBd0nSDbiQHToLtp2osZN8UccyNcQNr",
+	"v46YSAvNB41H33WrUkHSWlzXK3cwjnIVKCY73hzjEr26ZEjcADeBIxBuNrO/QMm92LSViNMiUAOuEUO3",
+	"ebdkxMduh0kl55kqHEM0c2N51kgY6VtapbwF9QjD3VSBk2x9hUzUdKZJIojrndTOmt5bhOZTPP2eyXks",
+	"RiKGnNhvH56mMzY3wCTQRYPZhEvI6fL310OvomwTa/PzjNuJShoFD3yORqe1T52uWdTFltLVv04UXvmO",
+	"ilFx3ShXNchiRJ8aEfAUh4mRcBcrCbKmZXrMiU5kbA6ePTM0eROjTVMyIvXboF65AnqyvIZfhVyeGSNv",
+	"5h75w5V0l84hEV6+XJwTvdtvtQRaQFOUkRODU/RCco0GayeATHhpsMC5MMDISdkF700Lfs9AXgxTEUey",
+	"fHVv4nQF0wUUV0wXrHarTnp/KFkLQTL7fRgIOebGno9ng0gKUuuzsxenvRAkw42t1jTSStpK03/28j9h",
+	"zCyfsXkk9ygU6f4j91W6sLhUd0Zm7uiqFTFwR7UN8MwRY/xQtZVICmt4OuriKScaXRvDubsrv5ydnZRg",
+	"QMoWqAbLBdqr/C42E4uAfXmri4+yNxt7NrOjYOIuTf2OLFC9buAOi7e5fncXb2qjhFNywTaCHPE7An/X",
+	"yf7uYEdOxbuycFdx41sU7wo7OVJyJMYNG9e8h+wJHCNzstBIjAuySYHkPKkw+O1xH47RCoRUPZ1H0snk",
+	"boXBvUgfMQrH02dzNkZdATSXiTdbvz5+dhTJYWGtkjDkIye0ud/RWTFhBsU31BGahAUlkhgDORfVL+kW",
+	"UqfyZTBet4MmgNXN/0QrIAOBkkur7gKSsahzKsbSiS9uk5F8fWFZ1OnDkfdMetnuxetXf3/7/Pzd2+fn",
+	"bnvnL57+9PzFoI1QGVa+enRLA3HjTQd8NGFyzE+YMTOl6/biJVuqt57mfiB8i3pt+HMVt7259TyMWFIm",
+	"7x8+eNikdvLZwhvLBj6MnYP7D+rGkpxreHV8egY/HB72Hn33E4wLkTCU6V8pUHbixE28TwaFCtBFyo2P",
+	"V3BUEXeRTzQz3BFSFsc8t4iaTCaRzDUfcUdeQDmZ1EyUtl5UfQ+0dENntbK/TMjyhwfbznIFYkvgaDw9",
+	"YpPtFS//wssCN9igfl2HwfHSVr75Llt5gcNX9Scv+Q2EHGlmrC5iW2h+7i5nzNIBMkoPhj6cchtoFAoC",
+	"6E5cXGmzNeTR4vE+6HZyZi3XbgX/9z9Z74/D3o+/+f/3fvvzsPvowYfw8/9pktm8rnMFwG+wfRFoF4xb",
+	"CzO2UEufwq/FkGvp9LMynl3zsZNZNC9dmEcvn/3Ur6FmZSe7JgRtttqe0oU1aTHuYehR5SDuQiHF7wUH",
+	"FmtlTLXKSB5nWeFvutNKAcFTso6bO+0mU1KLI6jZFgPgvX2xDPGrAN9GWPGvXdnuFMjQdrlkU1KCVUiJ",
+	"UUP/G/321wFG6XMbT/Dc3NeQwfYj+RSNoKA0OGGH9DupIHMSgRtiQPOMCX+Y1yUQLeFngzWfp4lxEgEL",
+	"VAbshFmIU4EiudOuDLeOt0DKbGnlWD0DNJIiPm5Qittw1aUVas57jr7AxcEUqWEW3F1OH5gpbScgrAE1",
+	"k06JKTLZh3csLUJWROB5cFQmWaBlNTjCrCrwuJxS4qBR3qb6umvxMhVwnYoX7L0NSmNFf56eHHt6DW/f",
+	"vIA9IYlgIniWjCVadBqdYsI6fiDsvOEQSxBZwTUJeW67WaYkOUXMYxiETzjldCLGEzQcZTwRRUYxjbOB",
+	"E0GcaltkPe6WGPNk1UFjUmVBSLSJCY1gt+y9kiqbw97J4cHJ/YN//9f/t79ClL570HTW5CI63+TcGmnB",
+	"ZZLOaWNdGIXttvJjcTkVWsms0SxYQa42DCwblx53Pu2CsWws5LgLuVbJsvfsURMKX5Rnf+4DUhpkVH/d",
+	"asjhx4LmudJeEa6h0Z6X0u/3H/zY/z7qLC+lEcIItLY3shmES5xVD4XVTM9RiemZIs9T4RCFAoku+PwA",
+	"cY6Oy/RbXiapbJNj5oWSYzqhXCvD+/BUziFj+iJxiCeMV7Ywac1RrJ4RCV+Cyw/3f2yCjJrJxuDMEifI",
+	"0Is0By0/nGVwAEr2YpamRCbVTBrvR49LIa3QIxaHyNQQzErqoVEgZIzc3uetJVybSF5INYPZRDn+MWMX",
+	"HIp85QKt89OqqUiaNvLWfTudu0OpIVEi3LvDAnULpTGK1g0J3+lH8nXOZc+BNXmCPoQaFRlfOGXxwnSB",
+	"uf+onEszESPbBe2eOLxnSdYF5fQQ93+nzzTKJw02uLG/J1tHFnKo1MV5oRs03RdCXlD0Enengw5izrJ7",
+	"GC3mXvPnuZhpsER/tzGpD+tZ7Vtkj5eXIFfEqJdcj3kvx/i8oUrmfXBCNQRREHmWeQIDDKRGT3kQE91R",
+	"eosajUKfZMpHFgoZoyadeN/JUYjUa5bDjqpAPmaMigW6ADBQiSyRZELrw89Kw4lK6E6A5iPHcVGIjSRm",
+	"LOpCOvUA9txyu4AReP5/58IneJZhg6do5uKmC0IKG8lRysb7T/AA/1HGrGHIio8qB8uz3Ikp9wwkPE4Z",
+	"EoZy8ZFcmlYKu98HL9cJCdP7j4GzeAJcWj2/Z8BMWE5qNhLPKe9G0igSYoM40ePvLWr3JZgTdFV5CQ0Y",
+	"mJzHMCyyfMnhu8lxsIJfy6JqeSbviGscy5FaNRYJcz7kE+9TaTIXGXseT3h8saPN3gHZ2HPLxg3+hCXx",
+	"tDa2W1vQ6uxNEuxzlT4n+L5Rs9X9La59VW6qLA6rz+YxicQNMoMVdu7dEeueBpFl3fPgSggm6bCULuYW",
+	"dLqdabM1mqv0PJCQNWDf8OicTZlIg7DfxC2SIm7+QOX+CUvmKu04MTfXCiNCxuf0i+P5KKA4tRx5l2w2",
+	"rNO47RhSB1kd/IvArpYfDq9cdBPm/MJZSu6uRZRZ3ae6aFz+WtHtp0KkSSmteceQLiRym8pz0d+qSm9Y",
+	"PUZFv0G9Wc8b8H674asBMTcYjp0c0CyFUxZPeO5khnvfULCCKUYj8Z6CFe7BTKRJzHSjX7CU7ra74pjl",
+	"55ijfJ5zfW54vLDBUarQGlQmJh/2D6vYF8qTbmmf2nw0JTwal1QBcxcr1dKpnjievqN9/5YB+WHbHt7m",
+	"htMN32ETdVxbjyo3tqP2x7z2CN9VpGGJ36Ik4xS45i3ULvQqvWFaMF+7o5Uhq76Ud/Ty9hjDaoG15dQm",
+	"37bnICFexQK3AMPtZrjLWr/q07zhI83NJIQrre6ApZqzZH7u6Xgz5v5e8KIZq5cW5Qd2Vz67bZ3hHFfX",
+	"V9rXdhYdryDlGXvOtW7lpa0Pv1LY9aJsuUPkRBVA6dG6katXAF7ic1lu58GM4XSMvMAQzmxKEUgbkTB8",
+	"tVxOO+nWVylpry76F74Gj1iZfTHl5Abze+/DKee+xM3hw9YesO8WHZyNPpG9f/b8v74JP+3/rdH/tZD2",
+	"1CYy6uYcZrXsqxvyn3nAb/Kf+SG7+s+2onOzSFpbW6gohLLp3rNXpz0KcjB2nvL9Prwlb1rOdS2XbRdf",
+	"2s3izbK/C8MW6uVn+rBuqU/IxxTGRjIrjAXPb4C/R68ZmS4JEXyIroGHhw9pn9vzSpcdf8vIdiU/YDi7",
+	"AuNlWD3ZsEKpNp7BsmzTVV2DgR5/Ba7Bpau3yTUoSwpwSd+gP5/zOGXGrHH2BArihtBtprR3H3ukYYg5",
+	"wVYF30zUkWMh30cd90+rGR+Ji1WnSFMa7+fjFcECDUOWMhk3F9hwlIil4Mb1wjhgSULXoQsZ5loLOY7k",
+	"gKwNfTf2Jz+070/mn78N+vC8tHyCMJEc/Cnyv3VLxf9vXciVtuZvHwZ9OFF5kTLvoppNmEVX6qhIRyJN",
+	"eUIB8wFpKHYpTlWR1M9TSZ+yUBYcNF1QOpIvuWXpi5/gAHlQ793xCRwAgwnTCcbkIzUpN6tkL9c868PT",
+	"SBohxykv9wB2nouYpU8gK1IrevS74bbITcgkoFC3pGBpz1gWX8De9OG300f7gMX4kkImTFp4d3xirmK8",
+	"zdh7n6hTc9KVpAVDvNbeCNCqQBcNDltvrg4ZFdV5oNm9qi2IWYJInKisEey5s+1CzuyE/osWuC4MWXzB",
+	"ZVm9I5J4HQ/w/Pev04Zt04Ztn704XYrOdNsTrbbuNmQi6SgSOSZGXHMZ8wROMUsGCcv17eDDerq6qx9o",
+	"WRK6kh8ocOkB0mbvGmKaR7JyDkFb39CLINYvUbxXp6fHDvBWjTXLJ3NAsZPSaIzjC1RNwJHsBZH9QfCo",
+	"RvJCyKRnVY/ezFieOzwvT89HSHAgjwHFvYn3YbhKeLoY9s1j5eO8u51hYYR0vLzbqWkS7q8kE9Lph8wH",
+	"WzeH3q0+yCdzg0+a1MoXaizk2oDUtz61BL4tg1C7VOkiMOtVprlbLGo9eWUL71oSEco3u52N0ZsveVNF",
+	"ESTlFL5m513QKuVdPEE+GvGYqoxg0mGDVJA0AwpEQkKQQ4+/uuV1y2oztQdldupW3SvkFC1ORaka9MHF",
+	"3KapKMOyfd2dbpm85oZH0o0YPPV1AxCPHsNPmL0/6MPb4xCWgPmeOnFcab6IqQtpTY2pnQVaD9xF3BBj",
+	"7NMDl8DVhzNdUODCUCnrUD33WR94NG6MiSQVqi1jpGfMLdtQiCmT9AIyb4qJh2Gq4gtDxbQi6bgSB/4+",
+	"5rmFwQEttRe+NvCpvegHRl+7g06yECVes6uFTK12tPKNaqSQa4CxKe/3+RKSehXLLeff/8//S+m/gSwp",
+	"X5nBe5Z9MYtu62Rvf9prxN/VxZf4vfGutwPBNhpQ1p1Zmx5c1pRpf0zlKxusVVU1xzZGlK8j3LuE21UC",
+	"vq/XbHEz1quFWp43ZLuqbCkbrFdVHeMd7Vc7o3ijvaeqt77N2hNGOu4Qyeu09XS3m9oqULYwtlUVFj+O",
+	"qW05XWUF1a5kuapAEWxX9Zj2Eiva2K6qathXNV5VJPorMF+t3LyNse3l6C8huv1sUa2nMHYf036ZOPaW",
+	"weVlBS+W1gLNYa9NZPk+VgOyQsaWYvyeHR+dgdtnD22CYuTrbHWdWEoZz1OOh7e4e/OpxJV/YXHVHyNi",
+	"WtbknHYx06FaWcK1gSvETE+YacvqcKwjhSlz9HroE/BDLP5T1B7IBh2ahQg5jjr7C4HUbo1OF8wy5egL",
+	"Ftis8IYmMbDg1rIY68ZbIvx1xUQv1Hu8hqjokvDuag9blawubRGreP+12MNeqWSXfajkTv/Zqv8E05pX",
+	"gFRyFd0HXT5b8x9LQbL/JWs/Ktms+Khkd51nB4z+rNUdB7tK0zHFMFFOjr0mbeeasfSG9R0Hi0ZVRyXt",
+	"tByVXIOC4yjv16Db1G7YZrXGHUs7jQZeqoRjDQ8lI8nAW5x6PvUw2O8xp6e6BFWpqiCtGNhDG3+E2SfW",
+	"dCFW0j/qVrU4X58CulP3+3BUYFGzSIY80p6TI0s+uzdAsRIrm1WKiPsTRVdUJmrSDdZWqpQx1Dm8Y/gc",
+	"PUKDfWTdec1DHUmeCExgPQhmcDvRqhhPloVNT3YWdatIlsoVzxqLuqWpihme13mcFw1ukpO34JA4KRA/",
+	"lvI6iVCQ4wot8HpKm2uT31mfm+cTnnHN0nNjlWbjZca49QMZzxQFJ+/yVq4S0+qdL1iHZjqeCMtRmmk+",
+	"//qIPmzIsWRZ8uhhF5jO3P/yPH70MOVdMN/9ePi+nTIQs5zFws6bkfFMWZaCWxJSO5IQMLSDHF8UJRK+",
+	"0Y/zAvZ+LxgSiFYpx+X0l8LH8u32yFi+0hYTK5LVWJvDFqZG1chgUfam2XvjhJAuvMTlnWhuTKEdPXwm",
+	"zEX5J5wcP6v+eMXtTOmLt7LMztqvh9tg1R4kxJTJWKMNlIBoHENmqPXGTMKImiU4wjZwexsc+NieAVTl",
+	"kXOmDb+5mJUyq/Lcp3Suz3T3NfLCC8njg4P7/b/07383aJNLfyvWqU+lWIGP5/K16Joqb4eQr+MTwkt/",
+	"XWshX2IETM6X5nv4fcN0i4xzE3SHTPOeI6tpqFWAr5RmkGc8TeFEzbh+nox5JN88engYdfaxCkWe8gxl",
+	"E5LoVZH0EKsTpwUay6SvuzhwgkskvcpX0uYnsCg3tLTxLHx6dWtYISSk7mEnqn5VtKEv1EF4v0dLw+OM",
+	"pK/3mD0S/fcp02MsyHpqmUyYTs6fPTTn0+8b0On+gx8al7jhtE+0yJieYx06f97+jJvPvc15X7j9pfWL",
+	"unWNDijnuVbv52tea7wp7q2U2/Uk4VcaAGNRtmwBDD/YWPhi+jVXvmhnoSUqKMfnPg5qVR06hRHLRDrf",
+	"BO9BKmTx3uH2TMhEzcygFcSVOaeWOqtlhB3nfH1KifcBYOFY3w4LaQt48KB/+LD/Hbw4O20K4310CwZp",
+	"sjvdbv0OlZzHItFtCl+EGh2NxpUjjK8NQ+r9w4he5Dzuh6fHz0pSxmbm8cHBAS96M25s7z47EL1DNozv",
+	"P/ju4feP/vLDj4cJHzWQtObdoIGmsX7ElEvBsZUIRf1AwrWYhp7eSIVRsBp4ylYJYP1IngW1svwR9lBT",
+	"1ZwZJQ9SZuyZZpJKJp6JjO/7nhEYZjiohLkBoASzLQ6pAXvdo8VFI9voud+XeMc3g0ACIrlShokCoHt5",
+	"yiRyDycYkvrLbZwMbtncr5LLWPq7HVL+mxopoJaLc+KQGvbRDwtx5hOGgeYXfN4lEHV93OCHQWjRqRJI",
+	"mUwMYL13KkA8AmEjaVXqqB33IWk0oW+/Tl9xSPBK+TXxg1fq+XseF/aaxOLaHS3F4kLW9PxV8CAcFsaU",
+	"AXYOhWKbOgzRiZIDGKVs3G/E0j+U3CrSWJWrVI3nS6jpXl2WZqq733DPH7X086hkdxdP3ZD8qXh3ltsE",
+	"t9/O8pt3Xp/dvD7L8LtGD9D9r9cDtAzVTd6gxj7ll78A+PpXmancCIlPCZ+/qvTlxtPY+R7s6ibd8TZs",
+	"dUeevDtq6Y1ciKy5tD/y2nHsq051dqfXnObciCdtXKp5+SJMibTH7tUre1mbucBX4HbdeGM3+mHd6V42",
+	"sBTbNaEFdvGItqmAlR7yw+rRDFUhk3NCi8br9/OvQUNcERBQMXQ7EgbwO5jAFxpBRfKEy8Tpdyfvjgx2",
+	"LyWN4+QdaDXDphZDjlkyKUe3797rV/Ds+YvnZ8/h9PkZvHr74sV+851sURnm8zDpbQ8wdPBtDi18DB7A",
+	"XfjJQb8LL1Rob7PVLED5hzypO9yW+7X5IWDEHxz2UCMNBTxNP7T16vsP7HexGRmzIiv1xajz/d8FNhJt",
+	"tSj/paXk/60p+h55m/niGzaDAS6dhr1CnS+o0ifvQgEBzDxz3L6Oy5E88unCKInRUfMpl0RoyPugvXmP",
+	"MD2gtrxnI4noTb2FeAJzbpt5aQutuZHi7KpGbxY0rj2PmKqqX4NmfVWB6muIQfOY3A/F+XuYoZd0wajQ",
+	"J+Kaws/uf8rhZ6uiTlMs2jKCXEqIunbx6WuUnNoJTauCx7VIUGsvEw1Ez7UJfIK/z5UJ/ZXkHNQokuiI",
+	"+IcWlr+WMdro33jV9iWT8/A3DqAfll85UcGOfz3SXIhvaWgbWha59kO2elEHUef+Ycm+sY1sUrL4JxAr",
+	"GfyxVsFwjrkIBpiPP3HPY65lyzgkx4nONR+t4eKvsJ4siY/EnZ1YRCIJvvuGj/ru1XZFfRanK5OVV+ck",
+	"hbPNxDiy5exGnGN3woYrfXR6TJ0LqQhZJWecvHPQPTo97mHNlSSswYg+jXeHVPZgFbJnNedwACkfs3ge",
+	"iGEQ3tqIIV+WEL1dhn4aIq6COB3JN9QTP+nCz9i1tq1sTfiVq1TE8ybB2jIh4QCeoeIDB/CGY5XqJey5",
+	"/+jaZWTycje6XWPt1uKQyx2Fnya4xStkow/9gj/vBzk6khXe3jMLHmUv+BRVi4lEmAs4ADNhmq8A9Pvm",
+	"fnJb+chVReFPz7tE3Xlb7kYlX6f1XCV3tvKPZCvPVbLRMq6SndW2TVi8VQFy62mZg3Op8p53Vu+btHq7",
+	"01tj9VbJxrYeG/p2tLyFVOg8cxR+TT359SXo6+JjQ4H6ZE1zjSCwXIYirLwz8x1uyo7460es2UizTl4n",
+	"JesPGU+olQKtkqurzCr5KrTkihJuVoxVcllduOp1tLUJ5kLHp3pAf9mzbqOO0Orb9dZEK2rDS5ZjV88w",
+	"2NtsFebqUA34XtBFhRypPvzK5yRbsWFV5cqdLYWVYjybhTm259cinjh9SirZw1QIJLCWjbsQysPjaCGB",
+	"pamaOXzuIkb4T+RaxdwYTh3/Gmrqfy7RxQlvoX5LyiSkLlrChGw1jIJtpf5u19bcl7eqa2+oTUIXTos4",
+	"xqbs3UiSmoan85baDdUTqFrVVmin4+UqaQ7GVwnUAvD3jk+mD91qjk+mj/b7cFzv5/kEMWjKUoE0322W",
+	"yUgen0AqLNcsXVlKY6x+SdybxIgzlfdSPuVp2QfNEwwKLvUpbA7ge894nqo59rU8iOSpZZaPitRJ1wfw",
+	"jPFMyVNu9zEhrpb3OGPphc9F+sFEEuOs34RiqhBPmK8M6MT1agaf2JnXGsAZlU65iaSDYI86BcEbjgK/",
+	"W0P4qfpG5Wmk72CYr1SRrFcOprK9wCTgyrDSXa3xEiSKG3nP+iSVObfed9WF/1DDLhxpJf9DDS/nhfzQ",
+	"TNl3VlVrYvGnU+v1RKth2pQ28ObnI/jLD4d/cWTRjfBR8Q2snx40d0bTWmmzhvl5hPYXB8v+4vCur9BJ",
+	"WuKQ7CmlWLE4N26vceqMG+P9oZvZN32ieuG3FmWMQ67Qolza3Mm36j6WsffUp+j7H3+sdS26f3hYviak",
+	"5WPfqVrYNT3dqgSnEStSNzUbqsI+HqZMXmztLby0fd+CjWbb2F7tDY+VjEXKvWvqFD1Ta0X5tsrzBec5",
+	"2W8XxMcttTU3uZ9qX9y4j9IyvG4nl1vazgaEzUpZ29284QaR4c+V64lhGQvrENI+ethZxbqllYRXN85b",
+	"NuZcAz9HqneE36cDd1r89kNQzSL+e55QGokT5nOuQ0Xsv/icCHyWsRy7HDAY4QtUhNa98e//+m8qrE8/",
+	"YWuhYKFx4tDTk2MYGB4XWtj5IJTrFaai8l0y64baxplIkpRjTf1/oWnBWua0ZSgnMYsZL5jrslDHGMsp",
+	"uL+xwEKn22FF+NdU8BnXjcWNT6mwfHtu6V/4Ks2hfu+fTjHYr8og6qG/ySjqh+xqGN2K01uNo74/w13v",
+	"o8/QNBrOrtk86nGjjQHOf+jKRrhAk78CQ9zSzdtojAv3/7IGuSCJNlgVnhojxk5h9hL08QnscWxC6Mj+",
+	"L5wlKTcGDsqaD2iwCee93ybj/67PUUOfI9Sl/bkaNIDNcx7JwYvaC4PQOyil5jLz0ITmCSg74RrfMZBy",
+	"NuUklOFtATw/NwU2JVqoQgVNfY0iWbY1evHTk5WGSIHfLzdPurm6LlgIqCGv118DfHytPYioI7/7bhcs",
+	"02Nuz+mPXCurYpV20Th5fu3NhwynNV3j7TjBZGVkwf7jfThRiSMYFhuo+0zl6powbDHqxlILmDaXJSj8",
+	"Laj5mRvaaLKqD9gkY5T0b57zPhwx43bhvWqImk4TWKhcaw1PR5HkmSBMKe20zHrFwi0xdAtatN2OClto",
+	"XhWbe+Luh0xSrhcMQ3KkdOznn94HUwxNiMIOiklJUzuUnHyitJME63e80+3UKesmTWVX696ybPfpWPhO",
+	"Sfdr4EYSGLVCmRQZk6EBTgNLu0zr+fe50Nzs9E6TkOhXX4tF8oBD14XmI/EevRcTNcMARqr294QoNFaQ",
+	"EOjeoHpvKWcXJM8zEqe07w69UB5iqb9xYXbcO0XneQlga4qLY6vnbMypQ3G74W3VsLVtY55x6V5OhXEY",
+	"pLTv/RNXZTu2t5DBOcNylvSvBcAtYEOzeGbqjcY3Cb8eYz2uXoMMbFq2JL8uUfStaeyt5u+gA+eS5ll5",
+	"OS51M7daMxJhsHP/Lh28t350hA487HIjz2NVNLXfPnIXLy7wPGl81ZrKaZ1Zbg0YIWNOzkNTYDj3qEix",
+	"lqnswxuOBcSsgkMnuy8PgBKvC5mq+MK9QOYu95cqHHfS3ExUmkRy79F+6ZwauOcIkQESlzLhJ5jsD9eC",
+	"oGbAv7R1yVgPuOs8kXJLqwfxj+BVd4y5kBZYYVWPXvBqOH8fc46pUUhX8bR6BOQShk67g/CW/1KMJUAX",
+	"uq1hzclw0H04oj5h9RZkvtvaydOzo1/gYHr/AH89wCZmB3+K5ANVPYQBHetf3Y4HfcwzhL+iM5ZWsaT2",
+	"Xwl867qzra8otL2f2XXYya7SB7Ak4N6ShivfxZBG1Kwyg601hXiTDBlCKkq3StDaNcF7Ro4vcBApcwCN",
+	"L8oHEdmoqTKWoTLFRFeVxeJBSkZyhLUVEYOjDoxSNSNz64ilhsqHGQxGoNZ5KDEUVmU1s9nqyW/s31g3",
+	"qzVGm++CNhuOfKP57mnvPw97P/bPe799uz2lq6lNpF/nOlRow8ERoFfl28hFb5dpVxrBNsH+lFts3zuo",
+	"eiNqPmHGcR4n0JMuE8lBE7YHalZ+JPBnegCaT9WFe5sUy0V5qIrTx6aQ5TfqhJI6MxqSkAMjNO5m+Nbf",
+	"gXYvMACrFGRMzj3tjyQR/8Cnm4pkh4U3k8n2BPX2rhVCaR1/dAjkYbcgILgTxS6aBgarYg+aQg/7kXyl",
+	"QokyVYLYt1d3qluNa8ERkzDkEKtsKCRPiNmhESqShGde5/N+CcOwyg/mcUOvByxNgSCLTa/TOTCrMm/b",
+	"cuxVSQ5vT549PXveTMqazAfvuBaj+Zm64Oub3lJDVN800yqY4jsUavTs5X/6FGoYM8tnbA575A29/2jf",
+	"4StipEBPqJkobXux0HEhLAiJlgD6rIEhHymNoWtziLXCHvUcCTqfsTR1WC8tKCxZe/bilArIOSZRCdL3",
+	"DOTFMBUxEiUuucYAoghlFfS0weDk9ekZCR+FnRzQTgZNaE4dXddZyU+ensHeIJ2e58yeo3gZk9ZKoqb/",
+	"yRSj8qeBE1t9uteA6bEyO7zbpormcgDIUkfaNUdOenJTZJo7bISP7+jlbkORWidt20JLjChM51Xspu/s",
+	"a8jA8ySS4YAPoKBgPzgA0hjdb0TwyuMfcwsMHh7erwLFvG2AspKoduce80viOsigQo64Buo1NhQWu9/O",
+	"tJLj/aZTpXoaaIU997f1vNk+gRfaL04YU4QLi0X5plmvNIUOvBs/oP33+77QZcPVwFqWlqxojqb/+oOp",
+	"gvUMAvRJJJc+7xeBFsZQ0hRrKBoq/BE+HjMZSc3dMWOHg2Cni51y5M10mpHRe8KQqcwYNjW+ZBWPGJtG",
+	"rwls9G2e97ABuJq5u+krIV9wR65gwHJxTnsj/N5q9+Dv83UzIV5h0iyDt1K8B56reAKGx0omlVFtEVkj",
+	"6cgD0mjCSyJpFTxRqSQa4bHfVD3PU26c9KlGGOccGt3zBM7OXpCBb4+/z6EHUs32B0sgXheps67HtVuX",
+	"XwiXSa6EXNS+CHdgWKPUpg9H2PO6jBMx4c4MebhGSa2BhjDw5uTIq+ZIhxPlaWehp04csR6rJypfNNKu",
+	"b3+9rmEzHts943swh/AYs3gC6AyOlTSoFUy44ZH0fKJC3lXOooZToQrj72UmjDdzLzkdrtTm+UiZjFsR",
+	"l9GzqRpDKqSXBTF6JriaQgHisC0jEt7YDxrpZYMVyUeUkJyHVs4Hh4eVkRMNJtjNzi3Em94Lw/vNMkCd",
+	"S9CM3RZ9o98JbQuWvmTxREi+KeenDHxR0vi8neZYzgUy3DhiuVL/1XKIRPMy6OHGJKLmNCE14/ocRezG",
+	"55qPvYF+rfh6DQlGDfENjecX4vna+z7CG59ksFYgk2028KsbewsBXmG+u6TXbTFentzcUKhXSLmo+dk3",
+	"hX2FY9s17mv7/QhIutv3CF1XtlhmiGCSRCLcM2xTqvTm6pBt6hOVIGtbmXKvPNEuLmj/rkLltQSk1W/G",
+	"leLSyhNtDkwL2PTRk3fXZsVeMqsXD+pcU2pSfcqajL356ZV5cHOC7uaTrU7k10YFYAt5cx9vjOoYuCcD",
+	"sixFciW8A3x0x9Mqzw5j42GvnmDVraV6Yd2VUsA7Kpewj8F0Q151PMaUOYeKGFlCjRPKvlYskj5+JBNj",
+	"avgEe4bzEEr/3f6ihlEllnW6nVr2W6fbKbPfGhWQANY2NuwA2SvbsUth6ysIwlxmgxujMJfSHO/you/y",
+	"oq8YcbpK75duVOj0ThzcDwTUOSlHFQFXSCtSIPehb1xT4WA9QGAzN1l2aBq0dq6Z9EmVuIvldqUCE7OU",
+	"aUj8i/TC1hWYnMfbwiiX2ImQSdUT1vsdFlumxhOFFfXqMZ5Yec5YzSwfzyO5mDXcDSHNqEtTyktFqPcX",
+	"e2UaLFgXSWbgP05fv/ppwWMRTvfDBnKzayTfirR+PaF8Xc9hu454RbIK6tu9siqGslLS16lbNN0ycr48",
+	"Ldw1+7NDBr6fg0xCdreVm3ZyXFrj0XCtCttTo96QSdRNJXLmgfum0uIPZL6PwXt5yPtA9lFyPvQjGclT",
+	"yiIbayatT9WnOR5HEqAHA3e9BgDkknHI4oj5mNuqoaPxI7E764BGhggCmfjrBnsic3TBhC+WRmwnZNwz",
+	"pPhw9719/z1KZ6SqwZpnasqhrIPsh2DkgJ+SpWkolsCGasqf+Fa9i+YzfKOHRtVgcDUODmdkjMdQ8hA3",
+	"Ez5P9kZcfyxsOgfDrDCjOVYyoIeBpWJ7RCYr4CCQT2qphF3IyNRWt/97DbkeVRPU2bfHkUQBqubiwvia",
+	"YGJfsP0L+S8MVS7Nv1xOYcq0t5HipUG7ISJFdTMn1ua10D4yMK/poVl6r2MchRx+OF92waFTddCHX6zN",
+	"3X3rRvKUZfxUWP7XU6tFbLvwQ2+iCg0mFWjwJWN/H+rgQvg9R995CVMsFJpbA1zgzgfVXUJv3GBhFwPK",
+	"y6Rz8pHJGfWHY0mteWyJiZjluUcxJWRf3welI0lXz6dd4nOC4n43eGzszAl2dmKozF7p7Y1kombSWM1Z",
+	"huZ9pYWhrWCSqDdgOwgTTIM+8bhDXtDzacHP/WqqQ2O5+JXPOx8+YIr7SDVUBXh+egaObLjVfvNN5VL9",
+	"5psuMDSVkL+q0h+4nAqtJHUEZSklwAQPWSSfvjo9PYZTHr8qMupot3f66mgffi9YWrkUR5pl3EndeHxn",
+	"E2HKLpJ7h/37/cN9Klo6YynVPbxwdx1Rasqd2OCpzwsx5ZIb4732LBH4V67VsKQBPpB8UBIHOHrz9hnS",
+	"tmJo+O8F1g72kiHMRJoCSxLsFdyFV5W1IzCSLpyoBMl+cOIvQMcKO/e6VMbyHN2lvlI/wSZm2qqxZvlk",
+	"Ts45QziMxRJgpJzQBmW5hr1Bzax+4Is3fPsvoyTWf40k9hf1YSPuJBMVF+5wCNAOiqGApiOpg4NExeaA",
+	"7JZ1R1Ktvbt5AkaMkcBg4N5BIfxt9XKSVU6Ug6hzpucgrGMzUccTkCLLmJ4vKK69GP0hMaHTMsrAKsZU",
+	"2FFWMgiIjtVB8DtPT4473U7ZoLSDaONbaEqWi87jznf4ExqZJshTDyacpXbyh/v3mKNaWBKN46TzuPN3",
+	"bn/xQ5x8R34WfPXB4WHQQ3xod/1c3Hm430jo2KZG0BR0L5uzdARerSnvL0gHncf//K0O4hL7Ed8drNjY",
+	"OKWNttn5zb18gPJvfctLXefIIWigRoISnjtxTcbu972EWTZkhlNffs1ZPAllPFag94Ym+9jAI5nfKh/9",
+	"YTUbjUSMBrDvD7/bsJb6BWu/plB1ZfOinAKGC9t8qm8Wydi6Yy35PLoc1x4vGjq6IDl2CPRhkt7soXms",
+	"dMITpBuOhChp+vCGRBUfhzPAz3sZp1uXA4fKTkoRCP3evnTAADmkIbbqf6NAD7d7kq2mwoihSB2tDJYh",
+	"EszoN6t8Jl0kKWBTlc5tR/N+xv7pJBo9ffWsF0Kr+jBAL/YADmCAmt0gdI3Avag4LrT2gV7aSeCwN2Hp",
+	"qOdoxmMY/BPf7pJSuB/6Yywi+Qth7FO3qedThwNIXhy9smibWKOMVEMOXohMWPQZbBl4RKYiN3LZrpJS",
+	"CB/2vHBijlcz0PMkTBmLiwLD7wXX80peYE7HI5NzhdtbLddbl8AwFs6xagalelkyXPRc+PLl3kjqFCi3",
+	"TgoBaVppePvcl7SplnvdyxPJ1jUsAWyHFdQmpCuGxdoDNPCoSLpfDwl674og8KqO0yCqFYV4uT68NU5f",
+	"pwZBTJoZSlkQdWZor6NmLCFgpCnEKerU4v8iGS41RvT1tK88hqIcwfz4xNSk2qUN05iFDZf1SnKBL7m5",
+	"z8czN4YaZf/WiLaNX3eXvBn/N9r6m7+GtGL3r/12gyyyIk9kA13lSktJWBS0gniCPPLh4f11c5SLPngr",
+	"vabyB0/ope+2v/Sz0kORJFwus8BFg8c/qQxN5zcH9SWds3q2JAwZu7CTGuOkIjdLfBNtq8EQ69aIxlNv",
+	"42yUDt0Ux+6tN9XYKx7jVZwN9aXMt5bUWmfIX0WO179+Kjjgj60RB/yzVRxApbrIfQuN6lgrc/gKZnh/",
+	"ZYkMbs5OrkwDDlCwwCLoy75dPylqnn4tt3hhjre54dqfVnWqPp5kCQPv38wSmlCFoOGP/nD70f/EkhBt",
+	"flso5t74cfsbR0qOUuGNz9eJk0+TBLuveNeMNwXshIvtyNbBnxNlrONKH6o6casITN0tlhF4SYZFRufU",
+	"5orPhY93lhFwk1iyyuUeNnXnhyOPrbeJFA+3v/FK2Z+d+nDtSPGGzNU1vCjNjLtSKWbjyeopn7ifb/OQ",
+	"b5j+4X7akb/D2yN/t8gpPzbGktuthrH3DGj3S+r02S5wiclhMErZOLibudmZugWL+kYZ7DQMunHd+yal",
+	"9HqVhK0ielUg4XMWzZrqk2yV08M4TBVf5GzLXvcUbfA+8+RJFScTkumGnGly3mGtbfROjbk18PDwvlN7",
+	"E+9RA80ToXls0QtO1QkaTEFvMJXptHS7bGd19EbS/4oYndswpaHWM1sbDn3Xy+wXcJx0Pvy2gDBkKNxI",
+	"QZ7mghy6nzcJCdtoR0O8AfWzpiBLvvG9jFuWMMuqtNA8ZUJad+vLGkFTbso43/1mzFNNQYJvfIRvWXuo",
+	"+rb12WcstukclIx58MfXShDVXFY+ksanawlrgOmxkg9EAhNmJr7qASVRFrzK14qk5k66n3IfIdeH4xGk",
+	"ytiuz6RE03uGeWEYdKkkb6JVpKkFhLkhlTV83kfU37K2GmZ/KWTjbaCMQQcqnjypnSUVm6qfIUYBfcpK",
+	"7TVfrZcV+ixcsG2smW7hVsZ8isn0PvH3nNnBE6r4Rq730LG8xp1DUrHmMRdTHsmHh/dBZBlPBLM8nfeB",
+	"zlKrGTmBLnhuvUs7EdRGQ8hCWCIJhfElHpESlnmUGDs/FXwGOcPaYVPls9fWM/uFC3TH7ddw+61YtCvX",
+	"RZivcnr0DW5k9G9xxGfN5MtCLFsZvC/F8jnz96qYkNnIqJuYGxaRuRnGVquLdMtMjSrjrJ68+z2EBfbv",
+	"7K/r0eoo1KqqUGsbW6sqk23iakfMxCyhQOlQo+eeKdValMteHz878rUureCmD2WIri/Yg4WsSCTx0TWY",
+	"M5DA3utX8Oz5i+dnz+HN89OzN8dHZ/s+0hVprJ3wLJL8fRlziqEdXSo2wihnPwtKVygjhMow7hHDKN7w",
+	"UWF8bg48PPyxViYB6/iCINkXZVZKIUEXOn40khSGioUeUmZsL4SlTpkWTNp9XEz5SQqfhJkq0gQFW4Sr",
+	"5/dCg5PBfEp4E/sl5b684ttYLw3/lFnvx74Xvss1W3cjumsj5JoP4fBWSN7XI0v9HQvjrD2c3QQaB7pj",
+	"Si4uHQbrkyAMz5i0IjY3VfsMc9mw2l+b8mfMfoz6Z5vII4GJSFlJbSGpOvW5VyL5B9cqbIkKGSMFF33e",
+	"h4RnCjezN9Aq5QgRqSQRUYonJ2jRmMWqcfvryXJJ3lcoKFnwdxKSsgopvt39DvtMnVt22qylHpTd64Pj",
+	"PnGB6bPiJKVryEtADp+7ZUnYLgTcJeGkfkM3CGKFnRwQOenVCwY2G+rKGGYUNAqNef/VAjy9IgkILWSw",
+	"F8xv+91IhiqATTSMErxC0TqsuESkysf+rynYiDX8iGoRdHtk0SApiKJhHx5+51uChdwiNPrRAipwlrV1",
+	"m6x6OPakVs7zBpSfxUnK69DmWj9sCkj2NaFDCtznZGdbvhDLugYdXR0Llw6xjvHFQiw3IjwWE1sbyx3s",
+	"0RdSDQmdiWvlbOwwmyeGbFpY+AEtyiphc2wNF8nZhGMyFKkkC4XLmEy6IEZgVJfMn4W1SlI+bp8yTCSl",
+	"l6ZzX2kRm+RiQwwdqgJiaTosry2NcJeiCWH/zq2jM0e00RuNgSxnaWAG7mkJAcrD2xiTf0LlJdnKa8Fh",
+	"SNDPNacq2puPmYaspWbP35fVPiEU7YVvq2LqaOdcSrIL1Rm9K7PsrktlBULP16FK5iQVkeBTaA57UjkK",
+	"bYWk6OQhtzPOZSRD8UZUUR0NHLKqovs+SmNYOXU5/2wAzJRZffDtSlof+WWHWs3QhOH7zQhLJd9Ls7Cj",
+	"oD2lxVhgdUNvIw5Vm7H4aWN4vgf/TRBC/PZV6V/ogFHabrqdCWeJN2Secttbl1x5unjiG+PBP9wmUX3w",
+	"421m1JwF0X1JZIczp0CMmZDeU7bxRp9apm1pFWrwSjdeW1XY9fe2Hn9A1b96RiSVbKDVDO+RFzco6x6P",
+	"MpK+W7oBI1Iu0Z6jdCkt1BL1HMmdCrZQ8TGSe4Eak09DXfB9MBi54GQtYUAkPMuVO581l8btbCf0pTr/",
+	"/S3SZKMYucQ1n/u4i8AydzgSqhS0kVkupO56U9y864VUKuGMAhym7ZKwR8lCjdIgxjdRsUoME2GhU3rJ",
+	"eCPpPt1j2BJMsqkY+5xkzFClsJJgMkTtOel5ic9Xc2nimS/5TfLKl7wxtpcMdgFkl7W8XBk9/jFRwDI4",
+	"prPx+SgSjiFRm5FDiSQ+KJeyFlFeCswQgpHmZkJ6SRdOfj16DrFK+HmoO+y0kTTldFBC+7oPUsmYP6nc",
+	"+3bCq0rF34IMXuWBW8y5WwwVjjSDJ5H87vBBaT2uiWPHyck9A+XCS4dlncc/RIFOltIcKg7lJ5qw6LVI",
+	"4qclMJaw6bvDB003aBFbj5OTJW71wjtMF1FtS7/yD5WGuxRN2bgXKqIqTK3eN4R+7W1IPDZXdl9m9bIX",
+	"PXe22CeiBQ458jFkVEq+EYWOlDRFFkg/2p4OCIVKXDjwuGCsU0axl1p5wpG0InPUqBT8CCMSXmVJHycn",
+	"3fA1en78rKT+WO7DoWSRYLOnLiZwM1to3qV597swwpx0FbxGPr/TTFiiZiTkXfA5wXtQftEUw/1BFz0U",
+	"phI6u+BRN5KYHT7ow88kThpIMTFe1tLG/4a4z7VW+q9UZURzZlStzEgjsh4FqDcHLi+lYTlo7RS1vC45",
+	"zNslLh/j3uouvT1udZVW784GfD9SWY42/auhPJWbXi/mYMEByVIsGl2YkHe6uSUA/O//fL+PCLN7MwAI",
+	"vQBASPcFdFDpwliewB9KciwI4oiOqUwvZXQVNVlHjQMZTyRrTdN1IQ12Vw4BosSkK8GBin87wYpEiFCc",
+	"3kkQdYnBlyEPWY+ZSnz9eien/nJ2dlJapOtRYfcMlYSOZCS/+QarYJTBKaLM2EQzr5KL/Q6ysxenlElN",
+	"EI9kSOX85hvYC8HYWL7hxetXf3/7/Pzd2+fnx6/+/vz07PzF8enZ81fnT589ezPY7y98OJJNnRR86rqv",
+	"MyksCUDYjmHCZGIm7IJ7Z2EkjUr5gsSqJGTcUTZhMm8gEwYBGpr9aJ8fH8mF2kRA9yOU0Q6HRBUMn/i+",
+	"qsKJjDHXtmwcUBoCSYBhpl6Euw9P5Rwt7bh8P0aYUEG/anO5uDuP4wEsDlIDnyn/VCbUWuEIF3PEtR2A",
+	"IV+Fr2/CFw5WM8t7GDdPs9U4GyUMZw42udMfMBG2d3wSyWGRYK8ER4YdWTRW5U6yiJnh9Q3eKyvXU/1/",
+	"t7Xh3AmwIft3WIzHcxgWIm0UFGptIm5Ij27oPXLLToKmVhhrIwbL1hYltmyiAcEedot2zQ08gTYKi/ri",
+	"WvofuhZvDKk6CoNuo/LBlpHHMk6LhJ9xjRWR0R6xak5jsQ0NmakW4wiT4/uAnYAMx1haIvrMEW9j0Ucg",
+	"LM/WpeT7JKldMt+uD3v9CbQLCgtn+hnHszo1uzFaLK5QMSB0+dP6sO7j0haCcipW7sOwaqlKNCnl7rGY",
+	"cklYg0Wg3WUHyWdOzZ9RXxfDMdMYS6A8OLwPPil2QIVoPDVw32crn48kSiv4+YVa04Ys8fhvtLLTZKWx",
+	"nRomPjg8hNe/DqrUlTLRRSXUdGYsldOhsOSeNybNmLTeVORL71F5wkiSv7ycMyzWTNDR7StTFbmfvOrn",
+	"GGBOzRzXR58flfWRb8RNRV/fJUzv2q9kox1l8cydoLN63E82HvcGXWHJyf3mONQ4XD7G/pqKL2t19OuM",
+	"YmwBnmZ7eKutSj5L52WNxMvu9/OkjVhUczUO24vqSgOXButaQlWdvIFWLgkADcGPTeF49Qu9zXAczjn5",
+	"5CPzNgPcQ2RdNN1GKK+PqVsLyVslUdRtzXy2Z9MkKFAc3ZZj2U2Q9eC6REDd41AKWIXKwCHtHzk203yh",
+	"NrCvKuwY+cYeG02BXrsy28vHevmZPk641wasDhFfJUP4koK+LsEVfJzWYl1rrP/UijdwlR5w6hrSefyn",
+	"/3Epm39r5aR3YWQroy7aSBb4eEKtojuPvz/EMvFUHP3BYUN59HUWXt+C4RK2YV2V0tj5XWqIonmuLvO2",
+	"D6m/zKsTZsj23vRyrT3cmhNg6ATl2B6XrLOfVq2zOlatU4g/mYJWaxXZsq1D1TQCEcaUmqLQvnUE4A2t",
+	"Luq6ehordYLQv1k36y/nN+KA5Vu6dHAPbuTg/NybTHFPsaR3OJSvIG/pTIvxGCOvqsxXjycYYh7P45TD",
+	"HiXdKJnO99cjRXc5vHYJOf6sqNOHTbWR62fWqp7QAtW7StmomyEYX1ZNn3XSL9oy3a7vmToC7bE0Bc9Y",
+	"zH4biiLHmhuzrUBiOeqTsA/jYsoq7scJ1UW92YxdP2s7+2wJ1S/RQCtqyFCiV/nb1iqLNPKm6ivS1z9O",
+	"Wm/YWgN6+EfXZxDzAP9iDGIfO0Fms8kNm6wEvG3C+WVqeqB5rGQsqIXa5tBSSj3xr4bTrlwU1OZyNlHG",
+	"+xR8NJWQkRxccJ5jhyYzaK5v4VdRJ+A3ce/KiUqqjD2Gktu2HJTreINBHk1XMQwRvheLD7D5jCl1ab1s",
+	"kkObTZslnCpq7lMQ6l0uW2F6O6tynexvsyoHYvllW5W3kZT1duW1sDy8TVb2xdqVtx/MbiKwB9gtWZbL",
+	"Znbku25oYdfa2ryrqHZ5a7Of6eNYmzfgerA2l9LWnbV5jbW5pYBUYuhmffNVNeyTDUja8lK5hdKxdBta",
+	"ajlrOz21Oo4vUVGVdSwKSFn7cZuq+qomCt2E0FyhyEdRV6vtNeBJ+fD6VNZaz/o7pfU2lNZGWX4B/1eo",
+	"8u56a6WiLmiuZVDc1fTWBUZwo4qrJ9N3auvnobZWKOv11lVv9xZMb6e3LvKArV0vysvwhUdEbaUs67XX",
+	"DRA9vG3e9uXGRrU4oN3k6pq75cb1WH+Xr0eL3V2Ku7weW871cTTZjVgfdNmaGHanza6LnWotOalkmyqL",
+	"Iz5bLVYlt6zAqqSt7uoA+0WqrR5jSrzDv7cqq1Wu9LXrqQ4JPo6K6jbVxMFVcp2KqUrudNJb00kJT5eR",
+	"u05PL6GEOny4rP4Jb2v57nlhJhCrNOWxxf7UMGZ6yMa853+MZOgfbKiMaSIMy3MsnFPJNamYcqi65SPR",
+	"oszhDbquv/d3au6dmluquQ4n1mu4TZenpV4b2MX2Ro7Jl6/NNtOkDTpsI/QOb4fvfcFK67pz2FFVVcnn",
+	"p6XuIr5dQUFVycfSTdegdKmWohB2p5Gu1Ug3yk2+VhmXdqrSIuNxykS2WTE9KV95h68c0SufgKbauLJb",
+	"DvdtXEM7xbQ6C6DDADqNL1FXXbfXGqauQc1t+mzjAdyQdNw418fReJu33YRzTQOvTydec7B3avItqclr",
+	"4N/mXm1kCbvr1ifvjm4oKHktB7qLUL7TgSsd+OTd0abg5Eveg3Zq8noutLUlQiN9/sIV6StQrfXKdssz",
+	"OPxUePCXq59f6Xh3UysaQfv5hVBfTYq9vJ7fOO/HUfxb36ZgCVgret4ZB9YZB65fWtzNdvCJmg1u0W+9",
+	"PPklTQVfh5Fgk3lgd8vAbRkFPgl7QBsx5AatAHf6/8fS/7dcmXVk/DL6/o1EcjexjDtP952WH7T8VSax",
+	"1u29E/5fTs+/lIr/1Wn3W9l4W5X+NrX5Vhz0K9Lht8tiV1LcPzdH/KWly+tT1j8NPX0nFf1OOd9BOW/J",
+	"ylSyRQl3Az4FvVslDc75Vu9h3bad3nilEvTg7PTSP5S+SBVLbskUoJKW2r9Kvkx9nxCzxHH351alXt1U",
+	"p+sTlXwk1V0ljTigkmtU0FVyp5LflkquklWsrhHr3VXtXCU35VqnK3jnSL9TsWsqtko2OtJXMbql8uxp",
+	"91Z9WSVfvIrcRCM26MFNkDu8DQ70BSu4zUewoxarks/Q2byDDHUFbVUlH0lBbcbmUidVyZ0WukEL3SC9",
+	"GM50PFltBLH4e/8Pkdef6anYVsfrNAz6BNRUv5ZbjiP3s7ZTCANMv0Sl0FSoEJCw/GmbcuiBeEMCrf/6",
+	"x1ESw9YacMM/uj5l0cP7TmG8JYXRlGjbgPFLZHR35dG/eUMKZI1y3ymRd0pkpUQGhN2gSG7A8nYKZZ3e",
+	"b1MqA5X8whXLjbRkvYK5FpKHt8nBvlxlc8ux7Cb0enB9fornrvLZ5ZVPP9PHUUA3YHpQQksR604RXaeI",
+	"tpGKZt5ht1m7/Ec56nMtrxV2cCn/aXj5VyEv8daC6/UmNeAwYTsVuDz5L1EHntUQNiB/9ds2LTgA8oZE",
+	"8vD5j6MHl5trwJDw7Po04QD0O1X4llThWYW7TYi/TPZ314bDq5vV4b0LIZMu/rwfSVvkaU07pvpfTLM0",
+	"5SmQpuzGmwEcQF1xBqY1m5uN+nOdN92oAl1NdKc6f+Kqc4neG3Tnjbeinfa8wCe2qc8lbf3C9ectBGi9",
+	"Br0emoe3y/y+XCV669nsJtxX0X63q0d3YeDYxaB7dYV6Z1Hv8hp1mOrjqNSbMD/o1JWwdqdUr1Oqt8lX",
+	"G2dr5GY0N9fTcOsWD+eo0JpLC0qLsZCw5wS2LOMycZdGaRhqNTNc94bM8ASizpmeg7CgCht1YCoYHCQq",
+	"Ngf7nW6n0GnncecAldfFSZxkn0LCpzxVecaxVz6NnlibPz44SN2AiTL28Q+HPxzidffbX/mUkwe5MXg3",
+	"HSkS+Feu1ZAb2Cvw+LkjAg7n9vu1XvucpXbSsLpaeVefgWBAe5EXe4Yh4Th6+eyn2tfCyM3fo7Kfe+4I",
+	"uYYD7CCvVdrLUyY5ZCyeuOXvYyN5IaskqdpEVCBu8yxVD41NH6rKnm/8GkaX/fu//ht3zazKRAwlYZhW",
+	"0g8UUlhTmwBjETZ+unzVwyF1oN57xvNUzR1adOHUMstHRXrKbReeMZ4pecrtfj+ST8EIOU55KOrrBNFc",
+	"pfNM6XwiYlB0TES6IRFuCWjBUfoJGM7h6bM3vcPDw++IWvs1V5dr48KDF62C70ITJP+x0v618VtlC9c+",
+	"HKXMGDESFZYNapAeQMrmXEPOdVj8wyeRdMOizmzC7D0DQlr8bo+/z5Xhyd+iDrAiERaQbDogCXdXzAxx",
+	"2V3YUWELzSPJY2XmxvKsR9NoniLlNxORmy7qUm44Pcx4NuTaPVoAX9UZbnXLPm+zZ9AhCCupWVX5ZYds",
+	"SnLQaoabjSeFvHD0cMjiCyHHkTRWaTbmCKKQxxozCRNHBVRh+/AClzkQcqSZsbqI3SbP88nciJilA9gz",
+	"LOORZAZeqYTvP8ZPnbyDjOUGlLQKwliHOxdwAEenx6EIg3FYubDx1XyPVQCUxsB1IKAyM4twcMsKSNkz",
+	"IuGR9JIDkmMPiC4MHfcBq4CtQlbJmEAVwBY7PItkrtVUOObANUyYAcOsMIR9FQTrCLhxy77yxOq+fyky",
+	"JqFGhx0Wur0Vhmt0ZB9AzoyZKZ1AqsZCdsEQ14KMSTbmSAsiWQ4iSa3vdhpuwl8W1uYma1jJ0yQTsqdk",
+	"Ogcuk1wJac1jXEZ9okCHe1ZdcHdfTMFkzLuRZLEDQy8sTvOp4LM+/B3FmUBwmJtkAHjGsKdVyv+KP+0v",
+	"rtD91Pnw24f/PwAA//+I6V9GSMgBAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -89,6 +90,51 @@ func (e AuditEventSource) Valid() bool {
 	case AuditEventSourceIngestGw:
 		return true
 	case AuditEventSourceSystem:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EolExtractRowEntityType.
+const (
+	EolExtractRowEntityTypeCluster EolExtractRowEntityType = "cluster"
+	EolExtractRowEntityTypeNode    EolExtractRowEntityType = "node"
+	EolExtractRowEntityTypeVm      EolExtractRowEntityType = "vm"
+)
+
+// Valid indicates whether the value is a known member of the EolExtractRowEntityType enum.
+func (e EolExtractRowEntityType) Valid() bool {
+	switch e {
+	case EolExtractRowEntityTypeCluster:
+		return true
+	case EolExtractRowEntityTypeNode:
+		return true
+	case EolExtractRowEntityTypeVm:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EolExtractRowStatus.
+const (
+	EolExtractRowStatusApproachingEol EolExtractRowStatus = "approaching_eol"
+	EolExtractRowStatusEol            EolExtractRowStatus = "eol"
+	EolExtractRowStatusSupported      EolExtractRowStatus = "supported"
+	EolExtractRowStatusUnknown        EolExtractRowStatus = "unknown"
+)
+
+// Valid indicates whether the value is a known member of the EolExtractRowStatus enum.
+func (e EolExtractRowStatus) Valid() bool {
+	switch e {
+	case EolExtractRowStatusApproachingEol:
+		return true
+	case EolExtractRowStatusEol:
+		return true
+	case EolExtractRowStatusSupported:
+		return true
+	case EolExtractRowStatusUnknown:
 		return true
 	default:
 		return false
@@ -272,6 +318,108 @@ func (e ListAuditEventsParamsSource) Valid() bool {
 	case IngestGw:
 		return true
 	case System:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EolExtractParamsFormat.
+const (
+	EolExtractParamsFormatCsv  EolExtractParamsFormat = "csv"
+	EolExtractParamsFormatJson EolExtractParamsFormat = "json"
+)
+
+// Valid indicates whether the value is a known member of the EolExtractParamsFormat enum.
+func (e EolExtractParamsFormat) Valid() bool {
+	switch e {
+	case EolExtractParamsFormatCsv:
+		return true
+	case EolExtractParamsFormatJson:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EolExtractParamsEntityType.
+const (
+	EolExtractParamsEntityTypeCluster EolExtractParamsEntityType = "cluster"
+	EolExtractParamsEntityTypeNode    EolExtractParamsEntityType = "node"
+	EolExtractParamsEntityTypeVm      EolExtractParamsEntityType = "vm"
+)
+
+// Valid indicates whether the value is a known member of the EolExtractParamsEntityType enum.
+func (e EolExtractParamsEntityType) Valid() bool {
+	switch e {
+	case EolExtractParamsEntityTypeCluster:
+		return true
+	case EolExtractParamsEntityTypeNode:
+		return true
+	case EolExtractParamsEntityTypeVm:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for EolExtractParamsStatus.
+const (
+	EolExtractParamsStatusApproachingEol EolExtractParamsStatus = "approaching_eol"
+	EolExtractParamsStatusEol            EolExtractParamsStatus = "eol"
+	EolExtractParamsStatusSupported      EolExtractParamsStatus = "supported"
+	EolExtractParamsStatusUnknown        EolExtractParamsStatus = "unknown"
+)
+
+// Valid indicates whether the value is a known member of the EolExtractParamsStatus enum.
+func (e EolExtractParamsStatus) Valid() bool {
+	switch e {
+	case EolExtractParamsStatusApproachingEol:
+		return true
+	case EolExtractParamsStatusEol:
+		return true
+	case EolExtractParamsStatusSupported:
+		return true
+	case EolExtractParamsStatusUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SearchExtractParamsKind.
+const (
+	Pods            SearchExtractParamsKind = "pods"
+	VirtualMachines SearchExtractParamsKind = "virtual_machines"
+	Workloads       SearchExtractParamsKind = "workloads"
+)
+
+// Valid indicates whether the value is a known member of the SearchExtractParamsKind enum.
+func (e SearchExtractParamsKind) Valid() bool {
+	switch e {
+	case Pods:
+		return true
+	case VirtualMachines:
+		return true
+	case Workloads:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for SearchExtractParamsFormat.
+const (
+	SearchExtractParamsFormatCsv  SearchExtractParamsFormat = "csv"
+	SearchExtractParamsFormatJson SearchExtractParamsFormat = "json"
+)
+
+// Valid indicates whether the value is a known member of the SearchExtractParamsFormat enum.
+func (e SearchExtractParamsFormat) Valid() bool {
+	switch e {
+	case SearchExtractParamsFormatCsv:
+		return true
+	case SearchExtractParamsFormatJson:
 		return true
 	default:
 		return false
@@ -583,6 +731,28 @@ type ContainerVersionInfo struct {
 	LastCheckedAt time.Time `json:"last_checked_at"`
 	LatestTag     string    `json:"latest_tag"`
 }
+
+// EolExtractRow defines model for EolExtractRow.
+type EolExtractRow struct {
+	CheckedAt       *string                 `json:"checked_at,omitempty"`
+	Cluster         *string                 `json:"cluster,omitempty"`
+	Cycle           string                  `json:"cycle"`
+	EntityId        string                  `json:"entity_id"`
+	EntityName      string                  `json:"entity_name"`
+	EntityType      EolExtractRowEntityType `json:"entity_type"`
+	EolDate         *string                 `json:"eol_date,omitempty"`
+	Latest          *string                 `json:"latest,omitempty"`
+	LatestAvailable *string                 `json:"latest_available,omitempty"`
+	Product         string                  `json:"product"`
+	Status          EolExtractRowStatus     `json:"status"`
+	Support         *string                 `json:"support,omitempty"`
+}
+
+// EolExtractRowEntityType defines model for EolExtractRow.EntityType.
+type EolExtractRowEntityType string
+
+// EolExtractRowStatus defines model for EolExtractRow.Status.
+type EolExtractRowStatus string
 
 // Health defines model for Health.
 type Health struct {
@@ -1618,6 +1788,20 @@ type PodCreate struct {
 	WorkloadId *openapi_types.UUID `json:"workload_id,omitempty"`
 }
 
+// PodExtractRow defines model for PodExtractRow.
+type PodExtractRow struct {
+	Cluster      string              `json:"cluster"`
+	Id           *openapi_types.UUID `json:"id,omitempty"`
+	ImageMatches *string             `json:"image_matches,omitempty"`
+	Name         string              `json:"name"`
+	Namespace    string              `json:"namespace"`
+	Node         *string             `json:"node,omitempty"`
+	Phase        *string             `json:"phase,omitempty"`
+	UpdatedAt    *time.Time          `json:"updated_at,omitempty"`
+	WorkloadKind *string             `json:"workload_kind,omitempty"`
+	WorkloadName *string             `json:"workload_name,omitempty"`
+}
+
 // PodList Paged list of pods.
 type PodList struct {
 	Items []Pod `json:"items"`
@@ -1965,6 +2149,21 @@ type VerifyTokenResponse struct {
 // not survive the DMZ hop.
 type VerifyTokenResponseKind string
 
+// VirtualMachineExtractRow defines model for VirtualMachineExtractRow.
+type VirtualMachineExtractRow struct {
+	ApplicationsMatched *string             `json:"applications_matched,omitempty"`
+	CloudAccount        *string             `json:"cloud_account,omitempty"`
+	DisplayName         *string             `json:"display_name,omitempty"`
+	Id                  *openapi_types.UUID `json:"id,omitempty"`
+	ImageId             *string             `json:"image_id,omitempty"`
+	ImageName           *string             `json:"image_name,omitempty"`
+	Name                string              `json:"name"`
+	PowerState          *string             `json:"power_state,omitempty"`
+	Region              *string             `json:"region,omitempty"`
+	Role                *string             `json:"role,omitempty"`
+	UpdatedAt           *time.Time          `json:"updated_at,omitempty"`
+}
+
 // Workload defines model for Workload.
 type Workload struct {
 	// Containers Containers associated with the resource. For Pods this reflects the
@@ -2042,6 +2241,19 @@ type WorkloadCreate struct {
 	// for Deployment, service_name for StatefulSet). Open-ended; stored
 	// as JSONB.
 	Spec *map[string]interface{} `json:"spec,omitempty"`
+}
+
+// WorkloadExtractRow defines model for WorkloadExtractRow.
+type WorkloadExtractRow struct {
+	Cluster       string              `json:"cluster"`
+	Id            *openapi_types.UUID `json:"id,omitempty"`
+	ImageMatches  *string             `json:"image_matches,omitempty"`
+	Kind          string              `json:"kind"`
+	Name          string              `json:"name"`
+	Namespace     string              `json:"namespace"`
+	ReadyReplicas *int                `json:"ready_replicas,omitempty"`
+	Replicas      *int                `json:"replicas,omitempty"`
+	UpdatedAt     *time.Time          `json:"updated_at,omitempty"`
 }
 
 // WorkloadKind Kubernetes workload controller kind. Casing matches the `kind` field
@@ -2272,6 +2484,22 @@ type ListClustersParams struct {
 	Name *string `form:"name,omitempty" json:"name,omitempty"`
 }
 
+// EolExtractParams defines parameters for EolExtract.
+type EolExtractParams struct {
+	Format     EolExtractParamsFormat      `form:"format" json:"format"`
+	EntityType *EolExtractParamsEntityType `form:"entity_type,omitempty" json:"entity_type,omitempty"`
+	Status     *EolExtractParamsStatus     `form:"status,omitempty" json:"status,omitempty"`
+}
+
+// EolExtractParamsFormat defines parameters for EolExtract.
+type EolExtractParamsFormat string
+
+// EolExtractParamsEntityType defines parameters for EolExtract.
+type EolExtractParamsEntityType string
+
+// EolExtractParamsStatus defines parameters for EolExtract.
+type EolExtractParamsStatus string
+
 // ListImageVersionsParams defines parameters for ListImageVersions.
 type ListImageVersionsParams struct {
 	Limit             *int       `form:"limit,omitempty" json:"limit,omitempty"`
@@ -2378,6 +2606,24 @@ type ListPodsParams struct {
 	// WorkloadId Filter pods by their controlling workload. Returns only pods whose
 	// `workload_id` FK matches the given UUID.
 	WorkloadId *PodWorkloadIdFilter `form:"workload_id,omitempty" json:"workload_id,omitempty"`
+}
+
+// SearchExtractParams defines parameters for SearchExtract.
+type SearchExtractParams struct {
+	Q      string                    `form:"q" json:"q"`
+	Kind   SearchExtractParamsKind   `form:"kind" json:"kind"`
+	Format SearchExtractParamsFormat `form:"format" json:"format"`
+}
+
+// SearchExtractParamsKind defines parameters for SearchExtract.
+type SearchExtractParamsKind string
+
+// SearchExtractParamsFormat defines parameters for SearchExtract.
+type SearchExtractParamsFormat string
+
+// SearchExtractZipParams defines parameters for SearchExtractZip.
+type SearchExtractZipParams struct {
+	Q string `form:"q" json:"q"`
 }
 
 // ListServicesParams defines parameters for ListServices.
@@ -2612,6 +2858,9 @@ type ServerInterface interface {
 	// Update mutable fields of a cluster
 	// (PATCH /v1/clusters/{id})
 	UpdateCluster(w http.ResponseWriter, r *http.Request, id ClusterId)
+	// Download EOL Dashboard rows as CSV or JSON
+	// (GET /v1/eol/extract)
+	EolExtract(w http.ResponseWriter, r *http.Request, params EolExtractParams)
 	// List enriched container images with their latest tags
 	// (GET /v1/image-versions)
 	ListImageVersions(w http.ResponseWriter, r *http.Request, params ListImageVersionsParams)
@@ -2729,6 +2978,12 @@ type ServerInterface interface {
 	// Update mutable fields of a pod
 	// (PATCH /v1/pods/{id})
 	UpdatePod(w http.ResponseWriter, r *http.Request, id PodId)
+	// Download Search results as CSV or JSON
+	// (GET /v1/search/extract)
+	SearchExtract(w http.ResponseWriter, r *http.Request, params SearchExtractParams)
+	// Download Search results as a ZIP bundle
+	// (GET /v1/search/extract.zip)
+	SearchExtractZip(w http.ResponseWriter, r *http.Request, params SearchExtractZipParams)
 	// List services
 	// (GET /v1/services)
 	ListServices(w http.ResponseWriter, r *http.Request, params ListServicesParams)
@@ -3681,6 +3936,64 @@ func (siw *ServerInterfaceWrapper) UpdateCluster(w http.ResponseWriter, r *http.
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.UpdateCluster(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// EolExtract operation middleware
+func (siw *ServerInterfaceWrapper) EolExtract(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"read"})
+
+	ctx = context.WithValue(ctx, SessionCookieScopes, []string{"read"})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params EolExtractParams
+
+	// ------------- Required query parameter "format" -------------
+
+	if paramValue := r.URL.Query().Get("format"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "format"})
+		return
+	}
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "format", r.URL.Query(), &params.Format, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "format", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "entity_type" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "entity_type", r.URL.Query(), &params.EntityType, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "entity_type", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "status" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "status", r.URL.Query(), &params.Status, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "status", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.EolExtract(w, r, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -4968,6 +5281,120 @@ func (siw *ServerInterfaceWrapper) UpdatePod(w http.ResponseWriter, r *http.Requ
 	handler.ServeHTTP(w, r)
 }
 
+// SearchExtract operation middleware
+func (siw *ServerInterfaceWrapper) SearchExtract(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"read"})
+
+	ctx = context.WithValue(ctx, SessionCookieScopes, []string{"read"})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params SearchExtractParams
+
+	// ------------- Required query parameter "q" -------------
+
+	if paramValue := r.URL.Query().Get("q"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "q"})
+		return
+	}
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "q", r.URL.Query(), &params.Q, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "q", Err: err})
+		return
+	}
+
+	// ------------- Required query parameter "kind" -------------
+
+	if paramValue := r.URL.Query().Get("kind"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "kind"})
+		return
+	}
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "kind", r.URL.Query(), &params.Kind, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "kind", Err: err})
+		return
+	}
+
+	// ------------- Required query parameter "format" -------------
+
+	if paramValue := r.URL.Query().Get("format"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "format"})
+		return
+	}
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "format", r.URL.Query(), &params.Format, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "format", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.SearchExtract(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// SearchExtractZip operation middleware
+func (siw *ServerInterfaceWrapper) SearchExtractZip(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"read"})
+
+	ctx = context.WithValue(ctx, SessionCookieScopes, []string{"read"})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params SearchExtractZipParams
+
+	// ------------- Required query parameter "q" -------------
+
+	if paramValue := r.URL.Query().Get("q"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "q"})
+		return
+	}
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "q", r.URL.Query(), &params.Q, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "q", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.SearchExtractZip(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ListServices operation middleware
 func (siw *ServerInterfaceWrapper) ListServices(w http.ResponseWriter, r *http.Request) {
 
@@ -5510,6 +5937,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("DELETE "+options.BaseURL+"/v1/clusters/{id}", wrapper.DeleteCluster)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/clusters/{id}", wrapper.GetCluster)
 	m.HandleFunc("PATCH "+options.BaseURL+"/v1/clusters/{id}", wrapper.UpdateCluster)
+	m.HandleFunc("GET "+options.BaseURL+"/v1/eol/extract", wrapper.EolExtract)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/image-versions", wrapper.ListImageVersions)
 	m.HandleFunc("POST "+options.BaseURL+"/v1/image-versions/refresh", wrapper.RefreshImageVersions)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/image-versions/{image_repo}", wrapper.GetImageVersion)
@@ -5549,6 +5977,8 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("DELETE "+options.BaseURL+"/v1/pods/{id}", wrapper.DeletePod)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/pods/{id}", wrapper.GetPod)
 	m.HandleFunc("PATCH "+options.BaseURL+"/v1/pods/{id}", wrapper.UpdatePod)
+	m.HandleFunc("GET "+options.BaseURL+"/v1/search/extract", wrapper.SearchExtract)
+	m.HandleFunc("GET "+options.BaseURL+"/v1/search/extract.zip", wrapper.SearchExtractZip)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/services", wrapper.ListServices)
 	m.HandleFunc("POST "+options.BaseURL+"/v1/services", wrapper.CreateService)
 	m.HandleFunc("POST "+options.BaseURL+"/v1/services/reconcile", wrapper.ReconcileServices)
@@ -6897,6 +7327,77 @@ type UpdateCluster404ApplicationProblemPlusJSONResponse struct {
 func (response UpdateCluster404ApplicationProblemPlusJSONResponse) VisitUpdateClusterResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type EolExtractRequestObject struct {
+	Params EolExtractParams
+}
+
+type EolExtractResponseObject interface {
+	VisitEolExtractResponse(w http.ResponseWriter) error
+}
+
+type EolExtract200ResponseHeaders struct {
+	ContentDisposition  string
+	XLongueVueTruncated string
+}
+
+type EolExtract200JSONResponse struct {
+	Body    []EolExtractRow
+	Headers EolExtract200ResponseHeaders
+}
+
+func (response EolExtract200JSONResponse) VisitEolExtractResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", fmt.Sprint(response.Headers.ContentDisposition))
+	w.Header().Set("X-Longue-Vue-Truncated", fmt.Sprint(response.Headers.XLongueVueTruncated))
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response.Body)
+}
+
+type EolExtract200TextcsvResponse struct {
+	Body          io.Reader
+	Headers       EolExtract200ResponseHeaders
+	ContentLength int64
+}
+
+func (response EolExtract200TextcsvResponse) VisitEolExtractResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "text/csv")
+	if response.ContentLength != 0 {
+		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
+	}
+	w.Header().Set("Content-Disposition", fmt.Sprint(response.Headers.ContentDisposition))
+	w.Header().Set("X-Longue-Vue-Truncated", fmt.Sprint(response.Headers.XLongueVueTruncated))
+	w.WriteHeader(200)
+
+	if closer, ok := response.Body.(io.ReadCloser); ok {
+		defer closer.Close()
+	}
+	_, err := io.Copy(w, response.Body)
+	return err
+}
+
+type EolExtract400ApplicationProblemPlusJSONResponse struct {
+	BadRequestApplicationProblemPlusJSONResponse
+}
+
+func (response EolExtract400ApplicationProblemPlusJSONResponse) VisitEolExtractResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type EolExtract403ApplicationProblemPlusJSONResponse struct {
+	ForbiddenApplicationProblemPlusJSONResponse
+}
+
+func (response EolExtract403ApplicationProblemPlusJSONResponse) VisitEolExtractResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(403)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -9085,6 +9586,136 @@ func (response UpdatePod404ApplicationProblemPlusJSONResponse) VisitUpdatePodRes
 	return json.NewEncoder(w).Encode(response)
 }
 
+type SearchExtractRequestObject struct {
+	Params SearchExtractParams
+}
+
+type SearchExtractResponseObject interface {
+	VisitSearchExtractResponse(w http.ResponseWriter) error
+}
+
+type SearchExtract200ResponseHeaders struct {
+	ContentDisposition  string
+	XLongueVueTruncated string
+}
+
+type SearchExtract200JSONResponse struct {
+	Body struct {
+		union json.RawMessage
+	}
+	Headers SearchExtract200ResponseHeaders
+}
+
+func (response SearchExtract200JSONResponse) VisitSearchExtractResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", fmt.Sprint(response.Headers.ContentDisposition))
+	w.Header().Set("X-Longue-Vue-Truncated", fmt.Sprint(response.Headers.XLongueVueTruncated))
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response.Body.union)
+}
+
+type SearchExtract200TextcsvResponse struct {
+	Body          io.Reader
+	Headers       SearchExtract200ResponseHeaders
+	ContentLength int64
+}
+
+func (response SearchExtract200TextcsvResponse) VisitSearchExtractResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "text/csv")
+	if response.ContentLength != 0 {
+		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
+	}
+	w.Header().Set("Content-Disposition", fmt.Sprint(response.Headers.ContentDisposition))
+	w.Header().Set("X-Longue-Vue-Truncated", fmt.Sprint(response.Headers.XLongueVueTruncated))
+	w.WriteHeader(200)
+
+	if closer, ok := response.Body.(io.ReadCloser); ok {
+		defer closer.Close()
+	}
+	_, err := io.Copy(w, response.Body)
+	return err
+}
+
+type SearchExtract400ApplicationProblemPlusJSONResponse struct {
+	BadRequestApplicationProblemPlusJSONResponse
+}
+
+func (response SearchExtract400ApplicationProblemPlusJSONResponse) VisitSearchExtractResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SearchExtract403ApplicationProblemPlusJSONResponse struct {
+	ForbiddenApplicationProblemPlusJSONResponse
+}
+
+func (response SearchExtract403ApplicationProblemPlusJSONResponse) VisitSearchExtractResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SearchExtractZipRequestObject struct {
+	Params SearchExtractZipParams
+}
+
+type SearchExtractZipResponseObject interface {
+	VisitSearchExtractZipResponse(w http.ResponseWriter) error
+}
+
+type SearchExtractZip200ResponseHeaders struct {
+	ContentDisposition  string
+	XLongueVueTruncated string
+}
+
+type SearchExtractZip200ApplicationzipResponse struct {
+	Body          io.Reader
+	Headers       SearchExtractZip200ResponseHeaders
+	ContentLength int64
+}
+
+func (response SearchExtractZip200ApplicationzipResponse) VisitSearchExtractZipResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/zip")
+	if response.ContentLength != 0 {
+		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
+	}
+	w.Header().Set("Content-Disposition", fmt.Sprint(response.Headers.ContentDisposition))
+	w.Header().Set("X-Longue-Vue-Truncated", fmt.Sprint(response.Headers.XLongueVueTruncated))
+	w.WriteHeader(200)
+
+	if closer, ok := response.Body.(io.ReadCloser); ok {
+		defer closer.Close()
+	}
+	_, err := io.Copy(w, response.Body)
+	return err
+}
+
+type SearchExtractZip400ApplicationProblemPlusJSONResponse struct {
+	BadRequestApplicationProblemPlusJSONResponse
+}
+
+func (response SearchExtractZip400ApplicationProblemPlusJSONResponse) VisitSearchExtractZipResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type SearchExtractZip403ApplicationProblemPlusJSONResponse struct {
+	ForbiddenApplicationProblemPlusJSONResponse
+}
+
+func (response SearchExtractZip403ApplicationProblemPlusJSONResponse) VisitSearchExtractZipResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type ListServicesRequestObject struct {
 	Params ListServicesParams
 }
@@ -9859,6 +10490,9 @@ type StrictServerInterface interface {
 	// Update mutable fields of a cluster
 	// (PATCH /v1/clusters/{id})
 	UpdateCluster(ctx context.Context, request UpdateClusterRequestObject) (UpdateClusterResponseObject, error)
+	// Download EOL Dashboard rows as CSV or JSON
+	// (GET /v1/eol/extract)
+	EolExtract(ctx context.Context, request EolExtractRequestObject) (EolExtractResponseObject, error)
 	// List enriched container images with their latest tags
 	// (GET /v1/image-versions)
 	ListImageVersions(ctx context.Context, request ListImageVersionsRequestObject) (ListImageVersionsResponseObject, error)
@@ -9976,6 +10610,12 @@ type StrictServerInterface interface {
 	// Update mutable fields of a pod
 	// (PATCH /v1/pods/{id})
 	UpdatePod(ctx context.Context, request UpdatePodRequestObject) (UpdatePodResponseObject, error)
+	// Download Search results as CSV or JSON
+	// (GET /v1/search/extract)
+	SearchExtract(ctx context.Context, request SearchExtractRequestObject) (SearchExtractResponseObject, error)
+	// Download Search results as a ZIP bundle
+	// (GET /v1/search/extract.zip)
+	SearchExtractZip(ctx context.Context, request SearchExtractZipRequestObject) (SearchExtractZipResponseObject, error)
 	// List services
 	// (GET /v1/services)
 	ListServices(ctx context.Context, request ListServicesRequestObject) (ListServicesResponseObject, error)
@@ -10858,6 +11498,32 @@ func (sh *strictHandler) UpdateCluster(w http.ResponseWriter, r *http.Request, i
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(UpdateClusterResponseObject); ok {
 		if err := validResponse.VisitUpdateClusterResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// EolExtract operation middleware
+func (sh *strictHandler) EolExtract(w http.ResponseWriter, r *http.Request, params EolExtractParams) {
+	var request EolExtractRequestObject
+
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.EolExtract(ctx, request.(EolExtractRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "EolExtract")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(EolExtractResponseObject); ok {
+		if err := validResponse.VisitEolExtractResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -11979,6 +12645,58 @@ func (sh *strictHandler) UpdatePod(w http.ResponseWriter, r *http.Request, id Po
 	}
 }
 
+// SearchExtract operation middleware
+func (sh *strictHandler) SearchExtract(w http.ResponseWriter, r *http.Request, params SearchExtractParams) {
+	var request SearchExtractRequestObject
+
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.SearchExtract(ctx, request.(SearchExtractRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "SearchExtract")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(SearchExtractResponseObject); ok {
+		if err := validResponse.VisitSearchExtractResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// SearchExtractZip operation middleware
+func (sh *strictHandler) SearchExtractZip(w http.ResponseWriter, r *http.Request, params SearchExtractZipParams) {
+	var request SearchExtractZipRequestObject
+
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.SearchExtractZip(ctx, request.(SearchExtractZipRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "SearchExtractZip")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(SearchExtractZipResponseObject); ok {
+		if err := validResponse.VisitSearchExtractZipResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // ListServices operation middleware
 func (sh *strictHandler) ListServices(w http.ResponseWriter, r *http.Request, params ListServicesParams) {
 	var request ListServicesRequestObject
@@ -12328,316 +13046,334 @@ func (sh *strictHandler) UpdateWorkload(w http.ResponseWriter, r *http.Request, 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+y965LbNrYw+iqrdL4qdyeSuu04nsSuqSmn7Ux6x5cud9tTtYc5LYiEJEyTAAOAkpWU",
-	"q/av8wCn9jOc/R77UeZJTmEtgKQkSqL65lv/SdwUSAALC+t++bMTqyxXkktrOo//7ORMs4xbrvGvo7Qw",
-	"luvjxP2RcBNrkVuhZOdx55TrKdc9ZowYS55ATENBJFxaMRJc9zvdjnBDc2YnnW5Hsox3HndE0ul2NP+9",
-	"EJonncdWF7zbMfGEZ8zNMlI6Y7bzuFMUONLOc/eWsVrIcefDh27nqNBG6dUVvc7Z7wWHGH8GzW2h3cJG",
-	"WmXAINd8KlRhIBXGguYmV9Lwco2/F1zPq0XSRzr1hWXs/Qsux3bSefz9/QdNCzuWcVok/IzrTEhmeQPU",
-	"/jHhEnDLIGg0aDUzMJsow2Fgy1fPmR2AMGC4hT2jRraX8JRbnsBwHkk74RCrNOWxxa3GSsYi5ZAzY/b7",
-	"8IyPWJFaA1bBiKWGPwYl0zmkYsrBHY8V3ESSaV6CqQ9Pn73pHR4+uA//+z/fwwH87/886kdyDXj82s+r",
-	"9S6AKqH5O49x8hJUQ6VSzqSH1VhzY9pglqCht4BZflGvWMZNzmJ+nPwsUssbcO0Ngo2g6tfHDQx5quRY",
-	"yLEDvJ0IAzJ8ah2ilQPOxSIMt6/2hciEXV3aS/ZeZEUGssiGXIMagbA8Q1ygw+4DQRjilGU5/vDP+114",
-	"cHj427pVpjhV4xF/f9h1V8NN2Xn84ND9JST9db9ctZCWj7nGZZfQLYlLGyCXcGqCsqc9ay8z/bw7hGuI",
-	"sB1NyxXeAqK+UsmO4FPJ7UJOJe2AppLbgNcJ10YYy6V9p9Ii40cpE1mb9eXlizDFN92lEdnHWvKOlGnN",
-	"6m+bUK1uZQfMXdnDbaLx8sovhzK3gCwqabU0ldzSYjI25utO94gZ3hPScGmEdRKJKYb0OmTMxhNgYyak",
-	"scDkHGIlLROS63sGBsJ9dhDJkeCpkwvAyUG5Su6ZapyB/zh9/Qr2hBS2/tSLLMl+P5K/MJnMYaQ0MGlm",
-	"HKeOOrOJiCfucwZ0IWGQqvHDfz1+0L//ff9w8LeoA//+r/92giTTVrA0kqm44PVRA5iJNPV7WHy7u/D3",
-	"/UEXuI03iFdun+uEzwfff7cG6rtSB7fTW6YEKnGcwS103Qqfv2exXUKE6pgHjmGcuxUM+vCCOxF3wsF9",
-	"ExJumUgjORV85s918VCduDtRxsnQSvq9qoS7k50JO1GFjWTOxk6edfDgU67ndGUI0QKRWXts5dp2P7p/",
-	"KH2RKpasPzl67g9t7hYkNOK3Vmnq1jvzn+gDHbKpnTKqF5EchDHnIhnAz78SmDkBcSymXMLbt8fP1u+w",
-	"9v6OJ+9IkWgnSBkaeguUyi9qx3vj13fbd+eUGyOUbIYg/lSDGOyRiqguBIcpSwu+fzkg1rD30cOmZZ2p",
-	"Cy7bHOvTk2OwbvAtHOxb085oUZhbsVhUt3v7ksIVu81l3SK3DtvblWW/FForTZRqUcAAo2Co7AQuhHRU",
-	"nii/G2dYxiMZeAAzxvELx9pJZgx2L5g6iU1Jxwh+L7hxG79e3hwA/auQrShMAJJx2jsu1u1tHU1xvy0s",
-	"6P9oPuo87vxfB5Vp74B+NQf1pSysbUciWC3xNqngB4fwZLlD++RPLHnD8czcXw51uMR/sjxPRczcwg9y",
-	"rYYpz779l3G7+LMloE7oLZp02cKSuoXyBDRN3u986HaOlBylIr7VlYQ5UYCBuNDa4bOxzHLY4/1xvwtJ",
-	"QfNzPJZ9XOrPSg9FknB5m2s9I9pvHDsSCQwLCymLL+hKm1jlHAIx8wIOqJxrXA2u+pWyP6tCJre56Dfc",
-	"qELHHKSyMHKz41LeSlbYidLiD36ry3kpjHE3TWkQ0sORM+3onYNuH2+0/46b5mkuEOwNVkJuWcIsIy0I",
-	"MhZPhOT+M3DmBO6UCWn5e+vOTDppmGi4MJEMlxBVImHveVmztLkrGXN3iINYc2Z5WMaAyGqu3cFaQXeY",
-	"hiTnzC5QgIRZ3rMChWnNWfJapvPA5JbIQrf8xnB+7li6IysN1GTrZ/j7XGhuNi1FFmnKhilf+41LTp0y",
-	"Y93ak10m3/pVorfLZ/9LkTHZi51OICFlQ54GYjGIOrHoaZ5yx/VzkfNUSB51Big9LjC6Rw3T5ZqPxPsm",
-	"3UUbCz9APGGaxdbxdmRsdSTzmPdMmDxlc54Ac2zFiISTu4NER7chx/CJMjiBIGalQDkH4vQ2UBohnYQX",
-	"Sa/egeZTzlBZcl8cFWlKsjGh5VZoaj5VF9d8Qkj48B6gld79Y2WMf8C0ZvMO8cAg9P2TpECvdHr4l19t",
-	"vBjd+o37rfy6Gv6Lx9ZNF27rEQ5bPc0TNkcB1SrIhLTAQPLZEgVZueWLV2vZcef+wVLAQfM+HI+ADQ2X",
-	"tgvV0Zeco5BWpOAPw810uYsa7sZWrK6OaElyx+cODGPNpO3D0yQT0rOymEnHMoacfuQILtyIcUQzkswN",
-	"7iHZ5DLJlZCWTBSGlDn6CalzHKtCWjYUqbBzL5kGZOGyyBwaOETrdDszLazbPTkLa8dbbScT8pjevr8F",
-	"tUpTBu5/E6q8EMY2IcqYJ+RvddcdN7+KGeVWyn9sYo4lR1u5F92O5O/teVx6h7dgwPI9wtk3bfKl8Bw+",
-	"TV+POo//2Xqhfy7t2Daz5JNFWtgFwmsYpNPznNnzqDg8/C7+wRFRg//m/pFmMlEZPXIs9kRzd3l4Avw9",
-	"i206R37ch1OrNHdEkYHhsXbaUMYkG3P9BBIVIcLGKsuEWwF4wcebmAjtNoOQ9rUKwt8apCoSH0qBoUlW",
-	"QClkgB8dACmRMdMaXdcl/a4YiBNFYpXPQViQatZ1/58pec8Cy3POtFNQZxOuOfDUIMl3Z1skwj6fetlt",
-	"iSxJjq51nXjrBYtRFoV/aGEtl0FKZe4bkIkkSfnM3WA2slzTGmfaTZ7AhMkk5RqVTnczzRMvUhW5I1qo",
-	"HuepU5kaJCSad3WBz5TtGZ4zjV+Ycj0EU6CmCwNH7fsE0UEXBsF2SdMNupEcOAm2n6qxkH1TxDE3xg2s",
-	"PR0xkRaaDxqPvutWpYKktbiuV+5gHOUqUEx2vDnGJXp1yZC4AW4CRyDcbGZ/gZJ7sWkrEadFoAZcI4Zu",
-	"827JiI/dDpNKzjNVOIZo5sbyrJEw0re0SnkL6hGGu6kCJ9n6Cpmo6UyTRBDXO6mdNb23CM2nePo9k/NY",
-	"jEQMObHfPjxNZ2xugEmgiwazCZeQ0+Xvr4deRdkm1ubnGbcTlTQKHvg7Gp3W/up0zaIutpSu/nWi8Mp3",
-	"VIyK60a5qkEWI/rUiICnOEyMhLtYSZA1LdNjTnQiY3Pw7JmhyZsYbZqSEanfBvXKFdAvy2v4VcjlmTHy",
-	"Zu6RP1xJd+kcEuHly8U50bv9VkugBTRFGTkxOEUvJNdosHYCyISXBgucCwOMnJRd8N604PcM5MUwFXEk",
-	"y1f3Jk5XMF1AccV0wWq36qT3h5K1ECSz34eBkGNu7Pl4NoikILU+O3tx2gtBMtzYak0jraStNP1nL/8T",
-	"xszyGZtHco9Cke4/cl+lC4tLdWdk5o6uWhEDd1TbAM8cMcYPVVuJpLCGp6MunnKi0bUxnLu78svZ2UkJ",
-	"BqRsgWqwXKC9yu9iM7EI2Je3uvgoe7OxZzM7Cibu0tTvyALV6wbusHib63d38aY2SjglF2wjyBG/I/B3",
-	"nezvDnbkVLwrC3cVN75F8a6wkyMlR2LcsHHNe8iewDEyJwuNxLggmxRIzpMKg98e9+EYrUBI1dN5JJ1M",
-	"7lYY3Iv0EaNwPH02Z2PUFUBzmXiz9evjZ0eRHBbWKglDPnJCm3uOzooJMyi+oY7QJCwokcQYyLmofkm3",
-	"kDqVL4Pxuh00Aaxu/idaARkIlFxadReQjEWdUzGWTnxxm4zk6wvLok4fjrxn0st2L16/+vvb5+fv3j4/",
-	"d9s7f/H0p+cvBm2EyrDy1aNbGogbbzrgowmTY37CjJkpXbcXL9lSvfU09wPhW9Rrw5+ruO3NredhxJIy",
-	"ef/wwcMmtZPPFt5YNvBh7Bzcf1A3luRcw6vj0zP44fCw9+i7n2BciIShTP9KgbITJ27ifTIoVIAuUm58",
-	"vIKjiriLfKKZ4Y6QsjjmuUXUZDKJZK75iDvyAsrJpGaitPWi6nugpRs6q5X9ZUKWDx5sO8sViC2Bo/H0",
-	"iE22V7z8Cy8L3GCD+nUdBsdLW/nmu2zlBQ5f1Z+85DcQcqSZsbqIbaH5ubucMUsHyCg9GPpwym2gUSgI",
-	"oDtxcaXN1pBHi8f7oNvJmbVcuxX83/9kvT8Oez/+5v/f++3Pw+6jBx/C4//TJLN5XecKgN9g+yLQLhi3",
-	"FmZsoZY+hV+LIdfS6WdlPLvmYyezaF66MI9ePvupX0PNyk52TQjabLU9pQtr0mLcw9CjykHchUKK3wsO",
-	"LNbKmGqVkTzOssLfdKeVAoKnZB03d9pNpqQWR1CzLQbAe/tiGeJXAb6NsOJfu7LdKZCh7XLJpqQEq5AS",
-	"o4b+N3r21wFG6XMbT/Dc3NeQwfYj+RSNoKA0OGGH9DupIHMSgRtiQPOMCX+Y1yUQLeFngzWfp4lxEgEL",
-	"VAbshFmIU4EiudOuDLeOt0DKbGnlWD0DNJIiPm5Qittw1aUVas57jr7AxcEUqWEW3F1OH5gpbScgrAE1",
-	"k06JKTLZh3csLUJWROB5cFQmWaBlNTjCrCrwuJxS4qBR3qb6umvxMhVwnYoX7L0NSmNFf56eHHt6DW/f",
-	"vIA9IYlgIniWjCVadBqdYsI6fiDsvOEQSxBZwTUJeW67WaYkOUXMYxiETzjldCLGEzQcZTwRRUYxjbOB",
-	"E0GcaltkPe6WGPNk1UFjUmVBSLSJCY1gt+y9kiqbw97J4cHJ/YN//9f/t79ClL570HTW5CI63+TcGmnB",
-	"ZZLOaWNdGIXttvJjcTkVWsms0SxYQa42DCwblx53Pu2CsWws5LgLuVbJsvfsURMKX5Rnf+4DUhpkVH/d",
-	"asjhx4LmudJeEa6h0Z6X0u/3H/zY/z7qLC+lEcIItLY3shmES5xVD4XVTM9RiemZIs9T4RCFAoku+PwA",
-	"cY6Oy/RbXiapbJNj5oWSYzqhXCvD+/BUziFj+iJxiCeMV7Ywac1RrJ4RCV+Cyw/3f2yCjJrJxuDMEifI",
-	"0Is0By0/nGVwAEr2YpamRCbVTBrvR49LIa3QIxaHyNQQzErqoVEgZIzc3uetJVybSF5INYPZRDn+MWMX",
-	"HIp85QKt89OqqUiaNvLWfTudu0OpIVEi3LvDAnULpTGK1g0J3+lH8nXOZc+BNXmCPoQaFRlfOGXxwnSB",
-	"uf+onEszESPbBe1+cXjPkqwLyukh7v9On2mUTxpscGN/T7aOLORQqYvzQjdoui+EvKDoJe5OBx3EnGX3",
-	"MFrMvebPczHTYIn+bmNSH9az2rfIHi8vQa6IUS+5HvNejvF5Q5XM++CEagiiIPIs8wQGGEiNnvIgJrqj",
-	"9BY1GoU+yZSPLBQyRk068b6ToxCp1yyHHVWBfMwYFQt0AWCgElkiyYTWh5+VhhOV0J0AzUeO46IQG0nM",
-	"WNSFdOoB7LnldgEj8Pz/zoVP8CzDBk/RzMVNF4QUNpKjlI33n+AB/qOMWcOQFR9VDpZnuRNT7hlIeJwy",
-	"JAzl4iO5NK0Udr8PXq4TEqb3HwNn8QS4tHp+z4CZsJzUbCSeU96NpFEkxAZxosffW9TuSzAn6KryEhow",
-	"MDmPYVhk+ZLDd5PjYAW/lkXV8kzeEdc4liO1aiwS5nzIJ96n0mQuMvY8nvD4YkebvQOyseeWjRv8CUvi",
-	"aW1st7ag1dmbJNhfOEvJabG4scpZEWy+6qLRuruWAf9UiDQpea437+tCIs2o7M/9rQrRBmssxra+Qe1H",
-	"z1c30cJ80SDQbDD/OWreLEtRLkb43VH+e9+Qy9kUo5F4Ty7nezATaRIz3ejdKXn0docKs/wcM03Pc67P",
-	"DY8XNjhKFer0ZXrpYf+wimCgbNeWVobNR1PCo3FJFTB3sTUsneqJo8w7WmlvGZAftu3hbW64tjtuoo5r",
-	"61HlxnbU/pjXHuG7ijQsUU3kR04Mb95C7UKv0humBfMVGFqZI+pLeUcvb48UqxZYW05t8m17Dnz+KnaU",
-	"BRhuN6Zc1oZRn+YNH2luJiHoZHUHLNWcJfNzT8ebMff3ghfNWL20KD+wu/LZbesM57i6vtJKsrMAcAVe",
-	"bew517qVr60+/ErBs4sSwg7+7yoMzqN1I1evALzE57LczoMy6iTFvMBAvGxKcSQbkTB8tVxOOxnF15po",
-	"L/T7F74Gv0YZQz/l5Mzwe+/DKee+UMnhw9Z+jO8W3VSNlu29f/b8v74Jj/b/1ujFWEheaRPfcnNuj1oO",
-	"zQ15QTzgN3lB/JBdvSBb0blZJK2tLdSFQdl079mr0x65qo2dp3y/D2/JJ5JzXctI2sUjcrN4s+y1QOdz",
-	"vYhIH9Yt9Ql5CsLYSGaFseD5DfD36PsgAxQhgg+0NPDw8CHtc3t24LL7ZhnZruTNCWdXYNQDq6eMVSjV",
-	"xr9TFt+5qoMn0OOvwMGzdPU2OXhkSQEu6eHx53Mep8yYNSb7QEHcELrNlLzsI0g0DDGz06pgYY86cizk",
-	"+6jj/mk14yNxsWrabkrG/Hxs25hmP2Qpk3FzmQRHiVgKblwvjAOWJHQdupBhxqyQ40gOyNrQd2N/8kP7",
-	"/mT++dugD89L+xUIE8nBnyL/W7dU/P/WhVxpa/72YdCHE5UXKfOOhtmEWXSIjYp0JNKUJxT2HJCGIlDi",
-	"VBVJ/TyV9IHnZdk40wWlI/mSW5a++AkOkAf13h2fwAEwmDCdYGQ1UpNys0r2cs2zPjyNpBFynPJyD2Dn",
-	"uYhZ+gSyIrWiR88Nt0VuQjw4BSwlBUt7xrL4AvamD7+dPtoHLKmWFDJh0sK74xNzFRNcxt77dIuaq6Uk",
-	"LRios/ZGgFYFGtpx2HqjY4iLr84DjadVhTjM9ULiRMVpYM+dbRdyZif0X4xi7cKQxRdcljUYIonX8QDP",
-	"f/86LZE2bdj22YvTpRg7tz3RautuQyaSjiKReXnENZcxT+AUcx2QsFzfDj6sp6u7WvOXJaErWfMDlx4g",
-	"bfYGfqZ5JCsTP7S18L8IYv0SxXt1enrsAG/VWLN8MgcUOykZwji+QDnhjmQviOwPgl8skhdCJj2revRm",
-	"xvLc4Xl5et7PzYHsvhS9JN6H4Srh6WLwLo+Vj9btdoaFEdLx8m6npkm4v5JMSKcfMh8y2xxAtfpDPpkb",
-	"/KVJrXyhxkKuDSt86xME4NsylLBL9QoCs15lmrtFFNZTELbwriURoXyz29kYg/eSN9WFQFJOQUh23gWt",
-	"Ut7FE+SjEY+pVgSmjjVIBUkzoEAkJAQ59PirW163rBlS+6HMMdyqe4XMkMWpKOCePriYoTIVZXCtr57S",
-	"LVOQ3PBIuhGDpz77G/HoMfyEOdiDPrw9Ds5lzNrTieNK80VMXUhOaUzQK9B64C7ihkhRn+S1BK4+nOmC",
-	"3M9DpaxD9dzH7uPRuDEmklRutIx0nTG3bEOBgkzSC8i8KbIZhqmKLwyVRIqk40oc+PuY5xYGB7TUXvja",
-	"wCdoojcPPaYOOslCrG/NrhbybdrRyjeqkUKuAcam7M3nS0jqVSy3nH//P/8vJXEGsqR8fr33D/qSBN3W",
-	"Kbv+tNeIv6uLL/F7411vB4JtNKCsHrI2ybOsDNL+mMpXNlirqpp8bYwoX0fQbgm3q4TtXq/Z4masVwsV",
-	"GW/IdlXZUjZYr6pqtDvar3ZG8UZ7T1U1e5u1J4x03CGS12nr6W43tVWgbGFsq+rkfRxT23LSwQqqXcly",
-	"VYEi2K7qkcklVrSxXVU1ja9qvKpI9Fdgvlq5eRsjlMvRX0KM8tmiWk/ByD4y+TLRyC1DhMs6TCythQvD",
-	"Xpv44H2s6WKFjC1Faj07PjoDt88e2gTFyFdL6jqxlPJWpxwPb3H35lOJDv7ComM/RtyrrMk57SJfQ82p",
-	"hGsDV4h8nTDTltXhWEcKU+bo9dCnUYeI6qeoPZANOrR8EHIcdfYXwmHdGp0umGXK0Rcsk1jhDU1iYMGt",
-	"ZbVKCscVWiH8dUW2LlTtu4bY1pLw7moPW5WsLm0Rq3j/tdjDXqlkl32o5E7/2ar/BNOaV4BUchXdB10+",
-	"W7PYSkGy/yVrPyrZrPioZHedZweM/qzVHQe7StMxxTBRTo69Jm3nmrH0hvUdB4tGVUcl7bQclVyDguMo",
-	"79eg29Ru2Ga1xh1LO40GXqqEYyUGJSPJwFucej6BLNjvMTOjugRVwaEgrRjYQxt/hDkE1nQhVtL/1K0q",
-	"Kr4+BXSn7vfhqMDSVJEM2YA9J0eWfHZvgGIl1qeqFBH3J4quqEzUpBuskFMpY6hzeMfwOXqEBvvIuvOa",
-	"hzqSPBGYhngQzOB2olUxniwLm57sLOpWkSyVK541luZKUxUzPK/zOC8a3CQnb8EhcVIgfixl5xGhIMcV",
-	"WuD1lDbXJkuvPjfPJzzjmqXnxirNxsuMcesHMp4pCk7e5a1cJabVO1+wDs10PBGWozTTfP71EX3YkCnH",
-	"suTRwy4wnbn/5Xn86GHKu2C++/HwfTtlIGY5i4WdNyPjmbIsBbckpHYkIWBoBzm+KEokfKMf5wXs/V4w",
-	"JBCtEkfL6S+Fj+Xb7ZGxfKUtJlYkq7HCgi1MjaqRwaLsMLL3xgkhXXiJyzvR3JhCO3r4TJiL8k84OX5W",
-	"/fGK25nSF28lmzKBJGC/Hm6DtVeQEFM+Wo02UBqZcQyZodYbMwkjKnnvCNvA7W1w4GN7BlAVuc2ZNvzm",
-	"YlbK3Lhzn5i3Pl/ZVzoLLySPDw7u9//Sv//doE1G9K1Ypz6VlHMfz+UrijXVTw4hX8cnhJf+utZCvsQI",
-	"mJwvzffw+4bpFhnnJugOmeY9R1bTkHGOr5RmkGc8TeFEzbh+nox5JN88engYdfaxlkCe8gxlE5LoVZH0",
-	"EKsTpwUay6SvnjdwgkskvcpX0uYnsCg3tLTxLHx6dWtY5yGk7mE/oX6Vet8X6iC836Ol4XFG0lftyx6J",
-	"/vuU6TGW1Ty1TCZMJ+fPHprz6fcN6HT/wQ+NS9xw2idaZEzPsZqYP29/xs3n3ua8L9z+0vpF3bpGB5Tz",
-	"XKv38zWvNd4U91bK7XqS8CsNgLEoG28Ahh9sLF8w/ZrrF7Sz0BIVlONzHwe1qg6dwohlIp1vgvcgFbJ4",
-	"73B7JmSiZmbQCuLKnFNjlNVisI5zvj6l9OkAsHCsb4eFtAU8eNA/fNj/Dl6cnTaF8T66BYM02Z1utwqD",
-	"Ss5jkeg25QtCpYVG48oRxteGIfUuUEQvch73w6/Hz0pSxmbm8cHBAS96M25s7z47EL1DNozvP/ju4feP",
-	"/vLDj4cJHzWQtObdoIGmsQrAlEvBsSEERf1AwrWYhs7MSIVRsBp4ylYJYP1IngW1snwIe6ipas6Mkgcp",
-	"M/ZMM0mF785Exvd95X8MMxxUwtwAUILZFofUgL3up8VFI9vouedLvOObQSABkVwppkMB0L08ZRK5hxMM",
-	"Sf3lNk4Gt2zuV8llLP3dDin/TeXwUcvFOXFIDfvowUKc+YRhoPkFn3cJRF0fN/hhEBotqgRSJhMDWLWb",
-	"ysiOQNhIWpU6asd9SBpN6Jto01ccErxSfk384JV6/p7Hhb0msbh2R0uxuJA1PX8VPAiHhTFlgJ1Dodim",
-	"DkN0ouQARikb9xux9A8lt4o0VuUqVeP5Emq6V5elmeruN9zzRy39PCrZ3cVTNyR/Kt6d5Wav7bez/Oad",
-	"12c3r88y/K7RA3T/6/UALUN1kzeosdv05S8Avv5VZio3QuJTwuevKn258TR2vge7ukl3vA1b3ZEn745a",
-	"eiMXImsu7Y+8dhz7qlOd3ek1pzk34kkbl+q6vv5X9bI2c4GvwO268cZu9MO6071sYCk23UEL7OIRbVMB",
-	"Kz3kh9WjGapCJueEFo3X7+dfg4a4IiCgYuh2JAzgdzCBL7TzieQJl4nT707eHRnsQUkax8k70GqGrQmG",
-	"HLNkUo5u373Xr+DZ8xfPz57D6fMzePX2xYv95jvZojLM52HS2x5g6ODbHFr4GDyAu/CTg34XXqjQpGSr",
-	"WYDyD3lSd7gtd93yQ8CIPzjsoUYayjCafmjO1Pcf2O9iSylmRVbqi1Hn+78LbAfZalH+S0vJ/1tT9D3y",
-	"NvPFN2wGA1w6DXuFOl9QpU/ehQICmHnmuH0dlyN55NOFURKjo+ZTLonQkPdBe/MeYXpAbXnPRhLRmzrE",
-	"8ATm3Dbz0hZacyPF2VWN3ixoXHseMdXGvgbN+qoC1dcQg+YxuR9KrPcwQy/pglGh2v81hZ/d/5TDz1ZF",
-	"naZYtGUEuZQQde3i09coObUTmlYFj2uRoNZeJhqInmsT+AR/nysTuuTIOahRJNER8Q8tLH8tY7TRv/Gq",
-	"7Usm5+FvHEAPll85UcGOfz3SXIhvaWj+WJYq9kO2elEHUef+Ycm+sRloUrL4JxArGfyxVsFwjrkIBpiP",
-	"P3G/x1zLlnFIjhOdaz5aw8VfYT1ZEh+JOzuxiEQSfPcNH/V9w/oWRX0WpyuTlVfnJIWzzcQ4suXsRpxj",
-	"j7mGK310ekz956gIWSVnnLxz0D06Pe5hzZUkrMGIPo13h1R20hSyZzXncAApH7N4HohhEN7aiCFflhC9",
-	"XYZ+GiKugjgdyTfU2Tzpws/Ye7StbE34latUxPMmwdoyIeEAnqHiAwfwhsfzOF323N9/dO0yMnm5G92u",
-	"sXZrccjljsJPE9ziFbLRh37Bx/tBjo5khbf3zIJH2Qs+RdUoIBHmAg7ATJjmKwD9vrkr2FY+clVR+NPz",
-	"LlGP1Za7UcnXaT1XyZ2t/CPZynOVbLSMq2RntW0TFm9VgNx6WubgXKq8553V+yat3u701li9VdJKPVPJ",
-	"1RUylXwVOlh1zzarXSq5rKZV9UPZ2ihvoStMPVy87Gu1UQJt9e16+5IVofQly7HzXxjsLYIKM0Gowngv",
-	"aDpCjlQffuVz4txsWNVQcmdLQYsYLWVhji28tYgnTlqXSvYw0B6vr2XjLoTi4zhaSGBpqmYOn7uIEf4T",
-	"uVZOGeXUFayhYvvnErua8BbKnaQ8Neq0I0zIhcIYy1bK1XZdwH15qzLwhorwd+G0iGNs3NyNJCkBeDpv",
-	"MZBT1tNzWmXut9MgcpU0h3qrBGrh3XvHJ9OHbjXHJ9NH+304rvf8e4IYNGWpQBbvNstkJI9PIBWWa5au",
-	"LKUxEnzmmyA1MqkzlfdSPuVp2SvJEwwKXfQJUg7ge894nqo59r47iOSpZZaPitTJbgfwjPFMyVNu9zHd",
-	"qpZVN2Pphc90+cFEEqN434RSnRBPmK8754TBagafNpjXmkQZlU65iaSDYI/60MAbjuKkW0N4VH2j8mPR",
-	"dzCIVKpI1uvSUlFYYBJwZVhHrdbWBxLFjbxnfQrEnFvvGenCf6hhF460kv+hhpfzcX1opuw7K0I1oevT",
-	"qSR6otUwbQpKf/PzEfzlh8O/OLLoRviY6wbWTz80VtvDxhNmDfPzCO0vDhaVxeFdX/+RdJAhaeulWLE4",
-	"N26vceqMG+O9bZvZN32ieuG3FkVyQybKou7R3O2z6m2VsffUBef7H3+s9cS5f3hYviak5WPfzVbYlG+o",
-	"YehgOmJF6qZmQ1XYx8OUyYut/UeXto+/htm6m9pfveGxkrFIuXd8nKLfo6EP1m6hlBec52QdXBAft1Ru",
-	"3OTcqH1x4z5Ku+O6nVxuaTurp5tF/ra7ecMNIsOfK9cTnf4L6xDSPnrYWcW6pZWEVzfOWzbvWwM/R6p3",
-	"hN+nA3da/PZDUM0i/nueUJKCE+adQuzrLf/FR9zjbxnLsYY+gxG+QCVO3Rv//q//prLt9Agb1wT934lD",
-	"T0+OYWB4XGhh54NQDFaYisp3yWgYKudmIklSjhXb/4WKq7UsngSvO5VbXcinwEyKhSq5mKzv/sb0/U63",
-	"w4rwr6ngM64bS+eeUtny9tzSv/BVGtv83j+dUqNflbnNQ3+Tyc0P2dXsthWnt5refPX/u846n6HhLZxd",
-	"s/HN40YbA5z/0JWNcIEmfwWGuKWbt9EYF+7/ZQ1yQRJtsCo8NUaMncLsJejjE9jj2OLOkf1fOEtSbgwc",
-	"lBUF0GATznu/TT75XRedhi46qEv7czVoAJvnPJKDF7UXBqEzTUqtS+ahxckT6nuO7xhIOZtyEsrwtgCe",
-	"n5sCW94s1DiCpq45kSyb5rz46clKu53A75db89xc1RAsM9OQNeqvAf58rR1uqGu3+24XLNNjbs/pj1wr",
-	"q2KVdtE4eX7trW0MpzVd4+04wVRYZMH+431qmZ4xG098EKue164JwwaWbiw1GGlzWYLC34Kan7mhjSar",
-	"+oBNMkZJ/+Y578MRM24XuB2vJzhNYKEuqjU8HUWSZ4IwpbTTMusVC7fE0Itm0XY7KmyheVXK7Im7HzJJ",
-	"uV4wDMmR0rGff3ofTDE0IcY3KCYlTe1Q6uuJ0k4SrN/xTrdTp6ybNJVdrXvLst2nY+E7Jd2vgRtJYNRo",
-	"Y1JkTIb2Kg0s7TKNzd/nQnOz0ztNQqJffS3SxQMOXReaj8R79F5M1AzD46iW3BOi0FifQKB7g6qJpZxd",
-	"kDzPSJzSvvfwQvGBpe65hdlx7xT75SWArQkUjq2eszGn/rfthrdVw9Y2JXnGpXs5FcZhkNK+s0xcFYXY",
-	"3qAE5wzLWdK/FgC3gA3N4pmpt7HeJPx6jPW4eg0ysGnZ8Pq6RNG3prFzl7+DDpxLmmfl5bjUzdxqzUiE",
-	"wb7wu/SH3vrRETrwsIeKPI9V0dTc+chdvLjA86TxVeMjp3VmuTVghIw5OQ9NgcHCoyLFSpmyD284lqey",
-	"Cg6d7L48AEq8LmSq4gv3Apm73F+qcNxJczNRaRLJvUf7pXNq4H5HiAyQuJTpJGUb+7UgqBnwL21dMtYD",
-	"7jpPpNzS6kH8I3jVHWMupAVWWNWjF7wazt/HnGPiDdJVPK0eAbmEodPuILzlvxRjgcmFXl5Y0TAcdB+O",
-	"qAtVvcGV7+V18vTs6Bc4mN4/wKcH2CLr4E+RfKCaejCgY/2r2/Ggj1ls8Fd0xtIqltT+K4FvXe+v9fVq",
-	"tnfLug472VW6zJUE3FvScOW7GNKImlVmsLWmEG+SIUNIRelWCVq7FmvPyPEFDiJlhpnxJd8gIhs11V0y",
-	"VASX6KqyWJpGyUiOsHIfYnDUgVGqZmRuHbHUUHEqg8EI1JgNJYbCqqxmNls9+Y3dAetmtcZY5l3QZsOR",
-	"bzTfPe3952Hvx/5577dvtycMNTUh9OtchwptODgC9Kp8G7no7TLtSiPYJtifcovNYQdV5z3NJ8w4zuME",
-	"etJlIjlowvZAzcqPBP5MP4DmU3Xh3ibFclEeqqLAseVg+Y06oaS+f4Yk5MAIjbsZvrF0oN0LDMAqBRmT",
-	"c0/7I0nEP/DpphLMYeHNZLI9Qb29a4VQWscfHQJ52C0ICO5EsUejgcGq2IOm0MN+JF+pUABLlSD2zbud",
-	"6lbjWnDEJAw5xCobCskTYnZohIok4ZnX+bxfwjCsIYNZwtDrAUtTIMhiS+V0DsyqzNu2HHtVksPbk2dP",
-	"z543k7Im88E7rsVofqYu+PqWqtRu07dktAqm+A6FGj17+Z8+QRfGzPIZm8MeeUPvP9p3+IoYKdATaiZK",
-	"214sdFwIC0KiJYA+a2DIR0pj6NocYq2wAzpHgs5nLE0d1ksLCguinr04pfJkjklUgvQ9A3kxTEWMRIlL",
-	"rjGAKEJZBT1tMDh5fXpGwkdhJwe0k0ETmlO/0HVW8pOnZ7A3SKfnObPnKF7GpLWSqOkfmWJUPho4sdUn",
-	"Ew2YHiuzw7ttajQuB4As9Ttdc+SkJzdFprnDRvj4flHuNhSpddK2LbTEiMJ0XsVu+r6xhgw8TyIZDvgA",
-	"Cgr2gwMgjdE9I4JXHv+YW2Dw8PB+FSjmbQOU80KVIfeYXxLXQQYVcsQ1UCerobDYW3WmlRzvN50qVWtA",
-	"K+y5v63nzfYJvNB+ccKYIlxYLPk2zXqlKXTg3fgB7b/f92UUG64GVkq0ZEVzNP3XH0wVrGcQoE8iufR5",
-	"vwi0MIaCmVihz1BZifDxmMlIau6OGevnBztd7JQjb6bTjIzeE4ZMZcawZe4la0TE2JJ4TWCjbyK8h+2l",
-	"1czdTV9n94I7cgUDlotz2hvh91a7B3+fr5sJ8QpTMhm8leI98FzFEzA8VjKpjGqLyBpJRx6QRhNeEkmr",
-	"4IlKJdEIj/2m6qidcuOkTzXCOOfQRp0ncHb2ggx8e/x9Dj2QarY/WALxukiddR2U3br8QrhMciXkovZF",
-	"uAPDGqU2fTjCjsplnIgJd2bIwzVKau0ZhIE3J0deNUc6nChPOws9deKI9Vg9UfmikXZ9c+V17YDx2O4Z",
-	"3+E3hMeYxRNAZ3CspEGtYMINj6TnExXyrnIWNZwKVRh/LzNhvJl7yelwpSbCR8pk3Iq4jJ5N1RhSIb0s",
-	"iNEzwdUUytuGbRmR8MZuw0gvG6xIPqKE5Dy0cj44PKyMnGgwwV5pbiHe9F4Y3m+WAepcgmbstuhKHOLB",
-	"2tvOwxufZLBPuGZtNvCrG3sLAUJhvruUvG0xQh5dbyhUKITs1/y0m8KGwrHtGje0/X4EJN3te4SuK1ss",
-	"MwwwyD4R7jdsoqj05tp1baqnlCBrWzdvrzzRLi5o/65+3rUENNVvxpXimsoTbQ5sWkC2VphRu0xukY0+",
-	"6IH7ZUB6cCRXnNHgfdFPq6wgjOSFvXo6SLeWmII1CDyZVfKoXMI+hv4MedX9ExN83MbRD05FxMseLyyS",
-	"3tudiTE1P4E9w3kI/P1uf1EeqtJgOt1OLVen0+2UuTqN4lIAaxuLW4Dsla1uJWv/CkLGlonuxpixpaSs",
-	"uyzOuyzOK8bHIRs410SSGtSi16HrMfELPxDQUEEZdQi4QlqRAjk7fBOHCgfr7sxV/XL93M+4QdvMmkmf",
-	"VGmGWHpSKjAxS5mGxL9IL2xdgcl5vC3oa4mdCJlU/RG9lXSxfWA8UVhdqh6RhlWYjNXM8vE8kos5jt0Q",
-	"gIkKHgXoV4R6f7FvnMHiTZFkBv7j9PWrnxbsq+F0P2wgN7vGHa3IhtcTeNT1HLbriFckqxCk3asMYuAd",
-	"paicukXTLSNT8dPCXbM/O2SO+DnIM2QlWLlpJ8el7RDNbKqwPTXqDZlETUgiZx64byot/kDm+xi8TZps",
-	"pWTNIVNpP5KRPKWcl7Fm0vrEYprjcSQBejBw12sAQAZkhyyOmI+5rZqbGT8SOxUOaGTwd8rEXzfYE5mj",
-	"CyZ8sTS5OSHjniExm7vv7fvvUfIVVdDUPFNTDmVNUD8E/Zx+SpamIbWbDdWUP/FtKxeVfXyjhyagYB4y",
-	"Dg5nZDrEwNfg5Q+fJ+sIrj8WNp2DYVaY0RzzrunHwFKxVRiTFXAQyCe1xKcuZCyeCMnr1kqvj9VjAILy",
-	"9PY4kihA1QzyGA0QDIILlkoh/4WBlaWxisspTJn2Fh28NGjlQKSobubE2rwWiETmsDX95EpfW4yjkMMP",
-	"58sOA3QBDfrwi7W5u2/dSJ6yjJ8Ky/96arWIbRd+6E1UocGkAs1TZJrsQx1cCL/n6OkrYYpF83JrgAvc",
-	"+aC6S+g7GCzsYkBZZHROPo4yo15JLKk1UiwxEXPS9sgDTtbAfVA6knT1fJIY/k5Q3O8G+7KdOcHOTgyV",
-	"nCp9U5FM1EwaqznL0BiptDC0FUxp8+Y2B2GCadBLHnfIZ3M+Lfi5X011aCwXv/J558MHTMgdqYYc5uen",
-	"Z+DIhlvtN99UDqBvvukCQ8WcrOuV/sDlVGglqTseSylcP9jzI/n01enpMZzy+FWRUXenvdNXR/vwe8HS",
-	"ygEy0izjTurG4zubCFN2VNs77N/vH+5TAb8ZS6kG2IW764hSU+7EBk99Xogpl9wY72NkicC/cq2GJQ3w",
-	"Ya+DkjjA0Zu3z5C2FUPDfy+wjqaXDGEm0hRYkmDfzC68qnTrwEi6cKISJPvB5bgAHSvs3OtSGctzdO74",
-	"qtUEm5hpq8aa5ZM5uRIM4TCmdsNIOaENyuTyvcq4peSBTzX/9l9GSayFGEnsteed3O4kExUX7nAI0A6K",
-	"oZicI6mDg0TF5oCsZHWzd63VsXkCRoyRwGCY0UEh/G31cpJVTpSDqHOm5yCsYzNRxxOQIsuYni8orr0Y",
-	"rbcxodMyysAqxlTYUeZdB0THWgb4nacnx51up2zW10G08e3kJMtF53HnO3yEJo0J8tSDCWepnfzh/j3m",
-	"qBaWROM46Tzu/J3bX/wQJ9+RVRhffXB4GPQQH4haPxd3Hu4ZCR3b1Aiagu5lc06BwKs15f0F6aDz+J+/",
-	"1UFcYj/iu4MVGxuntNE2O7+5lw9Q/q1veakDE7kvDNRIUMJzJ67J2D3fS5hlQ2Y49ajWnMWTUHRgBXpv",
-	"aLKPDTyS+a3yvmqr2WgkYjS3fH/43Ya11C9Y+zWFGhGbF+UUMFzY5lN9s0jG1h1ryefRQbL2eNHQ0QXJ",
-	"sVuWD+ryZg/NY6UTniDdcCRESdOHNySq+KiBAX7eyzjduhw4VHZSikDopfOJzgPkkIbYqn9Gbmm3e5Kt",
-	"psKIoUgdrQyWIRLM6JlVPu8nkhRepkpXnKN5P2MvYRKNnr561guBIH0YoM9tAAcwQM1uECqo415UHBda",
-	"+7AU7SRw2JuwdNRzNOMxDP6Jb3dJKdwPteIXkfyFMPap29TzqcMBJC+OXlm0TaxRRqohBy9EJixaqLcM",
-	"PCJTkRu5bFdJKeAI6787McerGejnEKaMHESB4feC63klLzCn45GBs8LtrXbSrUtgGLnjWDWDUr0sGS7a",
-	"yX0pX5/H5RQot05yWDetNLx97gtwVMu97uWJZOsalgC2wwpqE9IVw8LFARp4VCTdr4cEvXdFEHhVx2kQ",
-	"1YpCdE8f3hqnr1OzDCbNDKUsiDoztNdRY4Lg3m4KyIg6tWilSIZLjfFHPe3rJKEoRzA/PjE1qXZpwzRm",
-	"YcNldYVc4Etu7vPxzI2hprG/NaJt49fdJW/G/w1ZK+u+hrRi96/9doMssiJPZANd5UpLKSPkYkc8QR75",
-	"8PD+ujnKRR+8lV5T+YMn9NJ321/6WemhSBIul1ngosHjn1Q0o/Obg/qSzln9tiQMGbuwkxrjpJIcS3wT",
-	"bavBEOvWiMZTb+NslA7dFMfurTfV2Cse41WcDfWlzLcWAFpnyF9Fjte/fio44I+tEQf8b6s4gEp1kfty",
-	"8tWxVubwFczodhaRwc3ZyZVpwAFyTS+Cvuxh85OiRsLXcosX5nibG679aVWn6qMXljDw/s0soQlVCBr+",
-	"6A+3H/1PLAmxsbeFYu6NH7e/caTkKBXe+HydOPk0SbATgXfNeFPATrjYjmwd/DlRxjqu9KGqarWKwFTp",
-	"fRmBl2RYZHROba74XPh4ZxkBN4klq1zuYVOnajjy2HqbSPFw+xuvlP3ZqQ/XjhRvyFxdw4vSzLgrlWI2",
-	"nqye8ol7fJuHfMP0D/fTjvwd3h75u0VO+bExltxuNYy9Z0C7J6nTZ7vAJaayYAPw4G7mZmfqFizqG2Ww",
-	"0zDoxnXvm5TS6zndW0X0Kp37cxbNmqopbJXTwzhMbF3kbMte9xRt8D5O/kkVJxNSf4acaXLeYWVg9E6N",
-	"uTXw8PC+U3sT71EDzROheWzRC0651A2moDeYeHFaul22szp6I+l/RYzObZiS5up5eA2Hvutl9gs4Tjof",
-	"fltAGDIUbqQgT3NBDt3Pm4SEbbSjId6A+llTkCXf+F7GLUuYZVUSW54yIa279WVFkyk3ZVTpfjPmqaYg",
-	"wTc+nrSslFJ92/pcGRbbdA5Kxjz442sFU2ouKx9J45NLhDXA9FjJByKBCTMTn6NNKV8Fr7JLIqm5k+6n",
-	"3EfI9eF4BKkytuvzvtD0nmEWCwZdKsmbaBVpagFhbkhlDZ/38du3rK2G2V8K2XgbKL/JgYonT2pnSaVx",
-	"6meIUUCfslJ7zVfrZYU+CxdsG2umW7iVMZ9i6q9PUzxndvCE6lOR6z10761x55ACqXnMxZRH8uHhfRBZ",
-	"xhPBLE/nfaCz1GpGTqALnlvv0k4EFf0XshCWSEJhfEE6pIRl1hdGak8Fn0HOsNLRVBHemfXMfuEC3XH7",
-	"Ndx+KxbtynUR5qucHn2DGxn9WxzxWTP5smzEVgbvC0d8zvy9Kn1iNjLqJuaGJS9uhrHVqrjcMlOjOh6r",
-	"J++eh7DA/p39dT1aHYXKOhVqbWNrVR2lTVztiJmYJRQoHSqK3DOlWoty2evjZ0e+Mp8V3PShDNH15UWw",
-	"7A6JJD66BnMGEth7/QqePX/x/Ow5vHl+evbm+Ohs30e6Io21E55Fkr8vY04xtKNLpREYZRhnQekKRU9Q",
-	"GcY9YhjFGz4qjM/NgYeHP9aSurHqKAiSfVFmpRQSdKHjRyNJYaiYlp4yY3shLHXKtGDS7uNiqu70GD4J",
-	"M1WkCQq2CFfP74UGJ4P5OgJN7JeU+/KKb2O9NPxTZr0f+174jq9s3Y3oro2Qaz6Ew1sheV+PLPV3LOOx",
-	"9nB2E2gc6I4plbV0GKxPgjA8Y9KK2NxUpSbMZcPaZG2KNTH7Mao1bSKPBCYiZSW1haTqK+ZeieQfXKuw",
-	"JSq7ihRc9HkfEp4p3MzeQKuUI0SkkkREKZ6coEVjFmtc7a8nyyV5X6GgZMHfSUjKKqT4dvc77DN1btlp",
-	"s5Z6UBa7D477xAWmz4qTlK4hLwE5fO6WBSy7EHCXhJP6Dd0giBV2ckDkpFcvb9ZsqCtjmFHQKDRmmVcL",
-	"8PSKJCC0kMFeML/tdyMZapY10TBK8AoltrA+DJEqH/u/prwcVhwjqkXQ7ZFFg6QgioZ9ePidb2AUcovQ",
-	"6EcLqMBZVgJtsurh2JNa8cEbUH4WJymvQ5tr/bApINlXsA0pcJ+TnW35QizrGnR0dSxcOsQ6xhcLsdyI",
-	"8Fj6aG0sd7BHX0g1JHQmrpWzscNsnhiyaWGZAbQoq4TNsZFVJGcTjslQpJIslFliMumCGIFRXTJ/FtYq",
-	"Sfm4fcowkZRems59XThs6Ynl+3WoYYaFtLAYsDTCXYomhP07t47OHNFGbzQGspylgRm4X0sIUB7expj8",
-	"EyqGx1ZeCw5Dgn6uOdX83XzMNGQtNXv+vqxNCKHEKHxblX5GO+dSkl2oJeddmWUvUCorEDpUDlUyJ6mI",
-	"BJ9Cc9iTylFoKyRFJw+5nXEuIxlKzaGK6mjgkFX1p/dRGsM6j8v5ZwNgpszqg29X0vrILzvUaoYmDN8d",
-	"Q1gqUF2ahR0F7SktxgJrsXkbcagxi6UaG8PzPfhvghDit69K/0K9/tJ20+1MOEu8IfOU29665MrTxRPf",
-	"GA/+4TaJ6oMfbzOj5iyI7ksiO5w5BWLMhPSeso03+tQybUurUINXuvHaqsKuv7f1+AOqNdUzIqlkA61m",
-	"eI+8uEFZ93iUkfS9nQ0YkXKJ9hylS2mhlqjnSO5UsIX6dJHcC9SYfBrqgu+DwcgFJ2sJAyLhWa7c+ay5",
-	"NG5nO6EvVSXvb5EmG8XIJa753MddBJa5w5FQLaWNzHIhddeb4uZdL6RSwVkU4DBtl4Q9ShZqlAYxvolK",
-	"62GYCAt9nUvGG0n36R7DBkaSTcXY5yRjhiqFlQSTIWrPSc9LfL6aSxPPfMlvkle+5I2xvWSwCyC7rOXl",
-	"yujxj4kClsExnY3PR5FwDInajBxKJPFBuZS1iPJSYIYQjDQ3E9JLunDy69FziFXCz0OVVKeNpCmngxLa",
-	"132QSsb8SeXetxNe1VX9FmTwKg/cYs7dYs5xBjN4EsnvDh+U1uOaOHacnNwzUC68dFjWefxDFOhkKc2h",
-	"4lB+ogmLXoskfloCYwmbvjt80HSDFrH1ODlZ4lYvvMN0EdW2dFf+UGm4S9GUjXuhko/C1JuZh+7SbUg8",
-	"toJ1X2b1shc9d7ZY1b4FDjnyMWRU+LoRhY6UNEUWSD/ang4IhUpcOPC4YKxTRrHzU3nCkbQic9SoFPwI",
-	"IxJeZUkfJyfd8DX6/fhZSf2x3IdDySLB1jRdTOBmttC8S/Pud2GEOekqeI18fqeZsETNSMi74HOC96D8",
-	"oimG+4MueihMJXR2waNuJDE7fNCHn0mcNJBiYryspY3/DXEfW5f/laqMaM6MqpUZaUTWowD15sDlpTQs",
-	"B62dopbXJYd5u8TlY9xb3aW3x62u0urd2YDvRyrL0aZ/NZSn4rjrxRwsOCBZiiVuCxPyTjcXMIf//Z/v",
-	"9xFhdi9dDqFyOQjpvoAOKl0YyxP4Q0mOBUEc0TGV6aWMrqKW0KhxIOOJZK3Fsy6kwV6wIUCUmHQlOFCp",
-	"YidYkQgRSmk7CaIuMfiiySHrMVOJr7bt5NRfzs5OSot0PSrsnqECtpGM5DffYBWMMjhFlBmbaOZVcrE6",
-	"e3b24pQyqQnikQypnN98A3shGBvLN7x4/ervb5+fv3v7/Pz41d+fn56dvzg+PXv+6vzps2dvBvv9hQ9H",
-	"sqnuu09d91UNhSUBCIvHT5hMzIRdcO8sjKRRKV+QWJWEjDvKJkzmDWTCIEBDaxLt8+MjuVCbCOh+hKK/",
-	"4ZCoguET3wVSOJEx5tqWZc5LQyAJMMzUSwb34amco6Udl+/HCBPqfVdN+RZ353E8gMVBauAz5Z/KhArB",
-	"H+Fijri2AzDkq/D1TfjCwWpmeQ/j5mm2GmejhOHMwSZ3+gMmwvaOTyI5LBKs7O7IsCOLxqrcSRYxM7y+",
-	"wXtlnW2qVu62Npw7ATZk/w6L8XgOw0KkjYJCraj9DenRDZ0SbtlJ0FS4f23EYFmIv8SWTTQg2MNu0a65",
-	"gSfQRmFRX1xL/0OP1Y0hVUdh0G1UPtgy8ljGaZHwM66x/i7aI1bNaSy2oX0s1WIcYXJ8H7BvieEYS0tE",
-	"nznibSz6CITl2bqUfJ8ktUvm2/Vhrz+BdkFh4Uw/43hWp2Y3RovFFSoGhC4frQ/rPi5tISinYuU+DKuW",
-	"qkSTUu4eiymXhDVYcthddpB85tT8GXWhMBwzjbEEyoPD++CTYgdUiMZTA/d9tvL5SKK0gp9fqGxsyBKP",
-	"/0YrO01WGtupvduDw0N4/eugSl0pE11UQi0yxlI5HQpL7nlj0oxJ601FvvQelSeMJPnLyznDYs0EHd2+",
-	"MlWR+8mr7nMB5tR6bn30ucfbm3JT0dd3CdO79ivZaEdZPHMn6Kwe95ONx71BV1hycr85DjUOl4+xv6bi",
-	"y1od/TqjGFuAp9ke3mqrks/SeVkj8bL7/TxpIxbVXI3D9qK60sClwbqWAS7NtHJJAGgIfmwKx6tf6G2G",
-	"43DOyScfmbcZ4B4i66LpNkJ5fUzdWkjeKomi3lDmsz2bJkGB4ui2HMtugmxopL57QN3jUApYhcrAIe0f",
-	"OTbTfKE2sK8q7Bj5xo4OTYFeuzLby8d6+Zk+TrjXBqwOEV8lQ/iSgr4uwRV8nNZiXWus/9SKNywl7m8t",
-	"kvQujGxlv0VzyALLTqiHbefx94dYEZ7qoD84bKiEvs6Y67stXMIMrKuqGTu/i4A61zxXl3nbR89f5tUJ",
-	"M2Rmb3q51rdqzQkw9Hdy7NtJhthPq6xZHavW6b6fTO2qtTpr2cGh6g+BCGNKpVBo3yUC8DJWd3Jd6YyV",
-	"kkDoyqxb8JdTGXHA8i1dOrgHN3Jwfu5NVrenWL07HMpXkKJ0psV4jEFWVZKrxxOMJo/nccphj/JrlEzn",
-	"++uRorscSbuEHH9W1OnDpjLI9TNrVTpogepdpULUzRCML6t8zzpBF82Wbtf3TB2B9liagmcsZr8NRZFj",
-	"zY3ZVguxHPVJmIJxMWXB9uOESqDebHKun7WdKbaE6pdoixU1ZCjRq3y2taAijbypUor09Y+TwRu21oAe",
-	"/qfrs315gH8xtq+PnQuz2bqG/VQC3jbh/DI1PdA8VjIW1C1tcxQpZZn4V8NpV94I6p84myjj3Qc+cErI",
-	"SA4uOM+xGZMZNJey8KuoE/CbuHflRCVVxnZCyW0bCcp1vMF4jqarGIYI33bFx9J8xpS6NFQ2yaHNVswS",
-	"ThU199kGJcq1xfR2BuQ62d9mQA7E8ss2IG8jKetNyGtheXibrOyLNSFvP5jdRGAPsFsyIpd968hN3dCt",
-	"rrVheVdR7fKGZT/TxzEsb8D1YFgupa07w/Iaw3JLAanE0M365qtq2Ccbe7TlpXILpQ/pNrTUctZ2emp1",
-	"HF+ioirrWBSQsvZwm6r6qiYK3YTQXKHIR1FXq+014En54/WprLVm6HdK620orY2y/AL+r1Dl3fXWSkVd",
-	"0FzL+Ler6a0LjOBGFVdPpu/U1s9Dba1Q1uutq47tLZjeTm9d5AFbG1yUl+ELD37aSlnWa68bIHp427zt",
-	"yw2DanFAu8nVNXfLjeux/i5fjxa7uxR3eT22nOvjaLIbsT7osjUx7E6bXRcm1VpyUsk2VRZHfLZarEpu",
-	"WYFVSVvd1QH2i1RbPcaUeId/b1VWq7Toa9dTHRJ8HBXVbaqJg6vkOhVTldzppLemkxKeLiN3nZ5eQgl1",
-	"+HBZ/RPe1lLb88JMIFZpymOLrahhzPSQjXnPP4xkaBVsqGJpIgzLc6yRU8k1qZhyqBrjI9GiJOENuq6/",
-	"93dq7p2aW6q5DifWa7hNl6elXhvYxfaejcmXr80206QNOmwj9A5vh+99wUrrunPYUVVVyeenpe4ivl1B",
-	"QVXJx9JN16B0qZaiEHanka7VSDfKTb4sGZd2qtIi43HKRLZZMT0pX3mHrxzRK5+Aptq4slsO921cQzvF",
-	"tDoLoMMAOo0vUVddt9capq5BzW36bOMB3JB03DjXx9F4m7fdhHNNA69PJ15zsHdq8i2pyWvg3+ZebWQJ",
-	"u+vWJ++ObigoeS0HuotQvtOBKx345N3RpuDkS96Ddmryei60tftBI33+whXpK1Ct9cp2yzM4/FR48Jer",
-	"n1/peHdTKxpB+/mFUF9Nir28nt8478dR/FvfpmAJWCt63hkH1hkHrl9a3M128ImaDW7Rb708+SVNBV+H",
-	"kWCTeWB3y8BtGQU+CXtAGzHkBq0Ad/r/x9L/t1yZdWT8Mvr+jURyN7GMO0/3nZYftPxVJrHW7b0T/l9O",
-	"z7+Uiv/Vafdb2Xhblf42tflWHPQr0uG3y2JXUtw/N0f8paXL61PWPw09fScV/U4530E5b8nKVLJFCXcD",
-	"PgW9WyUNzvlW72Hdtp3eeKUS9ODs9NI/lL5IFUtuyRSgkpbav0q+TH2fELPEcffnVqVe3VRT6xOVfCTV",
-	"XSWNOKCSa1TQVXKnkt+WSq6SVayuEevdVe1cJTflWqcreOdIv1Oxayq2SjY60lcxuqXy7Gn3Vn1ZJV+8",
-	"itxEIzbowU2QO7wNDvQFK7jNR7CjFquSz9DZvIMMdQVtVSUfSUFtxuZSJ1XJnRa6QQvdIL0YrqdiW02u",
-	"0zDoE1A5/VpuOSbcz9pOuQsw/RIVPFOhQkCo8tE2Rc8D8YaEU//1j6Pwha014Ib/6foUPw/vO+XvlpQ/",
-	"U6JtA8YvkdHdFUH/5g0pgzXKfacQ3imElUIYEHaDUrgBy9sph3V6v01BDFTyC1cSN9KS9criWkge3iYH",
-	"+3IVxy3HspvQ68H1+SmRu8pnl1ck/UwfR5ncgOlBoSxFrDulcp1S2UYqmnnn22bt8h/lqM+1VFbYwaV8",
-	"oeHlX4W8xFsLbtSb1IDDhO1U4PLkv0QdeFZD2ID81bNtWnAA5A2J5OHzH0cPLjfXgCHht+vThAPQ71Th",
-	"W1KFZxXuNiH+MtnfXRsOr25Wh/cuhEy6+Hg/krbI05p2TLW8mGZpylMgTdmNNwM4gLriDExrNjcb9ec6",
-	"b7pRBbqa6E51/sRV5xK9N+jOG29FO+15gU9sU59L2vqF689bCNB6DXo9NA9vl/l9uUr01rPZTbivIvdu",
-	"V4/uwsCxi0H36gr1zqLe5TXqMNXHUak3YX7QqSth7U6pXqdUb5OvNs7WyM1obq6n4dYtHs5RoTWXFpQW",
-	"YyFhzwlsWcZl4i6N0jDUama47g2Z4QlEnTM9B2FBFTbqwFQwOEhUbA72O91OodPO484BKq+LkzjJPoWE",
-	"T3mq8oxj33saPbE2f3xwkLoBE2Xs4x8OfzjE6+63v/IpJw9yY/BuOlIk8K9cqyE3sFfg8XNHBBzO7fdr",
-	"ffM5S+2kYXW1Uq0+m8CA9iIv9v9CwnH08tlPta+FkZu/RyU899wRcg0H2A1eq7SXp0xyyFg8ccvfx6bw",
-	"QlYJT7WJqNjb5lmqfhibPlSVMN/4NYwU+/d//TfumlmViRhKwjCtpB8opLCmNgHGFWz8dPmqh0PqQL33",
-	"jOepmju06MKpZZaPivSU2y48YzxT8pTb/X4kn4IRcpzyUKDXCaK5SueZ0vlExKDomIh0QyLcEtCCo/QT",
-	"MJzD02dveoeHh98RtfZrri7XxoUHL1oF34WGRv5jpf1r47fKdqx9OEqZMWIkKiwb1CA9gJTNuYac67D4",
-	"h08i6YZFndmE2XsGhLT43R5/nyvDk79FHWBFIiwg2XRAEu6umBnisruwo8IWmkeSx8rMjeVZj6bRPEXK",
-	"byYiN13Updxw+jHj2ZBr99MC+Koub6tb9jmYPYMOQVhJs6pKKTtkU5KDVjPcbDwp5IWjh0MWXwg5jqSx",
-	"SrMxRxCFnNSYSZg4KqAK24cXuMyBkCPNjNVF7DZ5nk/mRsQsHcCeYRmPJDPwSiV8/zF+6uQdZCw3oKRV",
-	"EMY63LmAAzg6PQ4FFYzDyoWNr+ZurAKgNAauAwGVjFmEg1tWQMqeEQmPpJcckBx7QHRh6LgPWAVsFbJK",
-	"xgSqALbY4Vkkc62mwjEHrmHCDBhmhSHsqyBYR8CNW/ZVJFb3/UuRMQk1Ouyw0O2tMFyjI/sAcmbMTOkE",
-	"UjUWsguGuBZkTLIxR1oQyXIQSWp9t9NwE/6ysDY3WcNKniaZkD0l0zlwmeRKSGse4zLqEwU63LPqgrv7",
-	"YgomY96NJIsdGHphcZpPBZ/14e8ozgSCw9wkA8Azhj2tUv5XfLS/uEL3qPPhtw//fwAAAP//Qvf9ktHA",
-	"AQA=",
+	"H4sIAAAAAAAC/+y963IbN7Yw+iqreHaVpYSkZMfxJHZNTSmyM9FEtlWS7OyadI4IdoMkRk2gA6BJMzmu",
+	"2r/OA5zaz3D2e+xHmSf5CmsB3U2ySTZ1801/EquJbgALC+t++bMVq3GmJJfWtJ7+2cqYZmNuuca/DtPc",
+	"WK6PEvdHwk2sRWaFkq2nrTOuJ1x3mDFiKHkCMQ0FkXBpxUBw3W21W8INzZgdtdotyca89bQlkla7pfnv",
+	"udA8aT21OuftlolHfMzcLAOlx8y2nrbyHEfaWebeMlYLOWy9f99uHebaKL28otcZ+z3nEOPPoLnNtVvY",
+	"QKsxMMg0nwiVG0iFsaC5yZQ0vFjj7znXs3KR9JFWdWFj9u6Yy6EdtZ5++/BR3cKOZJzmCT/neiwks7wG",
+	"ar+MuATcMggaDVpNDUxHynDo2eLVC2Z7IAwYbmHHqIHtJDzllifQn0XSjjjEKk15bHGrsZKxSDlkzJjd",
+	"LjznA5an1oBVMGCp4U9ByXQGqZhwcMdjBTeRZJoXYOrCwfPTzv7+o4fwv//zLezB//7Pk24kV4DHr/2i",
+	"XO8cqBKav/UUJy9A1Vcq5Ux6WA01N6YJZgkaegeY5Rf1io25yVjMj5IfRWp5Da6dItgIqn593ECfp0oO",
+	"hRw6wNuRMCDDp1YhWjHgQszDcPNqj8VY2OWlvWTvxDgfg8zHfa5BDUBYPkZcoMPuAkEY4pSNM/zh14dt",
+	"eLS//9uqVaY4Ve0Rf7vfdlfDTdl6+mjf/SUk/fWwWLWQlg+5xmUX0C2ISxMgF3Cqg7KnPSsvM/28PYQr",
+	"iLAZTYsV3gGivlLJluBTyd1CTiXNgKaSu4DXCddGGMulfavSfMwPUybGTdaXFS/CBN90l0aMP9SSt6RM",
+	"K1Z/14RqeStbYO7SHu4SjRdXfjWUuQNkUUmjpankjhYzZkO+6nQPmeEdIQ2XRlgnkZi8T6/DmNl4BGzI",
+	"hDQWmJxBrKRlQnL9wEBPuM/2IjkQPHVyATg5KFPJA1OOM/CPs9evYEdIYatPvciS7HYj+ROTyQwGSgOT",
+	"Zspx6qg1HYl45D5nQOcSeqkaPv7X00fdh99293t/i1rw7//6bydIMm0FSyOZikteHdWDqUhTv4f5t9tz",
+	"fz/stYHbeI145fa5Svh89O03K6C+LXVwO71jSqASxxncQlet8MU7FtsFRCiPuecYxoVbQa8Lx9yJuCMO",
+	"7puQcMtEGsmJ4FN/rvOH6sTdkTJOhlbS71Ul3J3sVNiRym0kMzZ08qyDB59wPaMrQ4gWiMzKYyvWtv3R",
+	"/aL0ZapYsvrk6Lk/tJlbkNCI31qlqVvv1H+iC3TIpnLKqF5EshfGXIikBz/+TGDmBMShmHAJb94cPV+9",
+	"w8r7W568I0WimSBlaOgdUCq/qC3vjV/fXd+dM26MULIegvhTBWKwQyqiuhQcJizN+e7VgFjB3ieP65Z1",
+	"ri65bHKsBydHYN3gOzjYN6aZ0SI3d2KxKG/35iWFK3aXy7pDbh22ty3Lfim0Vpoo1byAAUZBX9kRXArp",
+	"qDxRfjfOsDGPZOABzBjHLxxrJ5kx2L1g4iQ2JR0j+D3nxm38ZnlzAPTPQjaiMAFIxmnvuFi3t1U0xf02",
+	"t6D/0HzQetr6v/ZK094e/Wr2qkuZW9uWRLBc4l1SwfcO4clyh/bJH1hyyvHM3F8OdbjEf7IsS0XM3ML3",
+	"Mq36KR9//S/jdvFnQ0Cd0Fs06aKFJXUL5Qlomrzbet9uHSo5SEV8pysJc6IAA3GutcNnY5nlsMO7w24b",
+	"kpzm53gsu7jUH5XuiyTh8i7Xek603zh2JBLo5xZSFl/SlTaxyjgEYuYFHFAZ17gaXPUrZX9UuUzuctGn",
+	"3KhcxxyksjBws+NS3kiW25HS4g9+p8t5KYxxN01pENLDkTPt6J2DbhdvtP+Om+YgEwj2GishtyxhlpEW",
+	"BGMWj4Tk/jNw7gTulAlp+Tvrzkw6aZhouDCRDJcQVSJhH3hZs7C5Kxlzd4i9WHNmeVhGj8hqpt3BWkF3",
+	"mIYkF8zOUYCEWd6xAoVpzVnyWqazwOQWyEK7+EZ/duFYuiMrNdRk42f4u0xobtYtReZpyvopX/mNK06d",
+	"MmPd2pNtJt/4VaK3i2f/Uz5mshM7nUBCyvo8DcSiF7Vi0dE85Y7rZyLjqZA8avVQepxjdE9qpss0H4h3",
+	"dbqLNha+g3jENIut4+3I2KpI5jHvuTBZymY8AebYihEJJ3cHiY5uQ47hE2VwAkHMCoFyBsTpbaA0QjoJ",
+	"L5JevQPNJ5yhsuS+OMjTlGRjQsuN0NR8oi5v+ISQ8OE9QCu9+8fSGP+Aac1mLeKBQej7laRAr3R6+Bdf",
+	"rb0Y7eqN+634uur/i8fWTRdu6yEOWz7NEzZDAdUqGAtpgYHk0wUKsnTL56/WouPO/YOlgINmXTgaAOsb",
+	"Lm0byqMvOEcurUjBH4ab6WoXNdyNjVhdHtGC5I7PHRiGmknbhYNkLKRnZTGTjmX0Of3IEVy4EeOIZiSZ",
+	"G9xBssllkikhLZkoDClz9BNS5zhWubSsL1JhZ14yDcjCZT52aOAQrdVuTbWwbvfkLKwcb7mdsZBH9PbD",
+	"DahVmDJw/+tQ5VgYW4coQ56Qv9Vdd9z8MmYUWyn+sY45Fhxt6V60W5K/sxdx4R3egAGL9whnX7fJl8Jz",
+	"+DR9PWg9/bXxQv9c2LGtZ8kn87SwDYTX0EsnFxmzF1G+v/9N/J0jogb/zf0jzWSixvTIsdgTzd3l4Qnw",
+	"dyy26Qz5cRfOrNLcEUUGhsfaaUNjJtmQ62eQqAgRNlbjsXArAC/4eBMTod16ENK+lkH4W41UReJDITDU",
+	"yQoohfTwoz0gJTJmWqPruqDfJQNxokisshkIC1JN2+7/UyUfWGBZxpl2Cup0xDUHnhok+e5s80TYFxMv",
+	"uy2QJcnRta4Tb71gMcqi8IsW1nIZpFTmvgFjkSQpn7obzAaWa1rjVLvJExgxmaRco9LpbqZ55kWqPHNE",
+	"C9XjLHUqU42ERPMuL/C5sh3DM6bxCxOu+2By1HSh56h9lyDaa0Mv2C5pul47kj0nwXZTNRSya/I45sa4",
+	"gZWnAybSXPNe7dG33apUkLTm1/XKHYyjXDmKyY43x7hEry4ZEjfATeAIhJvN7M5Rci82bSTitAjUgCvE",
+	"0G3eLRnxsd1iUsnZWOWOIZqZsXxcSxjpW1qlvAH1CMPdVIGTbHyFTNR0pkkiiOudVM6a3puH5gGefsdk",
+	"PBYDEUNG7LcLB+mUzQwwCXTRYDriEjK6/N3V0Csp28ja7GLM7UgltYIH/o5Gp5W/Ol0zr4othat/lSi8",
+	"9B0Vo+K6Vq6qkcWIPtUi4BkOEwPhLlYSZE3L9JATnRizGXj2zNDkTYw2TcmI1G2CesUK6JfFNfws5OLM",
+	"GHkz88gfrqS7dA6J8PJl4oLo3W6jJdAC6qKMnBicoheSazRYOwFkxAuDBc6FAUZOys55Z5LzBwayvJ+K",
+	"OJLFqzsjpyuYNqC4YtpgtVt10vlDyUoIktntQk/IITf2YjjtRVKQWj8+Pz7rhCAZbmy5poFW0paa/vOX",
+	"/4Qhs3zKZpHcoVCkh0/cV+nC4lLdGZmZo6tWxMAd1TbAx44Y44fKrURSWMPTQRtPOdHo2ujP3F356fz8",
+	"pAADUrZANVgm0F7ld7GeWATsyxpdfJS92dCzmS0FE3dpqndkjuq1A3eYv83Vuzt/U2slnIILNhHkiN8R",
+	"+NtO9ncHO3Aq3rWFu5Ib36F4l9vRoZIDMazZuOYdZE/gGJmThQZimJNNCiTnSYnBb466cIRWIKTq6SyS",
+	"TiZ3KwzuRfqIUTiePpuxIeoKoLlMvNn69dHzw0j2c2uVhD4fOKHNPUdnxYgZFN9QR6gTFpRIYgzknFe/",
+	"pFtIlcoXwXjtFpoAljf/A62ADARKLqy6DUjGotaZGEonvrhNRvL1pWVRqwuH3jPpZbvj16/+/ubFxds3",
+	"Ly7c9i6OD354cdxrIlSGlS8f3cJA3HjdAR+OmBzyE2bMVOmqvXjBluqtp5kfCF+jXhv+XMZtb269CCMW",
+	"lMmH+48e16mdfDr3xqKBD2Pn4OGjqrEk4xpeHZ2dw3f7+50n3/wAw1wkDGX6VwqUHTlxE++TQaECdJ5y",
+	"4+MVHFXEXWQjzQx3hJTFMc8soiaTSSQzzQfckRdQTiY1I6WtF1XfAS3d0Fkt7W8sZPHg0aazXILYAjhq",
+	"T4/YZHPFy7/wMscN1qhfN2FwvLKVb7bNVo5x+LL+5CW/npADzYzVeWxzzS/c5YxZ2kNG6cHQhTNuA41C",
+	"QQDdifMrrbeGPJk/3kftVsas5dqt4P/+lXX+2O98/5v/f+e3P/fbTx69D4//o05m87rONQC/xvZFoJ0z",
+	"bs3N2EAtPYCf8z7X0ulnRTy75kMns2heuDAPXz7/oVtBzdJOdkMIWm+1PaMLa9J82MHQo9JB3IZcit9z",
+	"DizWyphylZE8Go9zf9OdVgoInoJ13N5p15mSGhxBxbYYAO/ti0WIXwn4JsKKf+3adqdAhjbLJeuSEqxC",
+	"Sowa+t/o2V97GKXPbTzCc3NfQwbbjeQBGkFBaXDCDul3UsHYSQRuiAHNx0z4w7wpgWgBP2us+TxNjJMI",
+	"WKAyYEfMQpwKFMmddmW4dbwFUmYLK8fyGaCRFPFxjVLchKsurFBz3nH0BS73JkgNx8Hd5fSBqdJ2BMIa",
+	"UFPplJh8LLvwlqV5yIoIPA8OiyQLtKwGR5hVOR6XU0ocNIrbVF13JV6mBK5T8YK9t0ZpLOnPwcmRp9fw",
+	"5vQYdoQkgongWTCWaNGqdYoJ6/iBsLOaQyxAZAXXJOS57Y7HSpJTxDyFXviEU05HYjhCw9GYJyIfU0zj",
+	"tOdEEKfa5uMOd0uMebLsoDGpsiAk2sSERrBb9k5JNZ7Bzsn+3snDvX//1/+/u0SUvnlUd9bkIrpY59wa",
+	"aMFlks5oY20YhO028mNxORFayXGtWbCEXGUYWDYsPO580gZj2VDIYRsyrZJF79mTOhS+LM7+wgek1Mio",
+	"/rpVkMOPBc0zpb0iXEGjHS+lP+w++r77bdRaXEothBFoTW9kPQgXOKvuC6uZnqES0zF5lqXCIQoFEl3y",
+	"2R7iHB2X6Ta8TFLZOsfMsZJDOqFMK8O7cCBnMGb6MnGIJ4xXtjBpzVGsjhEJX4DLdw+/r4OMmsra4MwC",
+	"J8jQizQHLT+cjWEPlOzELE2JTKqpNN6PHhdCWq4HLA6RqSGYldRDo0DIGLm9z1tLuDaRvJRqCtORcvxj",
+	"yi455NnSBVrlp1UTkdRt5I37djpzh1JBokS4d/s56hZKYxStGxK+043k64zLjgNr8gx9CBUqMrx0yuKl",
+	"aQNz/1EZl2YkBrYN2v3i8J4l4zYop4e4/zt9plY+qbHBDf092Tgyl32lLi9yXaPpHgt5SdFL3J0OOog5",
+	"Gz/AaDH3mj/P+UyDBfq7iUm9X81q3yB7vLoEuSRGveR6yDsZxuf1VTLrghOqIYiCyLPMM+hhIDV6yoOY",
+	"6I7SW9RoFPokUz6wkMsYNenE+04OQ6RevRx2WAbyMWNULNAFgIFKZIkkE1oXflQaTlRCdwI0HziOi0Js",
+	"JDFjUefSqQew45bbBozA8/+7ED7BswgbPEMzFzdtEFLYSA5SNtx9hgf4SxGzhiErPqocLB9nTkx5YCDh",
+	"ccqQMBSLj+TCtFLY3S54uU5ImDx8CpzFI+DS6tkDA2bEMlKzkXhOeDuSRpEQG8SJDn9nUbsvwJygq8pL",
+	"aMDAZDyGfj7OFhy+6xwHS/i1KKoWZ/KWuMaRHKhlY5EwF30+8j6VOnORsRfxiMeXW9rsHZCNvbBsWONP",
+	"WBBPK2PblQUtz14nwb5Q6QuC76maLu9vfu3LclNpcVj+bRaTSFwjM1hhZ94dserXILKs+j24EoJJOiyl",
+	"jbkFrXZrUm+N5iq9CCRkBdjX/HTBJkykQdiv4xZJHtd/oHT/hCVzlbacmJtphREhwwt64ng+CihOLUfe",
+	"JesN6zRuM4ZUQVYF/zywy+WHwysWXYc5P3GWkrtrHmWW96kua5e/UnT7IRdpUkhr3jGkc4ncpvRcdDeq",
+	"0mtWj1HRp6g361kN3m82fNUg5hrDsZMD6qVwyuIJvzuZ4cFXFKxg8sFAvKNghQcwFWkSM13rFyyku82u",
+	"OGb5BeYoX2RcXxgez21wkCq0BhWJyfvd/TL2hfKkG9qn1h9NAY/aJZXA3MZKtXCqJ46nb2nfv2NAvt+0",
+	"hzeZ4XTDt9hEFddWo8qt7aj5Ma88wrclaVjgtyjJOAWufguVC71Mb5gWzNfuaGTIqi7lLb28OcawXGBl",
+	"OZXJN+05SIjXscDNwXCzGe6q1q/qNKd8oLkZhXCl5R2wVHOWzC48Ha/H3N9zntdj9cKi/MD20mc3rTOc",
+	"4/L6Cvva1qLjNaQ8Yy+41o28tNXh1wq7npctt4icKAMoPVrXcvUSwAt8bpzZWTBjOB0jyzGEczyhCKS1",
+	"SBi+WiynmXTrq5Q0Vxf9C1+CR6zIvphwcoP5vXfhjHNf4mb/cWMP2DfzDs5an8jOrx3/r6/Co92/1fq/",
+	"5tKemkRG3Z7DrJJ9dUv+Mw/4df4zP2Rb/9lGdK4XSStrCxWFUDbdef7qrENBDsbOUr7bhTfkTcu4ruSy",
+	"beNLu128WfR3YdhCtfxMF1Yt9Rn5mMLYSI5zY8HzG+Dv0GtGpktCBB+ia+Dx/mPa5+a80kXH3yKyXcsP",
+	"GM4ux3gZVk02LFGqiWewKNt0XddgoMdfgGtw4eqtcw3KggJc0Tfoz+ciTpkxK5w9gYK4IXSbKe3dxx5p",
+	"6GNOsFXBNxO15FDId1HL/dNqxgfictkpUpfG++l4RbBAQ5+lTMb1BTYcJWIpuHGdMA5YktB1aMMYc62F",
+	"HEayR9aGrhv7gx/a9Sfz62+9LrwoLJ8gTCR7f4rsb+1C8f9bGzKlrfnb+14XTlSWp8y7qKYjZtGVOsjT",
+	"gUhTnlDAfEAail2KU5Un1fNU0qcsFAUHTRuUjuRLbll6/APsIQ/qvD06gT1gMGI6wZh8pCbFZpXsZJqP",
+	"u3AQSSPkMOXFHsDOMhGz9BmM89SKDj033OaZCZkEFOqW5CztGMviS9iZPP568mQXsBhfksuESQtvj07M",
+	"dYy3Y/bOJ+pUnHQFacEQr5U3ArTK0UWDw1abq0NGRXkeaHYvawtiliASJyprBDvubNuQMTui/6IFrg19",
+	"Fl9yWVTviCRexz08/92btGHbtGbb58dnC9GZbnui0dbdhkwkHUUix8SAay5jnsAZZskgYbm5HbxfTVe3",
+	"9QMtSkLX8gMFLt1D2uxdQ0zzSJbOIWjqGzoOYv0CxXt1dnbkAG/VULNsNAMUOymNxji+QNUEHMmeE9kf",
+	"BY9qJC+FTDpWdejNMcsyh+fF6fkICQ7kMaC4N/EuDFcJT+fDvnmsfJx3u9XPjZCOl7dbFU3C/ZWMhXT6",
+	"IfPB1vWhd8s/ZKOZwV/q1MpjNRRyZUDqG59aAl8XQahtqnQRmPUy09wuFrWavLKBdy2ICMWb7dba6M2X",
+	"vK6iCJJyCl+zszZolfI2niAfDHhMVUYw6bBGKkjqAQUiISHIocdf3fLaRbWZyg9FdupG3SvkFM1PRaka",
+	"9MH53KaJKMKyfd2ddpG85oZH0o3oHfi6AYhHT+EHzN7vdeHNUQhLwHxPnTiuNJvH1Lm0ptrUzhytB+4i",
+	"rokx9umBC+DqwrnOKXChr5R1qJ75rA88GjfGRJIK1RYx0lPmlm0oxJRJegGZN8XEQz9V8aWhYlqRdFyJ",
+	"A38X88xCb4+W2glf6/nUXvQDo6/dQSeZixKv2NVCplYzWnmqainkCmCsy/t9sYCkXsVyy/n3//v/Ufpv",
+	"IEvKV2bwnmVfzKLdONnbn/YK8Xd58QV+r73rzUCwiQYUdWdWpgcXNWWaH1PxyhprVVnNsYkR5csI9y7g",
+	"dp2A75s1W9yO9Wquluct2a5KW8oa61VZx3hL+9XWKF5r7ynrrW+y9oSRjjtE8iZtPe3NprYSlA2MbWWF",
+	"xQ9jaltMV1lCtWtZrkpQBNtVNaa9wIomtquyGvZ1jVclif4CzFdLN29tbHsx+nOIbj+fV+spjN3HtF8l",
+	"jr1hcHlRwYullUBz2GkSWb6L1YCskLGlGL/nR4fn4PbZQZugGPg6W20nllLG84Tj4c3v3nwsceWfWVz1",
+	"h4iYlhU5p1nMdKhWlnBt4Box0yNmmrI6HOtIYcocve77BPwQi3+A2gPZoEOzECGHUWt3LpDardHpguOx",
+	"cvQFC2yWeEOTGJhza1mMdeMNEf6mYqLn6j3eQFR0QXi3tYctS1ZXtoiVvP9G7GGvVLLNPlRyr/9s1H+C",
+	"ac0rQCq5ju6DLp+N+Y+FINn9nLUflaxXfFSyvc6zBUZ/0uqOg12p6Zi8nygnx96QtnPDWHrL+o6DRa2q",
+	"o5JmWo5KbkDBcZT3S9BtKjdsvVrjjqWZRgMvVcKxhoeSkWTgLU4dn3oY7PeY01NegrJUVZBWDOygjT/C",
+	"7BNr2hAr6X9ql7U4X58BulN3u3CYY1GzSIY80o6TIws+u9NDsRIrm5WKiPsTRVdUJirSDdZWKpUx1Dm8",
+	"Y/gCPUK9XWTdWcVDHUmeCExg3QtmcDvSKh+OFoVNT3bmdatIFsoVH9cWdUtTFTM8r4s4y2vcJCdvwCFx",
+	"kiN+LOR1EqEgxxVa4PWENtckv7M6N89GfMw1Sy+MVZoNFxnjxg+M+VhRcPI2b2UqMY3e+Yx1aKbjkbAc",
+	"pZn686+O6MKaHEs2Tp48bgPTY/e/LIufPE55G8w33++/a6YMxCxjsbCzemQ8V5al4JaE1I4kBAztIMcX",
+	"RYmEb3TjLIed33OGBKJRynEx/ZXwsXi7OTIWrzTFxJJk1dbmsLmpUDUyWBS9aXZOnRDShpe4vBPNjcm1",
+	"o4fPhbks/oSTo+flH6+4nSp9+UYW2Vm71XAbrNqDhJgyGSu0gRIQjWPIDLXemEkYULMER9h6bm+9PR/b",
+	"04OyPHLGtOG3F7NSZFVe+JTO1ZnuvkZeeCF5urf3sPuX7sNvek1y6e/EOvWxFCvw8Vy+Fl1d5e0Q8nV0",
+	"Qnjpr2sl5EsMgMnZwnyPv62Zbp5xroNun2necWQ1DbUK8JXCDPKcpymcqCnXL5Ihj+Tpk8f7UWsXq1Bk",
+	"KR+jbEISvcqTDmJ14rRAY5n0dRd7TnCJpFf5Ctr8DOblhoY2nrlPL28NK4SE1D3sRNUtizZ0hdoL73do",
+	"aXickfT1HsdPRPddyvQQC7KeWSYTppOL54/NxeTbGnR6+Oi72iWuOe0TLcZMz7AOnT9vf8b1597kvC/d",
+	"/tLqRd24RgeUi0yrd7MVr9XeFPdWyu1qkvAzDYChKFq2AIYfrC18MfmSK180s9ASFZTDCx8HtawOncGA",
+	"jUU6WwfvXipk/s7h9lTIRE1NrxHElbmgljrLZYQd53x9Ron3AWDhWN/0c2lzePSou/+4+w0cn5/VhfE+",
+	"uQODNNmd7rZ+h0ouYpHoJoUvQo2OWuPKIcbXhiHV/mFELzIed8OvR88LUsam5une3h7PO1NubOch2xOd",
+	"fdaPHz765vG3T/7y3ff7CR/UkLT63aCBprZ+xIRLwbGVCEX9QMK1mISe3kiFUbDqecpWCmDdSJ4HtbJ4",
+	"CDuoqWrOjJJ7KTP2XDNJJRPPxZjv+p4RGGbYK4W5HqAEsykOqQZ73U/zi0a20XHPF3jHV71AAiK5VIaJ",
+	"AqA7Wcokcg8nGJL6y22c9O7Y3K+Sq1j62y1S/usaKaCWi3PikAr20YO5OPMRw0DzSz5rE4jaPm7wfS+0",
+	"6FQJpEwmBrDeOxUgHoCwkbQqddSO+5A0mtC3X6evOCR4pfya+N4r9eIdj3N7Q2Jx5Y4WYnEuK3r+MngQ",
+	"DnNjigA7h0KxTR2G6ETJHgxSNuzWYukfSm4UaazKVKqGswXUdK8uSjPl3a+5508a+nlUsr2Lp2pI/li8",
+	"O4ttgptvZ/HNe6/Pdl6fRfjdoAfo4ZfrAVqE6jpvUG2f8qtfAHz9i8xUroXEx4TPX1T6cu1pbH0PtnWT",
+	"bnkbNrojT94eNvRGzkXWXNkfeeM49kWnOrvTq09zrsWTJi7VrHgRJkTaY/fqtb2s9VzgC3C7rr2xa/2w",
+	"7nSvGliK7ZrQAjt/RJtUwFIP+W75aPoql8kFoUXt9fvx56AhLgkIqBi6HQkD+B1M4AuNoCJ5wmXi9LuT",
+	"t4cGu5eSxnHyFrSaYlOLPscsmZSj23fn9St4/uL4xfkLOHtxDq/eHB/v1t/JBpVhPg2T3uYAQwff+tDC",
+	"p+AB3IYfHPTbcKxCe5uNZgHKP+RJ1eG22K/NDwEj/uCwgxppKOBpuqGtV9d/YLeNzciYFeNCX4xa3/5d",
+	"YCPRRovyX1pI/t+You+Rt54vnrIp9HDpNOwV6nxBlT55GwoIYOaZ4/ZVXI7koU8XRkmMjppPuCRCQ94H",
+	"7c17hOkBteUDG0lEb+otxBOYcVvPSxtozbUUZ1s1er2gceN5xFRV/QY06+sKVF9CDJrH5G4ozt/BDL2k",
+	"DUaFPhE3FH728GMOP1sWdepi0RYR5EpC1I2LT1+i5NRMaFoWPG5Eglp5mWggeq5N4BP8XaZM6K8kZ6AG",
+	"kURHxC9aWP5axmijP/Wq7UsmZ+FvHEAPFl85UcGOfzPSXIhvqWkbWhS59kM2elF7UevhfsG+sY1sUrD4",
+	"ZxArGfyxVkF/hrkIBpiPP3G/x1zLhnFIjhNdaD5YwcVfYT1ZEh+JOzuxiEQSfPeUD7ru1WZFfeanK5KV",
+	"l+ckhbPJxDiy4exGXGB3wporfXh2RJ0LqQhZKWecvHXQPTw76mDNlSSswYgujXeHVPRgFbJjNeewBykf",
+	"sngWiGEQ3pqIIZ+XEL1Zhj4IEVdBnI7kKfXET9rwI3atbSpbE35lKhXxrE6wtkxI2IPnqPjAHpxyrFK9",
+	"gD0Pn9y4jExe7lq3a6zdWhxyuaPw0wS3eIls9KGf8PFukKMjWeLtAzPnUfaCT162mEiEuYQ9MCOm+RJA",
+	"v63vJ7eRj1xXFP74vEvUnbfhblTyZVrPVXJvK/9AtvJMJWst4yrZWm1bh8UbFSC3noY5OFcq73lv9b5N",
+	"q7c7vRVWb5Wsbeuxpm9Hw1tIhc7HjsKvqCe/ugR9VXysKVCfrGiuEQSWq1CEpXemvsNN0RF/9YgVG6nX",
+	"yaukZPUh4wk1UqBVcn2VWSVfhJZcUsL1irFKrqoLl72ONjbBnOv4VA3oL3rWrdURGn272ppoSW14yTLs",
+	"6hkGe5utwlwdqgHfCbqokAPVhZ/5jGQr1i+rXLmzpbBSjGezMMP2/FrEI6dPSSU7mAqBBNayYRtCeXgc",
+	"LSSwNFVTh89txAj/iUyrmBvDqeNfTU39TyW6OOEN1G9JmYTURUuYkK2GUbCN1N/N2pr78kZ17ZTaJLTh",
+	"LI9jbMrejiSpaXg6b6jdUDWBqlFthWY6XqaS+mB8lUAlAH/n6GTy2K3m6GTyZLcLR9V+ns8QgyYsFUjz",
+	"3WaZjOTRCaTCcs3SpaXUxuoXxL1OjDhXWSflE54WfdA8waDgUp/C5gC+85xnqZphX8u9SJ5ZZvkgT510",
+	"vQfPGR8recbtLibEVfIepyy99LlI35lIYpz1aSimCvGI+cqATlwvZ/CJnVmlAZxR6YSbSDoIdqhTEJxy",
+	"FPjdGsKj8hulp5G+g2G+UkWyWjmYyvYCk4Arw0p3lcZLkChu5APrk1Rm3HrfVRv+ofptONRK/kP1r+aF",
+	"fF9P2bdWVSti8cdT6/VEq35alzZw+uMh/OW7/b84suhG+Kj4GtZPP9R3RtNaabOC+XmE9hcHy/7i8Lav",
+	"0ElaYp/sKYVYMT83bq926jE3xvtD17Nv+kT5wm8NyhiHXKF5ubS+k2/ZfWzM3lGfom+//77Stejh/n7x",
+	"mpCWD32namFX9HQrE5wGLE/d1Kyvcvu0nzJ5ubG38ML2fQs2mm1te7VTHisZi5R719QZeqZWivJNledL",
+	"zjOy386Jjxtqa65zP1W+uHYfhWV41U6utrStDQjrlbKmuznlBpHhz6XriWEZc+sQ0j553FrGuoWVhFfX",
+	"zls05lwBP0eqt4TfxwN3WvzmQ1D1Iv47nlAaiRPmM65DRey/+JwI/G3MMuxywGCAL1ARWvfGv//rv6mw",
+	"Pj3C1kLBQuPEoYOTI+gZHuda2FkvlOsVpqTybTLrhtrGY5EkKcea+v9C04K1zGnLUExi5jNeMNdlro4x",
+	"llNwf2OBhVa7xfLwr4ngU65rixufUWH55tzSv/BFmkP93j+eYrBflEHUQ3+dUdQP2dYwuhGnNxpHfX+G",
+	"+95Hn6BpNJxdvXnU40YTA5z/0LWNcIEmfwGGuIWbt9YYF+7/VQ1yQRKtsSocGCOGTmH2EvTRCexwbELo",
+	"yP5PnCUpNwb2ipoPaLAJ573bJOP/vs9RTZ8j1KX9uRo0gM0yHsneceWFXugdlFJzmVloQvMMlB1xje8Y",
+	"SDmbcBLK8LYAnp+bApsSzVWhgrq+RpEs2hod//BsqSFS4PeLzZNur64LFgKqyev11wB/vtEeRNSR3323",
+	"DZbpIbcX9EemlVWxSttonLy48eZDhtOabvB2nGCyMrJg//EunKjEEQyLDdR9pnJ5TRi2GHVjqQVMk8sS",
+	"FP4G1PzcDa01WVUHrJMxCvo3y3gXDplxu/BeNURNpwnMVa61hqeDSPKxIEwp7LTMesXCLTF0C5q33Q5y",
+	"m2teFpt75u6HTFKu5wxDcqB07OefPAST902Iwg6KSUFTW5ScfKK0kwSrd7zVblUp6zpNZVvr3qJs9/FY",
+	"+M5I96vhRhIYtUIZ5WMmQwOcGpZ2ldbz7zKhudnqnToh0a++EovkAYeuC80H4h16L0ZqigGMVO3vGVFo",
+	"rCAh0L1B9d5Szi5JnmckTmnfHXquPMRCf+PcbLl3is7zEsDGFBfHVi/YkFOH4mbDm6phK9vGPOfSvZwK",
+	"4zBIad/7Jy7LdmxuIYNzhuUs6F9zgJvDhnrxzFQbja8Tfj3Gely9ARnYNGxJflOi6BtT21vN30EHzgXN",
+	"s/RyXOlmbrRmJMJg5/5tOnhv/OgAHXjY5UZexCqva7996C5enON50viyNZXTOseZNWCEjDk5D02O4dyD",
+	"PMVaprILpxwLiFkF+052XxwABV7nMlXxpXuBzF3uL5U77qS5Gak0ieTOk93COdVzvyNEekhcioSfYLLf",
+	"XwmCigH/ytYlYz3gbvJEii0tH8QvwavuGHMuLbDcqg694NVw/i7mHFOjkK7iaXUIyAUMnXYH4S3/pRhL",
+	"gM51W8Oak+Ggu3BIfcKqLch8t7WTg/PDn2Bv8nAPn+5hE7O9P0XynqoeQo+O9a9ux70u5hnCX9EZS6tY",
+	"UPuvBb5V3dlWVxTa3M/sJuxk1+kDWBBwb0nDlW9jSCNqVprBVppCvEmGDCElpVsmaM2a4D0nxxc4iBQ5",
+	"gMYX5YOIbNRUGctQmWKiq8pi8SAlIznA2oqIwVELBqmakrl1wFJD5cMMBiNQ6zyUGHKrxhWz2fLJr+3f",
+	"WDWr1Uabb4M2a458rfnuoPPP/c733YvOb19vTumqaxPp17kKFZpwcATodfk2ctG7ZdqlRrBJsD/jFtv3",
+	"9sreiJqPmHGcxwn0pMtEsleH7YGaFR8J/Jl+AM0n6tK9TYrlvDxUxuljU8jiG1VCSZ0ZDUnIgREadzN8",
+	"6+9Au+cYgFUKxkzOPO2PJBH/wKfrimSHhdeTyeYE9e6uFUJpFX90CORhNycguBPFLpoGestiD5pC97uR",
+	"fKVCiTJVgNi3V3eqW4VrwSGT0OcQq3FfSJ4Qs0MjVCQJz7zO5/0ShmGVH8zjhk4HWJoCQRabXqczYFaN",
+	"vW3LsVclObw5eX5w/qKelNWZD95yLQazc3XJVze9pYaovmmmVTDBdyjU6PnLf/oUahgyy6dsBjvkDX34",
+	"ZNfhK2KkQE+oGSltO7HQcS4sCImWAPqsgT4fKI2hazOItcIe9RwJOp+yNHVYLy0oLFl7fnxGBeQckygF",
+	"6QcGsryfihiJEpdcYwBRhLIKetqgd/L67JyEj9yO9mgnvTo0p46uq6zkJwfnsNNLJxcZsxcoXsaktZKo",
+	"6R+ZfFA86jmx1ad79ZgeKrPFu02qaC4GgCx0pF1x5KQn10WmucNG+PiOXu425Kl10rbNtcSIwnRWxm76",
+	"zr6GDDzPIhkOeA9yCvaDPSCN0T0jglcc/5BbYPB4/2EZKOZtA5SVRLU7d5hfEtdBBhVywDVQr7G+sNj9",
+	"dqqVHO7WnSrV00Ar7IW/rRf19gm80H5xwpg8XFgsyjcZdwpTaM+78QPaf7vrC13WXA2sZWnJiuZo+s/f",
+	"mTJYzyBAn0Vy4fN+EWhhDCVNsYaiocIf4eMxk5HU3B0zdjgIdrrYKUfeTKcZGb1HDJnKlGFT4ytW8Yix",
+	"afSKwEbf5nkHG4CrqbubvhLyJXfkCnosExe0N8LvjXYP/i5bNRPiFSbNMngjxTvgmYpHYHisZFIa1eaR",
+	"NZKOPCCNJrwkklbCE5VKohEe+03Z8zzlxkmfaoBxzqHRPU/g/PyYDHw7/F0GHZBquttbAPGqSJ1VPa7d",
+	"uvxCuEwyJeS89kW4A/0KpTZdOMSe10WciAl3ps/DNUoqDTSEgdOTQ6+aIx1OlKeduZ44ccR6rB6pbN5I",
+	"u7r99aqGzXhsD4zvwRzCY8z8CaAzOFbSoFYw4oZH0vOJEnmXOYvqT4TKjb+XY2G8mXvB6XCtNs+Hyoy5",
+	"FXERPZuqIaRCelkQo2eCqykUIA7bMiLhtf2gkV7WWJF8RAnJeWjlfLS/Xxo50WCC3ezcQrzpPTe8Wy8D",
+	"VLkEzdhu0Df6rdA2Z+lLFo+E5OtyforAFyWNz9upj+WcI8O1IxYr9V8vh0jUL4N+XJtEVJ8mpKZcX6CI",
+	"Xfu75kNvoF8pvt5AglFNfEPt+YV4vua+j/DGRxmsFchkkw387MbeQYBXmO8+6XVTjJcnN7cU6hVSLip+",
+	"9nVhX+HYto372nw/ApJu9z1C16UtFhkimCSRCPcbtilVen11yCb1iQqQNa1MuVOcaBsXtHtfofJGAtKq",
+	"N+NacWnFidYHpgVs+uDJuyuzYq+Y1YsHdaEpNak6ZUXGXv/rtXlwfYLu+pMtT+TnWgVgA3lzH6+N6ui5",
+	"X3pkWYrkUngH+OiOgzLPDmPjYaeaYNWupHph3ZVCwDsslrCLwXR9XnY8xpQ5h4oYWUKNE4q+ViySPn5k",
+	"LIbU8Al2DOchlP6b3XkNo0wsa7Vbley3VrtVZL/VKiABrE1s2AGy17ZjF8LWFxCEucgG10ZhLqQ53udF",
+	"3+dFXzPidJneL9yo0OmdOLgfCKhzUo4qAi6XVqRA7kPfuKbEwWqAwHpusujQNGjtXDHpszJxF8vtSgUm",
+	"ZinTkPgX6YWNKzAZjzeFUS6wEyGTsies9zvMt0yNRwor6lVjPLHynLGaWT6cRXI+a7gdQppRl6aUl5JQ",
+	"7873yjRYsC6SzMA/zl6/+mHOYxFO9/0acrNtJN+StH4zoXxtz2HbjnhFsgzq276yKoayUtLXmVs03TJy",
+	"vhzk7pr92SID349BJiG729JNOzkqrPFouFa57ahBp88k6qYSOXPPfVNp8Qcy36fgvTzkfSD7KDkfupGM",
+	"5BllkQ01k9an6tMcTyMJ0IGeu149AHLJOGRxxHzIbdnQ0fiR2J21RyNDBIFM/HWDHTF2dMGELxZGbCdk",
+	"PDCk+HD3vV3/PUpnpKrBmo/VhENRB9kPwcgBPyVL01AsgfXVhD/zrXrnzWf4RgeNqsHgahwczskYj6Hk",
+	"IW4mfJ7sjbj+WNh0BoZZYQYzrGRAPwaWiu0RmSyBg0A+qaQStmFMpraq/d9ryNWomqDOvjmKJApQFRcX",
+	"xtcEE/uc7V/If2GocmH+5XICE6a9jRQvDdoNESnKmzmyNquE9pGBeUUPzcJ7HeMo5PD92aILDp2qvS78",
+	"ZG3m7ls7kmdszM+E5X89s1rEtg3fdUYq12BSgQZfMvZ3oQouhN8L9J0XMMVCoZk1wAXuvFfeJfTG9eZ2",
+	"0aO8TDonH5k8pv5wLKk0jy0wEbM8dyimhOzru6B0JOnq+bRL/J2guNsOHhs7dYKdHRkqs1d4eyOZqKk0",
+	"VnM2RvO+0sLQVjBJ1BuwHYQJpkGfeNoiL+jFJOcXfjXlobFM/MxnrffvMcV9oGqqArw4OwdHNtxqv/qq",
+	"dKl+9VUbGJpKyF9V6g9cToRWkjqCspQSYIKHLJIHr87OjuCMx6/yMXW02zl7dbgLv+csLV2KA83G3End",
+	"eHznI2GKLpI7+92H3f1dKlo6ZSnVPbx0dx1RasKd2OCpz7GYcMmN8V57lgj8K9OqX9AAH0jeK4gDHJ6+",
+	"eY60Le8b/nuOtYO9ZAhTkabAkgR7BbfhVWntCIykDScqQbIfnPhz0LHCzrwuNWZZhu5SX6mfYBMzbdVQ",
+	"s2w0I+ecIRzGYgkwUE5og6Jcw06vYlbf88Ubvv6XURLrv0YS+4v6sBF3komKc3c4BGgHxVBA05HU3l6i",
+	"YrNHdsuqI6nS3t08AyOGSGAwcG8vF/62ejnJKifKQdQ61zMQ1rGZqOUJSD4eMz2bU1w7MfpDYkKnRZSB",
+	"ZYwpsaOoZBAQHauD4HcOTo5a7VbRoLSFaONbaEqWidbT1jf4CI1MI+SpeyPOUjv6w/17yFEtLIjGUdJ6",
+	"2vo7tz/5IU6+Iz8Lvvpofz/oIT60u3ou7jzcMxI6NqkRNAXdy/osHYFXa8K7c9JB6+mvv1VBXGA/4ruD",
+	"FRsap7TRNlu/uZf3UP6tbnmh6xw5BA1USFDCMyeuydg930mYZX1mOPXl15zFo1DGYwl6pzTZhwYeyfxW",
+	"+egPq9lgIGI0gH27/82atVQvWPM1haor6xflFDBc2PpTPZ0nY6uOteDz6HJcebxo6GiD5Ngh0IdJerOH",
+	"5rHSCU+QbjgSoqTpwimJKj4Op4ef9zJOuyoH9pUdFSIQ+r196YAeckhDbNU/o0APt3uSrSbCiL5IHa0M",
+	"liESzOiZVT6TLpIUsKkK57ajeT9i/3QSjQ5ePe+E0Kou9NCL3YM96KFm1wtdI3AvKo5zrX2gl3YSOOyM",
+	"WDroOJrxFHq/4tttUgp3Q3+MeSQ/FsYeuE29mDgcQPLi6JVF28QKZaQcsncsxsKiz2DDwEMyFbmRi3aV",
+	"lEL4sOeFE3O8moGeJ2GKWFwUGH7PuZ6V8gJzOh6ZnEvc3mi53rgEhrFwjlUzKNTLguGi58KXL/dGUqdA",
+	"uXVSCEjdSsPbF76kTbncm16eSDauYQFgW6ygMiFdMSzWHqCBR0XS/WpI0HvXBIFXdZwGUa4oxMt14Y1x",
+	"+jo1CGLSTFHKgqg1RXsdNWMJASN1IU5RqxL/F8lwqTGir6N95TEU5QjmRyemItUubJjGzG24qFeSCXzJ",
+	"zX0xnLox1Cj7t1q0rf26u+T1+L/W1l//NaQV23/tt1tkkSV5IhvoMldaSMKioBXEE+SRj/cfrpqjWPTe",
+	"G+k1lT94Qi99s/mlH5XuiyThcpEFzhs8fqUyNK3fHNQXdM7ytwVhyNi5nVQYJxW5WeCbaFsNhli3RjSe",
+	"ehtnrXTopjhyb52WY695jNdxNlSXMttYUmuVIX8ZOV7//LHggD+2Whzwvy3jACrVeeZbaJTHWprDlzDD",
+	"+ysLZHBztjJlanCAggXmQV/07fpBUfP0G7nFc3O8yQzX/rTKU/XxJAsY+PB2llCHKgQNf/T7m4/+B5aE",
+	"aPO7QjH3xveb3zhUcpAKb3y+SZw8SBLsvuJdM94UsBUuNiNbe3+OlLGOK70v68QtIzB1t1hE4AUZFhmd",
+	"U5tLPhc+3lpEwHViyTKXe1zXnR8OPbbeJVI83vzGK2V/dOrDjSPFKZmrK3hRmBm3pVLMxqPlUz5xj+/y",
+	"kG+Z/uF+mpG//bsjf3fIKT80xpLbrYKxDwxo9yR1+mwbuMTkMBikbBjczdxsTd2CRX2tDHYWBt267n2b",
+	"Unq1SsJGEb0skPApi2Z19Uk2yulhHKaKz3O2Ra97ijZ4n3nyrIyTCcl0fc40Oe+w1jZ6p4bcGni8/9Cp",
+	"vYn3qIHmidA8tugFp+oENaagU0xlOivcLptZHb2RdL8gRuc2TGmo1czWmkPf9jL7BRwlrfe/zSEMGQrX",
+	"UpCDTJBD99MmIWEbzWiIN6B+0hRkwTe+M+aWJcyyMi00S5mQ1t36okbQhJsizne3HvNUXZDgqY/wLWoP",
+	"ld+2PvuMxTadgZIxD/74SgmiisvKR9L4dC1hDTA9VPKRSGDEzMhXPaAkypyX+VqR1NxJ9xPuI+S6cDSA",
+	"VBnb9pmUaHofY14YBl0qyetoFWlqAWFuSWUNn/cR9XesrYbZXwpZexsoY9CBiifPKmdJxaaqZ4hRQB+z",
+	"UnvDV+tliT5zF2wTa6ZbuJExn2EyvU/8vWC294wqvpHrPXQsr3DnkFSseczFhEfy8f5DEOMxTwSzPJ11",
+	"gc5Sqyk5gS55Zr1LOxHURkPIXFgiCbnxJR6REhZ5lBg7PxF8ChnD2mET5bPXVjP7uQt0z+1XcPuNWLQt",
+	"10WYL3N69A2uZfRvcMQnzeSLQiwbGbwvxfIp8/eymJBZy6jrmBsWkbkdxlapi3THTI0q4yyfvHsewgK7",
+	"9/bX1Wh1GGpVlai1ia2VlcnWcbVDZmKWUKB0qNHzwBRqLcplr4+eH/pal1Zw04UiRNcX7MFCViSS+Oga",
+	"zBlIYOf1K3j+4vjF+Qs4fXF2fnp0eL7rI12RxtoRH0eSvytiTjG0o03FRhjl7I+D0hXKCKEyjHvEMIpT",
+	"PsiNz82Bx/vfV8okYB1fECT7osxKKSToQsePRpLCULHQQ8qM7YSw1AnTgkm7i4spPknhkzBVeZqgYItw",
+	"9fxeaHAymE8Jr2O/pNwXV3wT66XhHzPr/dD3wne5ZqtuRHtlhFz9IezfCcn7cmSpv2NhnJWHs51A40B3",
+	"RMnFhcNgdRKE4WMmrYjNbdU+w1w2rPbXpPwZsx+i/tk68khgIlJWUFtIyk597pVI/sG1CluiQsZIwUWX",
+	"dyHhY4Wb2elplXKEiFSSiCjFkxO0aMx81bjd1WS5IO9LFJQs+FsJSeMSKb7e/g77TJ07dtqspB6U3euD",
+	"4z5ygemT4iSFa8hLQA6f20VJ2DYE3CXhpHpD1whiuR3tETnpVAsG1hvqihhmFDRyjXn/5QI8vSIJCC1k",
+	"sBPMb7vtSIYqgHU0jBK8QtE6rLhEpMrH/q8o2Ig1/IhqEXQ7ZNEgKYiiYR/vf+NbgoXcIjT60QJKcBa1",
+	"deusejj2pFLO8xaUn/lJiuvQ5Fo/rgtI9jWhQwrcp2RnW7wQi7oGHV0VCxcOsYrx+VwsNyI8FhNbGcsd",
+	"7NGXUvUJnYlrZWzoMJsnhmxaWPgBLcoqYTNsDRfJ6YhjMhSpJHOFy5hM2iAGYFSbzJ+5tUpSPm6XMkwk",
+	"pZemM19pEZvkYkMMHaoCYmk6LK8tjXCXog5h/86tozOHtNFbjYEsZqlhBu7XAgKUh7c2Jv+EykuypdeC",
+	"w5Cgn2lOVbTXHzMNWUnNXrwrqn1CKNoLX5fF1NHOuZBkF6ozeldm0V2XygqEnq99lcxIKiLBJ9ccdqRy",
+	"FNoKSdHJfW6nnMtIhuKNqKI6GthnZUX3XZTGsHLqYv5ZD5gpsvrg66W0PvLL9rWaognD95sRlkq+F2Zh",
+	"R0E7SouhwOqG3kYcqjZj8dPa8HwP/tsghPjt69K/0AGjsN20WyPOEm/IPOO2syq58mz+xNfGg7+/S6L6",
+	"6Pu7zKg5D6L7gsgO506BGDIhvads7Y0+s0zbwipU45WuvbYqt6vvbTX+gKp/dYxIStlAqyneIy9uUNY9",
+	"HmUkfbd0A0akXKI9R+lCWqgk6jmSOxFsruJjJHcCNSafhrrku2AwcsHJWsKASPg4U+58Vlwat7Ot0Jfq",
+	"/Hc3SJO1YuQC13zh4y4Cy9ziSKhS0FpmOZe6601xs7YXUqmEMwpwmLZLwh4lC9VKgxjfRMUqMUyEhU7p",
+	"BeONpPt0h2FLMMkmYuhzkjFDlcJKgskQteek4yU+X82ljme+5LfJK1/y2theMtgFkF3V8nJt9PhlpICN",
+	"4YjOxuejSDiCRK1HDiWSeK9YykpEeSkwQwgGmpsR6SVtOPn58AXEKuEXoe6w00bSlNNBCe3rPkglY/6s",
+	"dO/bES8rFX8NMniVe24xF24xVDjS9J5F8pv9R4X1uCKOHSUnDwwUCy8cllUe/xgFOllIc6g4FJ+ow6LX",
+	"IokPCmAsYNM3+4/qbtA8th4lJwvc6tg7TOdRbUO/8velhrsQTVm7FyqiKkyl3jeEfu1NSDw2V3ZfZtWy",
+	"Fx13ttgnogEOOfLRZ1RKvhaFDpU0+TiQfrQ97REKFbiw53HBWKeMYi+14oQjacXYUaNC8COMSHiZJX2U",
+	"nLTD1+j3o+cF9cdyHw4l8wSbPbUxgZvZXPM2zbvbhgHmpKvgNfL5nWbEEjUlIe+SzwjeveKLJu/v9tro",
+	"oTCl0NkGj7qRxOzwXhd+JHHSQIqJ8bKSNv43xH2utdJ/pSojmjOjKmVGapH1MEC9PnB5IQ3LQWurqOVV",
+	"yWHeLnH1GPdGd+nNUaOrtHx31uD7oRpnaNO/HspTuenVYg4WHJAsxaLRuQl5p+tbAsD//s+3u4gw2zcD",
+	"gNALAIR0X0AHlc6N5Qn8oSTHgiCO6JjS9FJEV1GTddQ4kPFEstI0XefSYHflECBKTLoUHKj4txOsSIQI",
+	"xemdBFGVGHwZ8pD1OFaJr1/v5NSfzs9PCot0NSrsgaGS0JGM5FdfYRWMIjhFFBmbaOZVcr7fwfj8+Iwy",
+	"qQnikQypnF99BTshGBvLNxy/fvX3Ny8u3r55cXH06u8vzs4vjo/Ozl+8ujh4/vy0t9ud+3Ak6zop+NR1",
+	"X2dSWBKAsB3DiMnEjNgl987CSBqV8jmJVUkYc0fZhBl7A5kwCNDQ7Ef7/PhIztUmArofoYx2OCSqYPjM",
+	"91UVTmSMubZF44DCEEgCDDPVItxdOJAztLTj8v0YYUIF/bLN5fzuPI4HsDhI9Xym/IFMqLXCIS7mkGvb",
+	"A0O+Cl/fhM8drGaWdzBunmarcDZKGB472GROf8BE2M7RSST7eYK9EhwZdmTRWJU5ySJmhlc3+KCoXE/1",
+	"/93W+jMnwIbs334+HM6gn4u0VlCotIm4JT26pvfIHTsJ6lphrIwYLFpbFNiyjgYEe9gd2jXX8ATaKMzr",
+	"iyvpf+havDak6jAMuovKBxtGHsk4zRN+zjVWREZ7xLI5jcU2NGSmWowDTI7vAnYCMhxjaYnoM0e8jUUf",
+	"gbB8vCol3ydJbZP5dnPY60+gWVBYONNPOJ7Vqdm10WJxiYoBoYtHq8O6jwpbCMqpWLkPw6qlKtCkkLuH",
+	"YsIlYQ0WgXaXHSSfOjV/Sn1dDMdMYyyB8mj/Ifik2B4VovHUwH2fLX0+kiit4Ofnak0bssTjv9HKTpMV",
+	"xnZqmPhofx9e/9wrU1eKRBeVUNOZoVROh8KSe96YNGXSelORL71H5QkjSf7yYs6wWDNCR7evTJVnfvKy",
+	"n2OAOTVzXB19fljUR74VNxV9fZswvRu/krV2lPkzd4LO8nE/W3vca3SFBSf36VGocbh4jN0VFV9W6ug3",
+	"GcXYADz19vBGW5V8ms6KGolX3e+nSRuxqOZyHLYX1ZUGLg3WtYSyOnkNrVwQAGqCH+vC8aoXepPhOJxz",
+	"8tFH5q0HuIfIqmi6tVBeHVO3EpJ3SqKo25r5ZM+mTlCgOLoNx7KdIOvBdYWAuqehFLAKlYFD2j9ybKb5",
+	"XG1gX1XYMfK1PTbqAr22ZbZXj/XyM32YcK81WB0ivgqG8DkFfV2BK/g4rfm61lj/qRFv4Crd49Q1ZKUh",
+	"/MeUWctl1VjfFcq92v0KMLyJEqwI78McbZAq4YbE2An1GwspRNg4UaE+5oSijGvYCdp3hv0mqMI4xadE",
+	"skc/YtE4X5aQyrr3vNZnYCy09mFaCTOjvmI6eWAgHomsNvPrhUp9t5Rmpmgva6yzIYdqZrGZtNotxPjm",
+	"9csqO6wtkVZpQ0JG8clW1dEQWrUf5ipttd1d1QoPZ3hBT4pqS612y0eN1E14XZW4UVGs8rBO1bS2KJbl",
+	"7+yeA3y906ovJEN4LMmI7SXDAs7js0XnxFZfz6bzXJhMGbHZsN9u/WfnmO7M25x3znUusSrv/FtF20Wd",
+	"8zoIX1mMvQVtvS58tI4/P1dTiZ1BXrw+hufhPvrUTgOHZ2+dFPuPs9evKtTJ4V1BmBYqimys3vY2jGx0",
+	"m9FOO3cdEmpX33r67T62qqAGDY/2a1o0rLpkvg3MFfxTuizns/W71JRJ80xd5W2f1nOVV0fMkP+v7uVK",
+	"i8oVJ8AwEINji27yEH1c9RarWLXKKPfRFNVbaUwrWsuUjWsQYUxhrRLat68BvIfldVxV02epVhnGWFRd",
+	"i4s51jhg8ZYuHNyjWzk4P/c6d8ABthUIh/IF5E6eazEcYvRnmX3v8QTTXOJZnHLYocQ/JdPZ7mqkaC+G",
+	"+C8gx58ldXq/rj579cwa1TSbo3rXKV13OwTj86ortkoDR3+K2/UDU0WgHZam4BmL2W1CUeRQc2M2FWkt",
+	"Rn0UPipcTNFJ4iih2sy3WzXAz9rMR1RA9XN0EokKMhToVTzbWOmVRt5WjVf6+ocpLRC2VoMe/qebM8p7",
+	"gH82RvkPnaS33uyPjZ4C3tbh/CI13dM8VjIW1MZxfXg7pb/5V8Npl25SarU7HSnj/Zo+olPISPYuOc+w",
+	"S5zp1dfY8auoEvDbuHfFRAVVxj5nyV1bL4t1nGKgWd1VDEOE7wflg/w+YUpdeFDq5NB690oBp5Ka+zSo",
+	"aqfdRpjezLNVJfubPFuBWH7enq1NJGW1b2slLPfvkpV9tr6tzQeznQjsAXZH3q2ioSbZ6mvaaDb2eG0r",
+	"ql3d4+Vn+jAerzW4HjxehbR17/Fa4fFqKCAVGLpe33xVDvtogyI3vFRsoXBu34WWWszaTE8tj+NzVFRl",
+	"FYsCUlYeblJVX1VEodsQmksU+SDqarm9Gjwpfrw5lbWA/L3SejdKa60sP4f/S1R5e721VFHnNNciMPd6",
+	"euscI7hVxdWT6Xu19dNQW0uU9XrrcsTNBkxvprfO84CNnXeKy/CZR2VupCyrtdc1EN2/a972+cZnNjig",
+	"7eTqirvl1vVYf5dvRovdXoq7uh5bzPVhNNm1WB902YoYdq/NrorfbCw5qWSTKosjPlktViV3rMCqpKnu",
+	"6gD7WaqtHmMKvMO/NyqrZb2GG9dTHRJ8GBXVbaqOg6vkJhVTldzrpHemkxKeLiJ3lZ5eQQl1+HBV/RPe",
+	"VGpuZLkZQazSlMcWe+TDkOk+G/KOfxjJ0MPcUCnlRBiWZVi8q5RrUjHh8HPe51riMlPKHVyv6/p7f6/m",
+	"3qu5hZrrcGK1hlt3eRrqtYFdbG4mm3z+2mw9TVqjw9ZCb/9u+N5nrLSuOoctVVWVfHpa6jbi2zUUVJV8",
+	"KN10BUoXaikKYfca6UqNdK3c5OslcmknKs3HPE6ZGK9XTE+KV97iK4f0ykegqdau7I7DfWvX0EwxLc8C",
+	"6DCATuNz1FVX7bWCqStQc5M+W3sAtyQd1871YTTe+m3X4VzdwJvTiVcc7L2afEdq8gr4N7lXa1nC9rr1",
+	"ydvDWwpKXsmB7iOU73XgUgc+eXu4Ljj5ivegmZq8mgttbMtSS58/c0X6GlRrtbLd8Az2PxYe/Pnq59c6",
+	"3u3UilrQfnoh1NeTYq+u59fO+2EU/8a3KVgCVoqe98aBVcaBm5cWt7MdfKRmgzv0Wy9OfkVTwZdhJFhn",
+	"HtjeMnBXRoGPwh7QRAy5RSvAvf7/ofT/DVdmFRm/ir5/K5HcdSzj3tN9r+UHLX+ZSax0e2+F/1fT86+k",
+	"4n9x2v1GNt5Upb9Lbb4RB/2CdPjNsti1FPdPzRF/Zeny5pT1j0NP30pFv1fOt1DOG7IylWxQwt2Aj0Hv",
+	"VkmNc77Re1i3bas3XqkEPThbvfSL0pepYskdmQJU0lD7V8nnqe8TYhY47v7cqNSr2+q2f6KSD6S6q6QW",
+	"B1Rygwq6Su5V8rtSyRFFF7C6Qqy3V7UzldyWa52u4L0j/V7FrqjYKlnrSF/G6IbKs6fdG/VllXz2KnId",
+	"jVijB9dBbv8uONBnrODWH8GWWqxKPkFn8xYy1DW0VZV8IAW1HpsLnVQl91roGi10jfRiONPxaGMzmtAt",
+	"n4SXoFTBHjiCsgdvfaOZl9RoBsYOubAx4ohHErtPd6jVCtCEgH0JoPd7rw2aOxkV2wX7jt5+6KWQSSTd",
+	"tUiw77/7u0f9kgd5mvomNDzxraXBcOr1bDV377QhZlnGk0gyO9e6+cV/np8eHJ5fvDz4z4vT17+c9WDH",
+	"96GAb/dhf39/17czpc7HWSSFgZGwoY01HhfETGvBDfTqu408BXcp8GpTm+0Bltx0yxNpClOeph0nsfME",
+	"+3LsYVuOugt+hgDbqmvO72urs4/Zu2Muhw6XHn37pHEzGwf9Ro14ph470EJBwqhvRHQRGhFt0UPnxjoA",
+	"XVfvZ3L2ekAgb9I8J9yRdR102g2/daJu5DP+lvpLuu6Lv91ecx/EdmHgzfmPne+oHQaDH16/RB54eHr8",
+	"I3CZCDk0z/BGuKEMBimzgGtr1hxofn5mLaMi+c/wFjrM+mvUKvtqdYgodaJ8f/+bGMmO+xf3D37vmDQf",
+	"zj2yhv7s0p+xmfw/DmPoYdRa39hlTX+iBWlNc8MltdKPsFNR1IJpoExaTR11gilD6tSt7TP1WbY3IpLo",
+	"yf6a1kZ0rKuYXfcPka1keD/kMkl983s70pzPTwrIZQ3sFMSuG5tJm+x67l+RXKR57vEuHiWD0xcHz1++",
+	"6Np3llqyMTBCDlMO/zw62cgD/imyu2AD29FLD8tr0Yl/Hp1AH+F+3wLsFu4IgxLAay+JnohNVVrPwqCP",
+	"wAnh13LHWYJ+1mbm/gDTz9Hkb0pUKFHKP9pk+vdAvCVzpf/6h3EBhK3V4Ib/6eZcAR7e9+6AO3IHmAJt",
+	"azB+gYxu7xrwb96Se6BCue9dBPcugtJFEBB2jZtgDZY3cxdU6f0ml0Ggkp+522AtLVntPlgJyf275GCf",
+	"rythw7FsJ/R6cH16boVt5bOruxb8TB/GvbAG04OLoRCx7t0Mq9wMTaSi0ja8Trv8pWpB/iSLp4YdXCk6",
+	"Lrz8s5BXeGsusO42NeAwYTMVuDSUfYY6cNXlEZC/fLZJCw6AvCWRPHz+w+jBxeZqMKTwI96YJhyAfq8K",
+	"35EqPC1xtw7xF8n+9tpweHW9OrxzKWTSxse7kbR5lla0Y6ruyjRLU54CacpuvOnBHlQVZ3IxmbX6c5U3",
+	"3aoCXU50rzp/5Kpzgd5rdOe1t6KZ9jzHJzapzwVt/cz15w0EaLUGvRqa+3fL/D5fJXrj2Wwn3Je5HHer",
+	"R7d96FH7+gr11qLe1TXqMNWHUanXYX7QqUth7V6pXqVUb5Kv1s5Wy81obq4n4dbNH85hrjWXFpQWQyFh",
+	"xwls4zGXibs0SkNfq6nhutNnhicQtc71DIQFlduoBRPBYC9RsdnbbbVbuU5bT1t7qLzOT+Ik+xQSPuGp",
+	"ysYO2cLokbXZ07291A0YKWOffrf/3T5ed7/9pU85eZAbg3fTkSKBf2Va9bmBnRyPnzsi4HBut1uGR4w4",
+	"S+2oZnWV4v0+v9SA9iIvhSI6wnH48vkPla+Fkeu/R0XdMWqEa9gDd9e0SjtZyjBskkJFdjEuSsgyBb4y",
+	"EZX/XT9L2SFt3YfKpjZrv4a5A//+r//GXTOrxiKGgjBMSukHcimsqUyAwX9rP1286uGQOlDvPOdZqmYO",
+	"LdpwZpnlgzw947YNzxkfK3nG7W43kgchZsZ3Z3CCaKbS2VjpbCRiUHRMRLohEW4JaMFR+hkYzuHg+Wln",
+	"f3//G6LWfs3l5Vq78OBFK+E71+LSf6ywf639VtGgvwuHKTNGDESJZb0KpHuQshnXkHEdFv/4GQWXRq3p",
+	"iNkHBoS0+N0Of5cpw5O/RS1geSIsINl0QBLurpgp4rK7sIPc5ppHksfKzIzl4w5No3mKlN+MRGbaqEu5",
+	"4fTjmI/7XLuf5sBX9v1d3rKvytEx6BCEpcT7srmGQzYlKcLNbTYe5fLS0cM+iy+FHEbSWKXZkFOErq9S",
+	"EjMJI0cFVG67cIzL7Ak50MxYncdukxfZaGZEzNIe7Bg25pFkBl6phO8+xU+dvIUxywwoaRWEsQ53LmEP",
+	"Ds+OQokt47BybuPL2bzLACiMgatAQEUE5+HglhWQsmNEwiPpJQckxx4Qbeg77gMYS7YEWSVjAlUAW+zw",
+	"LJKZVhPhmAPXMGIGDLPCEPaVEKwi4Not+7piy/v+KR8zCRU67LDQ7S03XKMjew8yZsxU6QRSNRSyDYa4",
+	"FoyZZEOOtCCSxSCS1Lpup+Em/GVubW6ympUcJGMhO0qmM+AyyZSQ1jzFZVQnCnS4Y9Uld/fF5EzGvB1J",
+	"FjswdMLiNJ8IPu3C31GcCQSHuUl6gGcMO1ql/K/4aHd+he5R6/1v7/9PAAAA//+gMgN2qtYBAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/api/audit.go
+++ b/internal/api/audit.go
@@ -178,9 +178,10 @@ func AuditMiddleware(recorder AuditRecorder, source string, trustedProxies []*ne
 // are audited only when they hit /v1/admin/* OR a credentials-fetch
 // endpoint under /v1/cloud-accounts/.../credentials (ADR-0015 §5: every
 // plaintext SK read must produce an audit row, even though the endpoint
-// is reached by collector PATs not admins). /healthz, /readyz,
-// /metrics, /ui/*, and /v1/auth/config are chatty reads not worth
-// logging.
+// is reached by collector PATs not admins) OR the bulk extract routes
+// (data-exfiltration evidence for SecNumCloud chapter 8). /healthz,
+// /readyz, /metrics, /ui/*, and /v1/auth/config are chatty reads not
+// worth logging.
 func shouldAudit(r *http.Request) bool {
 	if r.Method != http.MethodGet {
 		return true
@@ -189,8 +190,16 @@ func shouldAudit(r *http.Request) bool {
 		return true
 	}
 	// /v1/cloud-accounts/<id-or-by-name/...>/credentials
-	return strings.HasPrefix(r.URL.Path, "/v1/cloud-accounts/") &&
-		strings.HasSuffix(r.URL.Path, "/credentials")
+	if strings.HasPrefix(r.URL.Path, "/v1/cloud-accounts/") &&
+		strings.HasSuffix(r.URL.Path, "/credentials") {
+		return true
+	}
+	// Bulk extracts — recorded for SNC chapter-8 evidence-of-exfiltration.
+	switch r.URL.Path {
+	case "/v1/search/extract", "/v1/search/extract.zip", "/v1/eol/extract":
+		return true
+	}
+	return false
 }
 
 func buildAuditEvent(r *http.Request, status int, bodySnap []byte, trustedProxies []*net.IPNet) AuditEventInsert {

--- a/internal/api/audit.go
+++ b/internal/api/audit.go
@@ -163,7 +163,8 @@ func AuditMiddleware(recorder AuditRecorder, source string, trustedProxies []*ne
 				}
 			}
 			if err := recorder.InsertAuditEvent(ctx, ev); err != nil {
-				slog.Error("audit: insert failed",
+				slog.Error(
+					"audit: insert failed",
 					slog.Any("error", err),
 					slog.String("method", r.Method),
 					slog.String("path", r.URL.Path),

--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -262,7 +262,8 @@ func (s *Server) findOrCreateOidcUser(ctx context.Context, claims *auth.OIDCClai
 		// fails if someone tries the local-login flow with this name.
 		// argon2id verify against a junk PHC string returns
 		// ErrInvalidHashFormat, which the login handler surfaces as 401.
-		out, err := s.store.CreateUserWithIdentity(ctx,
+		out, err := s.store.CreateUserWithIdentity(
+			ctx,
 			UserInsert{
 				Username:           username,
 				PasswordHash:       "$argon2id$shadow$oidc", // never verifies

--- a/internal/api/extract_audit_test.go
+++ b/internal/api/extract_audit_test.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestShouldAudit_AllowlistsExtractRoutes(t *testing.T) {
+	cases := []string{
+		"/v1/search/extract",
+		"/v1/search/extract.zip",
+		"/v1/eol/extract",
+	}
+	for _, path := range cases {
+		req := httptest.NewRequest("GET", path, nil)
+		if !shouldAudit(req) {
+			t.Errorf("shouldAudit(%q) = false, want true", path)
+		}
+	}
+}
+
+func TestShouldAudit_DoesNotAllowlistOtherSearchPaths(t *testing.T) {
+	for _, path := range []string{"/v1/search", "/v1/search/something"} {
+		req := httptest.NewRequest("GET", path, nil)
+		if shouldAudit(req) {
+			t.Errorf("shouldAudit(%q) = true, want false", path)
+		}
+	}
+}

--- a/internal/api/extract_audit_test.go
+++ b/internal/api/extract_audit_test.go
@@ -1,6 +1,8 @@
+//nolint:noctx // unit tests for shouldAudit use httptest.NewRequest for brevity; context is unused by the tested function
 package api
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 )
@@ -12,7 +14,7 @@ func TestShouldAudit_AllowlistsExtractRoutes(t *testing.T) {
 		"/v1/eol/extract",
 	}
 	for _, path := range cases {
-		req := httptest.NewRequest("GET", path, nil)
+		req := httptest.NewRequest("GET", path, http.NoBody)
 		if !shouldAudit(req) {
 			t.Errorf("shouldAudit(%q) = false, want true", path)
 		}
@@ -21,7 +23,7 @@ func TestShouldAudit_AllowlistsExtractRoutes(t *testing.T) {
 
 func TestShouldAudit_DoesNotAllowlistOtherSearchPaths(t *testing.T) {
 	for _, path := range []string{"/v1/search", "/v1/search/something"} {
-		req := httptest.NewRequest("GET", path, nil)
+		req := httptest.NewRequest("GET", path, http.NoBody)
 		if shouldAudit(req) {
 			t.Errorf("shouldAudit(%q) = true, want false", path)
 		}

--- a/internal/api/extract_cap_test.go
+++ b/internal/api/extract_cap_test.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	openapi_types "github.com/oapi-codegen/runtime/types"
-
 	"github.com/google/uuid"
 
 	"github.com/sthalbert/longue-vue/internal/api"
@@ -36,9 +34,8 @@ func newLowCapServer(t *testing.T, store *extractStubStore, maxRows int) *httpte
 }
 
 func makeBigCluster(id uuid.UUID, displayName string, anns map[string]string) api.Cluster {
-	uid := openapi_types.UUID(id)
 	return api.Cluster{
-		Id:          &uid,
+		Id:          &id,
 		Name:        "big-cluster",
 		DisplayName: &displayName,
 		Annotations: &anns,
@@ -50,7 +47,7 @@ func TestEolExtract_CapTruncates(t *testing.T) {
 	clusterID := uuid.MustParse("88888888-8888-8888-8888-888888888888")
 	displayName := "big"
 	manyAnnotations := make(map[string]string, 50)
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		k := fmt.Sprintf("longue-vue.io/eol.fake%02d", i)
 		manyAnnotations[k] = `{"product":"fake","cycle":"1","eol_status":"unknown","checked_at":"2026-05-15T00:00:00Z"}`
 	}
@@ -59,11 +56,11 @@ func TestEolExtract_CapTruncates(t *testing.T) {
 	srv := newLowCapServer(t, store, 10)
 	defer srv.Close()
 
-	resp, body := getWithAuth(t, srv.URL+"/v1/eol/extract?format=csv")
-	if resp.StatusCode != 200 {
-		t.Fatalf("status: %d", resp.StatusCode)
+	status, header, body := getWithAuth(t, srv.URL+"/v1/eol/extract?format=csv")
+	if status != 200 {
+		t.Fatalf("status: %d", status)
 	}
-	if got := resp.Header.Get("X-Longue-Vue-Truncated"); got != "true" {
+	if got := header.Get("X-Longue-Vue-Truncated"); got != "true" {
 		t.Errorf("X-Longue-Vue-Truncated: got %q want %q", got, "true")
 	}
 	bodyAfterBOM := strings.TrimPrefix(body, "\xEF\xBB\xBF")

--- a/internal/api/extract_cap_test.go
+++ b/internal/api/extract_cap_test.go
@@ -1,0 +1,77 @@
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	"github.com/google/uuid"
+
+	"github.com/sthalbert/longue-vue/internal/api"
+	"github.com/sthalbert/longue-vue/internal/auth"
+)
+
+func newLowCapServer(t *testing.T, store *extractStubStore, maxRows int) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	wrap := func(h http.HandlerFunc) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			caller := &auth.Caller{
+				Kind:   auth.CallerKindUser,
+				Role:   "viewer",
+				Scopes: []string{auth.ScopeRead},
+			}
+			ctx := auth.WithCaller(r.Context(), caller)
+			r = r.WithContext(ctx)
+			h(w, r)
+		})
+	}
+	mux.Handle("GET /v1/eol/extract", wrap(api.HandleEolExtract(store, maxRows)))
+	mux.Handle("GET /v1/search/extract", wrap(api.HandleSearchExtract(store, maxRows)))
+	return httptest.NewServer(mux)
+}
+
+func makeBigCluster(id uuid.UUID, displayName string, anns map[string]string) api.Cluster {
+	uid := openapi_types.UUID(id)
+	return api.Cluster{
+		Id:          &uid,
+		Name:        "big-cluster",
+		DisplayName: &displayName,
+		Annotations: &anns,
+	}
+}
+
+func TestEolExtract_CapTruncates(t *testing.T) {
+	store := newExtractStubStore()
+	clusterID := uuid.MustParse("88888888-8888-8888-8888-888888888888")
+	displayName := "big"
+	manyAnnotations := make(map[string]string, 50)
+	for i := 0; i < 50; i++ {
+		k := fmt.Sprintf("longue-vue.io/eol.fake%02d", i)
+		manyAnnotations[k] = `{"product":"fake","cycle":"1","eol_status":"unknown","checked_at":"2026-05-15T00:00:00Z"}`
+	}
+	store.clusters = append(store.clusters, makeBigCluster(clusterID, displayName, manyAnnotations))
+
+	srv := newLowCapServer(t, store, 10)
+	defer srv.Close()
+
+	resp, body := getWithAuth(t, srv.URL+"/v1/eol/extract?format=csv")
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("X-Longue-Vue-Truncated"); got != "true" {
+		t.Errorf("X-Longue-Vue-Truncated: got %q want %q", got, "true")
+	}
+	bodyAfterBOM := strings.TrimPrefix(body, "\xEF\xBB\xBF")
+	// Count CRLF separators after stripping trailing newlines.
+	// With maxRows=10: 1 header + 10 data rows = 11 CRLF-terminated lines.
+	// After TrimRight the trailing CRLF of the last row is stripped → 10.
+	totalLines := strings.Count(strings.TrimRight(bodyAfterBOM, "\r\n"), "\r\n")
+	if totalLines != 10 {
+		t.Errorf("expected 10 CRLF separators (1 header + 10 rows = 11 lines, last stripped), got %d", totalLines)
+	}
+}

--- a/internal/api/extract_csv.go
+++ b/internal/api/extract_csv.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+)
+
+// extractCSVWriter wraps encoding/csv with the conventions our extracts
+// commit to: UTF-8 BOM so Excel auto-detects encoding, CRLF line endings
+// (RFC 4180), and a fixed header row written eagerly so even a zero-row
+// extract is a valid CSV. Caller must Close() to flush.
+type extractCSVWriter struct {
+	w       *csv.Writer
+	columns int
+	closed  bool
+}
+
+func newExtractCSVWriter(out io.Writer, header []string) *extractCSVWriter {
+	// UTF-8 BOM up front so Excel decodes the file as UTF-8 by default.
+	_, _ = out.Write([]byte{0xEF, 0xBB, 0xBF})
+	cw := csv.NewWriter(out)
+	cw.UseCRLF = true
+	_ = cw.Write(header)
+	return &extractCSVWriter{w: cw, columns: len(header)}
+}
+
+// WriteRow writes one row. Returns an error if the row's column count
+// does not match the header's.
+func (e *extractCSVWriter) WriteRow(row []string) error {
+	if len(row) != e.columns {
+		return fmt.Errorf("csv: column count mismatch (got %d, want %d)", len(row), e.columns)
+	}
+	if err := e.w.Write(row); err != nil {
+		return fmt.Errorf("csv: write row: %w", err)
+	}
+	return nil
+}
+
+// Close flushes the underlying buffer. Safe to call twice.
+func (e *extractCSVWriter) Close() error {
+	if e.closed {
+		return nil
+	}
+	e.closed = true
+	e.w.Flush()
+	if err := e.w.Error(); err != nil {
+		return fmt.Errorf("csv: flush: %w", err)
+	}
+	return nil
+}

--- a/internal/api/extract_csv.go
+++ b/internal/api/extract_csv.go
@@ -2,9 +2,12 @@ package api
 
 import (
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"io"
 )
+
+var errCSVColumnMismatch = errors.New("csv: column count mismatch")
 
 // extractCSVWriter wraps encoding/csv with the conventions our extracts
 // commit to: UTF-8 BOM so Excel auto-detects encoding, CRLF line endings
@@ -29,7 +32,7 @@ func newExtractCSVWriter(out io.Writer, header []string) *extractCSVWriter {
 // does not match the header's.
 func (e *extractCSVWriter) WriteRow(row []string) error {
 	if len(row) != e.columns {
-		return fmt.Errorf("csv: column count mismatch (got %d, want %d)", len(row), e.columns)
+		return fmt.Errorf("%w (got %d, want %d)", errCSVColumnMismatch, len(row), e.columns)
 	}
 	if err := e.w.Write(row); err != nil {
 		return fmt.Errorf("csv: write row: %w", err)

--- a/internal/api/extract_csv_test.go
+++ b/internal/api/extract_csv_test.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCSVWriter_BOMAndHeader(t *testing.T) {
+	var buf bytes.Buffer
+	w := newExtractCSVWriter(&buf, []string{"a", "b"})
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	got := buf.Bytes()
+	if !bytes.HasPrefix(got, []byte{0xEF, 0xBB, 0xBF}) {
+		t.Fatalf("missing UTF-8 BOM, got %q", got)
+	}
+	rest := bytes.TrimPrefix(got, []byte{0xEF, 0xBB, 0xBF})
+	if string(rest) != "a,b\r\n" {
+		t.Fatalf("header mismatch, got %q", rest)
+	}
+}
+
+func TestCSVWriter_EscapesSpecialChars(t *testing.T) {
+	var buf bytes.Buffer
+	w := newExtractCSVWriter(&buf, []string{"col"})
+	if err := w.WriteRow([]string{`has,comma`}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteRow([]string{"has\"quote"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteRow([]string{"has\nnewline"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out := string(bytes.TrimPrefix(buf.Bytes(), []byte{0xEF, 0xBB, 0xBF}))
+	want := "col\r\n" +
+		`"has,comma"` + "\r\n" +
+		`"has""quote"` + "\r\n" +
+		`"has` + "\r\n" + `newline"` + "\r\n"
+	if out != want {
+		t.Fatalf("escape mismatch\n got: %q\nwant: %q", out, want)
+	}
+}
+
+func TestCSVWriter_RejectsRowLengthMismatch(t *testing.T) {
+	var buf bytes.Buffer
+	w := newExtractCSVWriter(&buf, []string{"a", "b"})
+	if err := w.WriteRow([]string{"only-one"}); err == nil {
+		t.Fatal("expected error on column-count mismatch")
+	} else if !strings.Contains(err.Error(), "column count") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/api/extract_handlers.go
+++ b/internal/api/extract_handlers.go
@@ -29,6 +29,14 @@ type ExtractStore interface {
 
 const extractPageSize = 200
 
+// extractQueryMax is the maximum byte-length accepted for the ?q= parameter.
+const extractQueryMax = 256
+
+// extractServerVersion is the placeholder version label written into the
+// extract ZIP README. main.go can later override it via a setter if we
+// wire build info through.
+var extractServerVersion = "longue-vue"
+
 // HandleEolExtract — read scope. GET /v1/eol/extract?format=csv|json
 // [&entity_type=...&status=...]. Iterates clusters / nodes / VMs, flattens
 // EOL annotations via internal/eolagg, applies optional filters, and
@@ -793,9 +801,114 @@ func collectVMExtract(ctx context.Context, store ExtractStore, q string) ([][]st
 	return rows, objs, nil
 }
 
-// HandleSearchExtractZip is a stub; implementation is Task 10.
-func HandleSearchExtractZip(_ ExtractStore, _ int) http.HandlerFunc {
-	return func(w http.ResponseWriter, _ *http.Request) {
-		writeProblem(w, http.StatusNotImplemented, "Not Implemented", "zip extract is implemented in Task 10")
+// HandleSearchExtractZip — read scope. GET /v1/search/extract.zip?q=...
+// Returns a ZIP bundle of workloads.csv + pods.csv + virtual_machines.csv + README.txt.
+// Truncation is a per-CSV decision; if any of the three exceeds maxRows
+// it is truncated independently and X-Longue-Vue-Truncated is set on
+// the response. Row counts in the README reflect the truncated counts.
+func HandleSearchExtractZip(store ExtractStore, maxRows int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller := auth.CallerFromContext(r.Context())
+		if caller == nil || !caller.HasScope(auth.ScopeRead) {
+			writeProblem(w, http.StatusForbidden, "Forbidden", "read scope required")
+			return
+		}
+		q := r.URL.Query().Get("q")
+		if q == "" {
+			SetAuditDetails(r.Context(), map[string]any{
+				"action": "extract", "page": "search", "format": "zip", "outcome": "denied",
+			})
+			metrics.ObserveExtract("search", "zip", "denied", 0)
+			writeProblem(w, http.StatusBadRequest, "Bad Request", "q is required")
+			return
+		}
+		if len(q) > extractQueryMax {
+			SetAuditDetails(r.Context(), map[string]any{
+				"action": "extract", "page": "search", "format": "zip", "outcome": "denied",
+			})
+			metrics.ObserveExtract("search", "zip", "denied", 0)
+			writeProblem(w, http.StatusBadRequest, "Bad Request", "q is longer than 256 characters")
+			return
+		}
+
+		generated := time.Now()
+		var buf bytes.Buffer
+		zw := newExtractZIPWriter(&buf, extractZIPMeta{
+			Query: q, GeneratedAt: generated, Version: extractServerVersion,
+		})
+
+		totalRows := 0
+		truncated := false
+
+		emit := func(name string, header []string, rows [][]string) error {
+			if len(rows) > maxRows {
+				rows = rows[:maxRows]
+				truncated = true
+			}
+			cw, err := zw.AddCSV(name, header)
+			if err != nil {
+				return err
+			}
+			for _, row := range rows {
+				if err := cw.WriteRow(row); err != nil {
+					return err
+				}
+			}
+			if err := cw.Close(); err != nil {
+				return err
+			}
+			zw.SetRowCount(name, len(rows))
+			totalRows += len(rows)
+			return nil
+		}
+
+		wlRows, _, err := collectWorkloadExtract(r.Context(), store, q)
+		if err == nil {
+			err = emit("workloads.csv", searchCSVHeader("workloads"), wlRows)
+		}
+		if err == nil {
+			var podRows [][]string
+			podRows, _, err = collectPodExtract(r.Context(), store, q)
+			if err == nil {
+				err = emit("pods.csv", searchCSVHeader("pods"), podRows)
+			}
+		}
+		if err == nil {
+			var vmRows [][]string
+			vmRows, _, err = collectVMExtract(r.Context(), store, q)
+			if err == nil {
+				err = emit("virtual_machines.csv", searchCSVHeader("virtual_machines"), vmRows)
+			}
+		}
+		if err == nil {
+			err = zw.Close()
+		}
+		if err != nil {
+			slog.Error("extract: zip", slog.Any("error", err))
+			writeProblem(w, http.StatusInternalServerError, "Internal Server Error", "")
+			SetAuditDetails(r.Context(), map[string]any{
+				"action": "extract", "page": "search", "format": "zip", "outcome": "error",
+			})
+			metrics.ObserveExtract("search", "zip", "error", 0)
+			return
+		}
+
+		outcome := "ok"
+		if truncated {
+			outcome = "truncated"
+			w.Header().Set("X-Longue-Vue-Truncated", "true")
+		}
+		filename := fmt.Sprintf("longue-vue-search-%s-%s.zip", slugForFilename(q), extractTimestamp(generated))
+		w.Header().Set("Content-Type", extractContentType("zip"))
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename=%q`, filename))
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(buf.Bytes())
+
+		SetAuditDetails(r.Context(), map[string]any{
+			"action": "extract", "page": "search", "format": "zip", "q": q,
+			"row_count": totalRows, "truncated": truncated, "outcome": outcome,
+		})
+		metrics.ObserveExtract("search", "zip", outcome, totalRows)
 	}
 }

--- a/internal/api/extract_handlers.go
+++ b/internal/api/extract_handlers.go
@@ -1,0 +1,334 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/sthalbert/longue-vue/internal/auth"
+	"github.com/sthalbert/longue-vue/internal/eolagg"
+	"github.com/sthalbert/longue-vue/internal/metrics"
+)
+
+// ExtractStore is the narrow slice of Store the extract handlers consume.
+type ExtractStore interface {
+	ListClusters(ctx context.Context, limit int, cursor string, includeTerminated bool) ([]Cluster, string, error)
+	ListNodes(ctx context.Context, clusterID *uuid.UUID, limit int, cursor string, includeTerminated bool) ([]Node, string, error)
+	ListNamespaces(ctx context.Context, clusterID *uuid.UUID, limit int, cursor string, includeTerminated bool) ([]Namespace, string, error)
+	ListWorkloads(ctx context.Context, filter WorkloadListFilter, limit int, cursor string) ([]Workload, string, error)
+	ListPods(ctx context.Context, filter PodListFilter, limit int, cursor string) ([]Pod, string, error)
+	ListVirtualMachines(ctx context.Context, filter VirtualMachineListFilter, limit int, cursor string) ([]VirtualMachine, string, error)
+	ListCloudAccounts(ctx context.Context, limit int, cursor string) ([]CloudAccount, string, error)
+}
+
+const extractPageSize = 200
+
+// HandleEolExtract — read scope. GET /v1/eol/extract?format=csv|json
+// [&entity_type=...&status=...]. Iterates clusters / nodes / VMs, flattens
+// EOL annotations via internal/eolagg, applies optional filters, and
+// emits CSV or JSON. The response body is buffered before flushing so
+// the X-Longue-Vue-Truncated header can be written before any bytes
+// hit the wire — at the row cap, peak buffer is ~10 MB.
+//
+//nolint:gocyclo // validation branches inflate the score; each branch is short
+func HandleEolExtract(store ExtractStore, maxRows int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller := auth.CallerFromContext(r.Context())
+		if caller == nil || !caller.HasScope(auth.ScopeRead) {
+			writeProblem(w, http.StatusForbidden, "Forbidden", "read scope required")
+			return
+		}
+		q := r.URL.Query()
+		format := q.Get("format")
+		if format != "csv" && format != "json" {
+			SetAuditDetails(r.Context(), map[string]any{
+				"action": "extract", "page": "eol", "format": format, "outcome": "denied",
+			})
+			metrics.ObserveExtract("eol", format, "denied", 0)
+			writeProblem(w, http.StatusBadRequest, "Bad Request", "format must be 'csv' or 'json'")
+			return
+		}
+		entityType := q.Get("entity_type")
+		if entityType != "" && entityType != "cluster" && entityType != "node" && entityType != "vm" {
+			SetAuditDetails(r.Context(), map[string]any{
+				"action": "extract", "page": "eol", "format": format, "outcome": "denied",
+			})
+			metrics.ObserveExtract("eol", format, "denied", 0)
+			writeProblem(w, http.StatusBadRequest, "Bad Request", "entity_type must be 'cluster', 'node', or 'vm'")
+			return
+		}
+		status := q.Get("status")
+		if status != "" && status != "eol" && status != "approaching_eol" && status != "supported" && status != "unknown" {
+			SetAuditDetails(r.Context(), map[string]any{
+				"action": "extract", "page": "eol", "format": format, "outcome": "denied",
+			})
+			metrics.ObserveExtract("eol", format, "denied", 0)
+			writeProblem(w, http.StatusBadRequest, "Bad Request", "status must be 'eol', 'approaching_eol', 'supported', or 'unknown'")
+			return
+		}
+
+		clusters, err := collectAllClusters(r.Context(), store)
+		if err != nil {
+			slog.Error("extract: list clusters", slog.Any("error", err))
+			SetAuditDetails(r.Context(), map[string]any{
+				"action": "extract", "page": "eol", "format": format, "outcome": "error",
+			})
+			metrics.ObserveExtract("eol", format, "error", 0)
+			writeProblem(w, http.StatusInternalServerError, "Internal Server Error", "")
+			return
+		}
+		nodes, err := collectAllNodes(r.Context(), store)
+		if err != nil {
+			slog.Error("extract: list nodes", slog.Any("error", err))
+			SetAuditDetails(r.Context(), map[string]any{
+				"action": "extract", "page": "eol", "format": format, "outcome": "error",
+			})
+			metrics.ObserveExtract("eol", format, "error", 0)
+			writeProblem(w, http.StatusInternalServerError, "Internal Server Error", "")
+			return
+		}
+		vms, err := collectAllVMs(r.Context(), store, VirtualMachineListFilter{})
+		if err != nil {
+			slog.Error("extract: list virtual machines", slog.Any("error", err))
+			SetAuditDetails(r.Context(), map[string]any{
+				"action": "extract", "page": "eol", "format": format, "outcome": "error",
+			})
+			metrics.ObserveExtract("eol", format, "error", 0)
+			writeProblem(w, http.StatusInternalServerError, "Internal Server Error", "")
+			return
+		}
+
+		rows := eolagg.Flatten(toEolaggClusters(clusters), toEolaggNodes(nodes), toEolaggVMs(vms))
+		if entityType != "" {
+			filtered := rows[:0]
+			for _, row := range rows {
+				if row.EntityType == entityType {
+					filtered = append(filtered, row)
+				}
+			}
+			rows = filtered
+		}
+		if status != "" {
+			filtered := rows[:0]
+			for _, row := range rows {
+				if row.Status == status {
+					filtered = append(filtered, row)
+				}
+			}
+			rows = filtered
+		}
+
+		truncated := false
+		if len(rows) > maxRows {
+			rows = rows[:maxRows]
+			truncated = true
+		}
+
+		var buf bytes.Buffer
+		switch format {
+		case "csv":
+			cw := newExtractCSVWriter(&buf, eolCSVHeader())
+			for _, row := range rows {
+				if err := cw.WriteRow(eolRowToCSV(row)); err != nil {
+					slog.Error("extract: csv row", slog.Any("error", err))
+					writeProblem(w, http.StatusInternalServerError, "Internal Server Error", "")
+					return
+				}
+			}
+			if err := cw.Close(); err != nil {
+				slog.Error("extract: csv close", slog.Any("error", err))
+				writeProblem(w, http.StatusInternalServerError, "Internal Server Error", "")
+				return
+			}
+		case "json":
+			jw := newExtractJSONWriter(&buf)
+			for _, row := range rows {
+				if err := jw.WriteRow(row); err != nil {
+					slog.Error("extract: json row", slog.Any("error", err))
+					writeProblem(w, http.StatusInternalServerError, "Internal Server Error", "")
+					return
+				}
+			}
+			if err := jw.Close(); err != nil {
+				slog.Error("extract: json close", slog.Any("error", err))
+				writeProblem(w, http.StatusInternalServerError, "Internal Server Error", "")
+				return
+			}
+		}
+
+		outcome := "ok"
+		if truncated {
+			outcome = "truncated"
+			w.Header().Set("X-Longue-Vue-Truncated", "true")
+		}
+		filename := fmt.Sprintf("longue-vue-eol-%s.%s", extractTimestamp(time.Now()), format)
+		w.Header().Set("Content-Type", extractContentType(format))
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename=%q`, filename))
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(buf.Bytes())
+
+		SetAuditDetails(r.Context(), map[string]any{
+			"action":      "extract",
+			"page":        "eol",
+			"format":      format,
+			"entity_type": entityType,
+			"status":      status,
+			"row_count":   len(rows),
+			"truncated":   truncated,
+			"outcome":     outcome,
+		})
+		metrics.ObserveExtract("eol", format, outcome, len(rows))
+	}
+}
+
+func extractContentType(format string) string {
+	switch format {
+	case "csv":
+		return "text/csv; charset=utf-8"
+	case "json":
+		return "application/json; charset=utf-8"
+	case "zip":
+		return "application/zip"
+	}
+	return "application/octet-stream"
+}
+
+func eolCSVHeader() []string {
+	return []string{
+		"entity_type", "entity_id", "entity_name", "cluster",
+		"product", "cycle", "status", "eol_date",
+		"latest", "latest_available", "support", "checked_at",
+	}
+}
+
+func eolRowToCSV(r eolagg.Row) []string {
+	return []string{
+		r.EntityType, r.EntityID, r.EntityName, r.Cluster,
+		r.Product, r.Cycle, r.Status, r.EOLDate,
+		r.Latest, r.LatestAvailable, r.Support, r.CheckedAt,
+	}
+}
+
+func collectAllClusters(ctx context.Context, store ExtractStore) ([]Cluster, error) {
+	var out []Cluster
+	cursor := ""
+	for {
+		items, next, err := store.ListClusters(ctx, extractPageSize, cursor, false)
+		if err != nil {
+			return nil, fmt.Errorf("listClusters: %w", err)
+		}
+		out = append(out, items...)
+		if next == "" {
+			return out, nil
+		}
+		cursor = next
+	}
+}
+
+func collectAllNodes(ctx context.Context, store ExtractStore) ([]Node, error) {
+	var out []Node
+	cursor := ""
+	for {
+		items, next, err := store.ListNodes(ctx, nil, extractPageSize, cursor, false)
+		if err != nil {
+			return nil, fmt.Errorf("listNodes: %w", err)
+		}
+		out = append(out, items...)
+		if next == "" {
+			return out, nil
+		}
+		cursor = next
+	}
+}
+
+func collectAllVMs(ctx context.Context, store ExtractStore, filter VirtualMachineListFilter) ([]VirtualMachine, error) {
+	var out []VirtualMachine
+	cursor := ""
+	for {
+		items, next, err := store.ListVirtualMachines(ctx, filter, extractPageSize, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("listVirtualMachines: %w", err)
+		}
+		out = append(out, items...)
+		if next == "" {
+			return out, nil
+		}
+		cursor = next
+	}
+}
+
+func toEolaggClusters(in []Cluster) []eolagg.ClusterInput {
+	out := make([]eolagg.ClusterInput, len(in))
+	for i, c := range in {
+		id := ""
+		if c.Id != nil {
+			id = c.Id.String()
+		}
+		display := ""
+		if c.DisplayName != nil {
+			display = *c.DisplayName
+		}
+		ann := map[string]string{}
+		if c.Annotations != nil {
+			ann = *c.Annotations
+		}
+		out[i] = eolagg.ClusterInput{
+			ID: id, Name: c.Name, DisplayName: display, Annotations: ann,
+		}
+	}
+	return out
+}
+
+func toEolaggNodes(in []Node) []eolagg.NodeInput {
+	out := make([]eolagg.NodeInput, len(in))
+	for i, n := range in {
+		id := ""
+		if n.Id != nil {
+			id = n.Id.String()
+		}
+		ann := map[string]string{}
+		if n.Annotations != nil {
+			ann = *n.Annotations
+		}
+		out[i] = eolagg.NodeInput{
+			ID: id, Name: n.Name, ClusterID: n.ClusterId.String(), Annotations: ann,
+		}
+	}
+	return out
+}
+
+func toEolaggVMs(in []VirtualMachine) []eolagg.VMInput {
+	out := make([]eolagg.VMInput, len(in))
+	for i, v := range in {
+		display := ""
+		if v.DisplayName != nil {
+			display = *v.DisplayName
+		}
+		out[i] = eolagg.VMInput{
+			ID: v.ID.String(), Name: v.Name, DisplayName: display, Annotations: v.Annotations,
+		}
+	}
+	return out
+}
+
+// Stubs — Task 9 / Task 10 will implement these.
+
+// HandleSearchExtract is a stub; implementation is Task 9.
+func HandleSearchExtract(_ ExtractStore, _ int) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		writeProblem(w, http.StatusNotImplemented, "Not Implemented", "search extract is implemented in Task 9")
+	}
+}
+
+// HandleSearchExtractZip is a stub; implementation is Task 10.
+func HandleSearchExtractZip(_ ExtractStore, _ int) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		writeProblem(w, http.StatusNotImplemented, "Not Implemented", "zip extract is implemented in Task 10")
+	}
+}

--- a/internal/api/extract_handlers.go
+++ b/internal/api/extract_handlers.go
@@ -343,7 +343,7 @@ func HandleSearchExtract(store ExtractStore, maxRows int) http.HandlerFunc {
 			writeProblem(w, http.StatusBadRequest, "Bad Request", "q is required")
 			return
 		}
-		if len(searchQ) > 256 {
+		if len(searchQ) > extractQueryMax {
 			writeProblem(w, http.StatusBadRequest, "Bad Request", "q must be ≤ 256 characters")
 			return
 		}

--- a/internal/api/extract_handlers.go
+++ b/internal/api/extract_handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -317,13 +318,479 @@ func toEolaggVMs(in []VirtualMachine) []eolagg.VMInput {
 	return out
 }
 
-// Stubs — Task 9 / Task 10 will implement these.
+// HandleSearchExtract — read scope. GET /v1/search/extract?q=...&kind=workloads|pods|virtual_machines&format=csv|json
+// Searches container images (workloads/pods) or VM image/application (virtual_machines).
+//
+//nolint:gocyclo // dispatch + validation branches; each is short
+func HandleSearchExtract(store ExtractStore, maxRows int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		caller := auth.CallerFromContext(r.Context())
+		if caller == nil || !caller.HasScope(auth.ScopeRead) {
+			writeProblem(w, http.StatusForbidden, "Forbidden", "read scope required")
+			return
+		}
+		q := r.URL.Query()
+		searchQ := q.Get("q")
+		if searchQ == "" {
+			writeProblem(w, http.StatusBadRequest, "Bad Request", "q is required")
+			return
+		}
+		if len(searchQ) > 256 {
+			writeProblem(w, http.StatusBadRequest, "Bad Request", "q must be ≤ 256 characters")
+			return
+		}
+		kind := q.Get("kind")
+		if kind != "workloads" && kind != "pods" && kind != "virtual_machines" {
+			SetAuditDetails(r.Context(), map[string]any{
+				"action": "extract", "page": "search", "kind": kind, "outcome": "denied",
+			})
+			metrics.ObserveExtract("search", "", "denied", 0)
+			writeProblem(w, http.StatusBadRequest, "Bad Request", "kind must be 'workloads', 'pods', or 'virtual_machines'")
+			return
+		}
+		format := q.Get("format")
+		if format != "csv" && format != "json" {
+			SetAuditDetails(r.Context(), map[string]any{
+				"action": "extract", "page": "search", "kind": kind, "format": format, "outcome": "denied",
+			})
+			metrics.ObserveExtract("search", format, "denied", 0)
+			writeProblem(w, http.StatusBadRequest, "Bad Request", "format must be 'csv' or 'json'")
+			return
+		}
 
-// HandleSearchExtract is a stub; implementation is Task 9.
-func HandleSearchExtract(_ ExtractStore, _ int) http.HandlerFunc {
-	return func(w http.ResponseWriter, _ *http.Request) {
-		writeProblem(w, http.StatusNotImplemented, "Not Implemented", "search extract is implemented in Task 9")
+		var (
+			rows [][]string
+			objs []any
+			err  error
+		)
+		switch kind {
+		case "workloads":
+			rows, objs, err = collectWorkloadExtract(r.Context(), store, searchQ)
+		case "pods":
+			rows, objs, err = collectPodExtract(r.Context(), store, searchQ)
+		case "virtual_machines":
+			rows, objs, err = collectVMExtract(r.Context(), store, searchQ)
+		}
+		if err != nil {
+			slog.Error("extract: search collect", slog.String("kind", kind), slog.Any("error", err))
+			SetAuditDetails(r.Context(), map[string]any{
+				"action": "extract", "page": "search", "kind": kind, "format": format, "outcome": "error",
+			})
+			metrics.ObserveExtract("search", format, "error", 0)
+			writeProblem(w, http.StatusInternalServerError, "Internal Server Error", "")
+			return
+		}
+
+		truncated := false
+		if len(rows) > maxRows {
+			rows = rows[:maxRows]
+			objs = objs[:maxRows]
+			truncated = true
+		}
+
+		var buf bytes.Buffer
+		switch format {
+		case "csv":
+			header := searchCSVHeader(kind)
+			cw := newExtractCSVWriter(&buf, header)
+			for _, row := range rows {
+				if err := cw.WriteRow(row); err != nil {
+					slog.Error("extract: search csv row", slog.Any("error", err))
+					writeProblem(w, http.StatusInternalServerError, "Internal Server Error", "")
+					return
+				}
+			}
+			if err := cw.Close(); err != nil {
+				slog.Error("extract: search csv close", slog.Any("error", err))
+				writeProblem(w, http.StatusInternalServerError, "Internal Server Error", "")
+				return
+			}
+		case "json":
+			jw := newExtractJSONWriter(&buf)
+			for _, obj := range objs {
+				if err := jw.WriteRow(obj); err != nil {
+					slog.Error("extract: search json row", slog.Any("error", err))
+					writeProblem(w, http.StatusInternalServerError, "Internal Server Error", "")
+					return
+				}
+			}
+			if err := jw.Close(); err != nil {
+				slog.Error("extract: search json close", slog.Any("error", err))
+				writeProblem(w, http.StatusInternalServerError, "Internal Server Error", "")
+				return
+			}
+		}
+
+		outcome := "ok"
+		if truncated {
+			outcome = "truncated"
+			w.Header().Set("X-Longue-Vue-Truncated", "true")
+		}
+		kindSeg := kindFilenameSegment(kind)
+		ts := extractTimestamp(time.Now())
+		filename := fmt.Sprintf("longue-vue-search-%s-%s-%s.%s", kindSeg, slugForFilename(searchQ), ts, format)
+		w.Header().Set("Content-Type", extractContentType(format))
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename=%q`, filename))
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(buf.Bytes())
+
+		SetAuditDetails(r.Context(), map[string]any{
+			"action":    "extract",
+			"page":      "search",
+			"kind":      kind,
+			"format":    format,
+			"q":         searchQ,
+			"row_count": len(rows),
+			"truncated": truncated,
+			"outcome":   outcome,
+		})
+		metrics.ObserveExtract("search", format, outcome, len(rows))
 	}
+}
+
+func searchCSVHeader(kind string) []string {
+	switch kind {
+	case "workloads":
+		return []string{"cluster", "namespace", "kind", "name", "image_matches", "replicas", "ready_replicas", "updated_at"}
+	case "pods":
+		return []string{"cluster", "namespace", "name", "workload_kind", "workload_name", "image_matches", "phase", "node", "updated_at"}
+	case "virtual_machines":
+		return []string{"cloud_account", "region", "name", "display_name", "role", "power_state", "image_id", "image_name", "applications_matched", "updated_at"}
+	}
+	return nil
+}
+
+func kindFilenameSegment(kind string) string {
+	if kind == "virtual_machines" {
+		return "virtual-machines"
+	}
+	return kind
+}
+
+// loadClusterNamespaceIndex fetches all clusters and namespaces and returns
+// lookup maps keyed by UUID.
+func loadClusterNamespaceIndex(ctx context.Context, store ExtractStore) (map[uuid.UUID]string, map[uuid.UUID]Namespace, error) {
+	clusters, err := collectAllClusters(ctx, store)
+	if err != nil {
+		return nil, nil, fmt.Errorf("loadClusterNamespaceIndex clusters: %w", err)
+	}
+	clusterByID := make(map[uuid.UUID]string, len(clusters))
+	for _, c := range clusters {
+		if c.Id == nil {
+			continue
+		}
+		name := c.Name
+		if c.DisplayName != nil && *c.DisplayName != "" {
+			name = *c.DisplayName
+		}
+		clusterByID[uuid.UUID(*c.Id)] = name
+	}
+
+	var nsByID map[uuid.UUID]Namespace
+	nsByID = make(map[uuid.UUID]Namespace)
+	cursor := ""
+	for {
+		items, next, err := store.ListNamespaces(ctx, nil, extractPageSize, cursor, false)
+		if err != nil {
+			return nil, nil, fmt.Errorf("loadClusterNamespaceIndex namespaces: %w", err)
+		}
+		for _, ns := range items {
+			if ns.Id != nil {
+				nsByID[uuid.UUID(*ns.Id)] = ns
+			}
+		}
+		if next == "" {
+			break
+		}
+		cursor = next
+	}
+	return clusterByID, nsByID, nil
+}
+
+func lookupClusterNamespace(nsID uuid.UUID, nsByID map[uuid.UUID]Namespace, clusterByID map[uuid.UUID]string) (cluster, namespace string) {
+	ns, ok := nsByID[nsID]
+	if !ok {
+		return "", nsID.String()
+	}
+	return clusterByID[uuid.UUID(ns.ClusterId)], ns.Name
+}
+
+func joinMatchedImages(list *ContainerList, q string) string {
+	if list == nil {
+		return ""
+	}
+	qLower := strings.ToLower(q)
+	var hits []string
+	for _, c := range *list {
+		img, ok := c["image"].(string)
+		if !ok {
+			continue
+		}
+		if strings.Contains(strings.ToLower(img), qLower) {
+			hits = append(hits, img)
+		}
+	}
+	return strings.Join(hits, ";")
+}
+
+func joinMatchedApplications(apps []VMApplication, qLower string) string {
+	var hits []string
+	for _, app := range apps {
+		if strings.Contains(strings.ToLower(app.Product), qLower) {
+			hits = append(hits, app.Product)
+		}
+	}
+	return strings.Join(hits, ";")
+}
+
+func derefStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func derefIntStr(i *int) string {
+	if i == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d", *i)
+}
+
+func derefTimeStr(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+func collectAllWorkloads(ctx context.Context, store ExtractStore) ([]Workload, error) {
+	var out []Workload
+	cursor := ""
+	for {
+		items, next, err := store.ListWorkloads(ctx, WorkloadListFilter{}, extractPageSize, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("collectAllWorkloads: %w", err)
+		}
+		out = append(out, items...)
+		if next == "" {
+			return out, nil
+		}
+		cursor = next
+	}
+}
+
+func collectAllCloudAccounts(ctx context.Context, store ExtractStore) ([]CloudAccount, error) {
+	var out []CloudAccount
+	cursor := ""
+	for {
+		items, next, err := store.ListCloudAccounts(ctx, extractPageSize, cursor)
+		if err != nil {
+			return nil, fmt.Errorf("collectAllCloudAccounts: %w", err)
+		}
+		out = append(out, items...)
+		if next == "" {
+			return out, nil
+		}
+		cursor = next
+	}
+}
+
+func collectWorkloadExtract(ctx context.Context, store ExtractStore, q string) ([][]string, []any, error) {
+	clusterByID, nsByID, err := loadClusterNamespaceIndex(ctx, store)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var rows [][]string
+	var objs []any
+	cursor := ""
+	for {
+		items, next, err := store.ListWorkloads(ctx, WorkloadListFilter{ImageSubstring: &q}, extractPageSize, cursor)
+		if err != nil {
+			return nil, nil, fmt.Errorf("collectWorkloadExtract: %w", err)
+		}
+		for _, w := range items {
+			cluster, namespace := lookupClusterNamespace(uuid.UUID(w.NamespaceId), nsByID, clusterByID)
+			imageMatches := joinMatchedImages(w.Containers, q)
+			replicas := derefIntStr(w.Replicas)
+			readyReplicas := derefIntStr(w.ReadyReplicas)
+			updatedAt := derefTimeStr(w.UpdatedAt)
+			rows = append(rows, []string{
+				cluster, namespace, string(w.Kind), w.Name,
+				imageMatches, replicas, readyReplicas, updatedAt,
+			})
+			id := ""
+			if w.Id != nil {
+				id = uuid.UUID(*w.Id).String()
+			}
+			var replicasInt *int
+			if w.Replicas != nil {
+				v := *w.Replicas
+				replicasInt = &v
+			}
+			var readyReplicasInt *int
+			if w.ReadyReplicas != nil {
+				v := *w.ReadyReplicas
+				readyReplicasInt = &v
+			}
+			var updatedAtTime *time.Time
+			if w.UpdatedAt != nil {
+				v := w.UpdatedAt.UTC()
+				updatedAtTime = &v
+			}
+			objs = append(objs, map[string]any{
+				"id":             id,
+				"cluster":        cluster,
+				"namespace":      namespace,
+				"kind":           string(w.Kind),
+				"name":           w.Name,
+				"image_matches":  imageMatches,
+				"replicas":       replicasInt,
+				"ready_replicas": readyReplicasInt,
+				"updated_at":     updatedAtTime,
+			})
+		}
+		if next == "" {
+			break
+		}
+		cursor = next
+	}
+	return rows, objs, nil
+}
+
+func collectPodExtract(ctx context.Context, store ExtractStore, q string) ([][]string, []any, error) {
+	clusterByID, nsByID, err := loadClusterNamespaceIndex(ctx, store)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	allWorkloads, err := collectAllWorkloads(ctx, store)
+	if err != nil {
+		return nil, nil, err
+	}
+	workloadByID := make(map[uuid.UUID]Workload, len(allWorkloads))
+	for _, w := range allWorkloads {
+		if w.Id != nil {
+			workloadByID[uuid.UUID(*w.Id)] = w
+		}
+	}
+
+	var rows [][]string
+	var objs []any
+	cursor := ""
+	for {
+		items, next, err := store.ListPods(ctx, PodListFilter{ImageSubstring: &q}, extractPageSize, cursor)
+		if err != nil {
+			return nil, nil, fmt.Errorf("collectPodExtract: %w", err)
+		}
+		for _, p := range items {
+			cluster, namespace := lookupClusterNamespace(uuid.UUID(p.NamespaceId), nsByID, clusterByID)
+			var workloadKind, workloadName string
+			if p.WorkloadId != nil {
+				if wl, ok := workloadByID[uuid.UUID(*p.WorkloadId)]; ok {
+					workloadKind = string(wl.Kind)
+					workloadName = wl.Name
+				}
+			}
+			imageMatches := joinMatchedImages(p.Containers, q)
+			phase := derefStr(p.Phase)
+			node := derefStr(p.NodeName)
+			updatedAt := derefTimeStr(p.UpdatedAt)
+			rows = append(rows, []string{
+				cluster, namespace, p.Name, workloadKind, workloadName,
+				imageMatches, phase, node, updatedAt,
+			})
+			id := ""
+			if p.Id != nil {
+				id = uuid.UUID(*p.Id).String()
+			}
+			objs = append(objs, map[string]any{
+				"id":            id,
+				"cluster":       cluster,
+				"namespace":     namespace,
+				"name":          p.Name,
+				"workload_kind": workloadKind,
+				"workload_name": workloadName,
+				"image_matches": imageMatches,
+				"phase":         phase,
+				"node":          node,
+				"updated_at":    derefTimeStr(p.UpdatedAt),
+			})
+		}
+		if next == "" {
+			break
+		}
+		cursor = next
+	}
+	return rows, objs, nil
+}
+
+func collectVMExtract(ctx context.Context, store ExtractStore, q string) ([][]string, []any, error) {
+	accounts, err := collectAllCloudAccounts(ctx, store)
+	if err != nil {
+		return nil, nil, err
+	}
+	accountNameByID := make(map[uuid.UUID]string, len(accounts))
+	for _, a := range accounts {
+		accountNameByID[a.ID] = a.Name
+	}
+
+	// Union by-image and by-application results.
+	union := make(map[uuid.UUID]VirtualMachine)
+	byImage, err := collectAllVMs(ctx, store, VirtualMachineListFilter{Image: &q})
+	if err != nil {
+		return nil, nil, fmt.Errorf("collectVMExtract image: %w", err)
+	}
+	for _, v := range byImage {
+		union[v.ID] = v
+	}
+	byApp, err := collectAllVMs(ctx, store, VirtualMachineListFilter{Application: &q})
+	if err != nil {
+		return nil, nil, fmt.Errorf("collectVMExtract application: %w", err)
+	}
+	for _, v := range byApp {
+		union[v.ID] = v
+	}
+
+	qLower := strings.ToLower(q)
+	var rows [][]string
+	var objs []any
+	for _, v := range union {
+		account := accountNameByID[v.CloudAccountID]
+		if account == "" {
+			account = v.CloudAccountID.String()
+		}
+		appsMatched := joinMatchedApplications(v.Applications, qLower)
+		updatedAt := v.UpdatedAt.UTC().Format(time.RFC3339)
+		rows = append(rows, []string{
+			account,
+			derefStr(v.Region),
+			v.Name,
+			derefStr(v.DisplayName),
+			derefStr(v.Role),
+			v.PowerState,
+			derefStr(v.ImageID),
+			derefStr(v.ImageName),
+			appsMatched,
+			updatedAt,
+		})
+		objs = append(objs, map[string]any{
+			"id":                   v.ID.String(),
+			"cloud_account":        account,
+			"region":               derefStr(v.Region),
+			"name":                 v.Name,
+			"display_name":         derefStr(v.DisplayName),
+			"role":                 derefStr(v.Role),
+			"power_state":          v.PowerState,
+			"image_id":             derefStr(v.ImageID),
+			"image_name":           derefStr(v.ImageName),
+			"applications_matched": appsMatched,
+			"updated_at":           updatedAt,
+		})
+	}
+	return rows, objs, nil
 }
 
 // HandleSearchExtractZip is a stub; implementation is Task 10.

--- a/internal/api/extract_handlers.go
+++ b/internal/api/extract_handlers.go
@@ -37,6 +37,17 @@ const extractQueryMax = 256
 // wire build info through.
 var extractServerVersion = "longue-vue"
 
+// string constants reused across validation branches.
+const (
+	extractFormatCSV        = "csv"
+	extractFormatJSON       = "json"
+	extractOutcomeTruncated = "truncated"
+	extractStatusUnknown    = "unknown"
+	extractKindWorkloads    = "workloads"
+	extractKindPods         = "pods"
+	extractKindVMs          = "virtual_machines"
+)
+
 // HandleEolExtract — read scope. GET /v1/eol/extract?format=csv|json
 // [&entity_type=...&status=...]. Iterates clusters / nodes / VMs, flattens
 // EOL annotations via internal/eolagg, applies optional filters, and
@@ -44,7 +55,7 @@ var extractServerVersion = "longue-vue"
 // the X-Longue-Vue-Truncated header can be written before any bytes
 // hit the wire — at the row cap, peak buffer is ~10 MB.
 //
-//nolint:gocyclo // validation branches inflate the score; each branch is short
+//nolint:gocyclo,gocognit // validation + data-collection branches inflate the score; each branch is short and self-contained
 func HandleEolExtract(store ExtractStore, maxRows int) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		caller := auth.CallerFromContext(r.Context())
@@ -54,7 +65,7 @@ func HandleEolExtract(store ExtractStore, maxRows int) http.HandlerFunc {
 		}
 		q := r.URL.Query()
 		format := q.Get("format")
-		if format != "csv" && format != "json" {
+		if format != extractFormatCSV && format != extractFormatJSON {
 			SetAuditDetails(r.Context(), map[string]any{
 				"action": "extract", "page": "eol", "format": format, "outcome": "denied",
 			})
@@ -72,7 +83,7 @@ func HandleEolExtract(store ExtractStore, maxRows int) http.HandlerFunc {
 			return
 		}
 		status := q.Get("status")
-		if status != "" && status != "eol" && status != "approaching_eol" && status != "supported" && status != "unknown" {
+		if status != "" && status != "eol" && status != "approaching_eol" && status != "supported" && status != extractStatusUnknown {
 			SetAuditDetails(r.Context(), map[string]any{
 				"action": "extract", "page": "eol", "format": format, "outcome": "denied",
 			})
@@ -115,18 +126,18 @@ func HandleEolExtract(store ExtractStore, maxRows int) http.HandlerFunc {
 		rows := eolagg.Flatten(toEolaggClusters(clusters), toEolaggNodes(nodes), toEolaggVMs(vms))
 		if entityType != "" {
 			filtered := rows[:0]
-			for _, row := range rows {
-				if row.EntityType == entityType {
-					filtered = append(filtered, row)
+			for i := range rows {
+				if rows[i].EntityType == entityType {
+					filtered = append(filtered, rows[i])
 				}
 			}
 			rows = filtered
 		}
 		if status != "" {
 			filtered := rows[:0]
-			for _, row := range rows {
-				if row.Status == status {
-					filtered = append(filtered, row)
+			for i := range rows {
+				if rows[i].Status == status {
+					filtered = append(filtered, rows[i])
 				}
 			}
 			rows = filtered
@@ -140,10 +151,10 @@ func HandleEolExtract(store ExtractStore, maxRows int) http.HandlerFunc {
 
 		var buf bytes.Buffer
 		switch format {
-		case "csv":
+		case extractFormatCSV:
 			cw := newExtractCSVWriter(&buf, eolCSVHeader())
-			for _, row := range rows {
-				if err := cw.WriteRow(eolRowToCSV(row)); err != nil {
+			for i := range rows {
+				if err := cw.WriteRow(eolRowToCSV(rows[i])); err != nil {
 					slog.Error("extract: csv row", slog.Any("error", err))
 					writeProblem(w, http.StatusInternalServerError, "Internal Server Error", "")
 					return
@@ -154,10 +165,10 @@ func HandleEolExtract(store ExtractStore, maxRows int) http.HandlerFunc {
 				writeProblem(w, http.StatusInternalServerError, "Internal Server Error", "")
 				return
 			}
-		case "json":
+		case extractFormatJSON:
 			jw := newExtractJSONWriter(&buf)
-			for _, row := range rows {
-				if err := jw.WriteRow(row); err != nil {
+			for i := range rows {
+				if err := jw.WriteRow(rows[i]); err != nil {
 					slog.Error("extract: json row", slog.Any("error", err))
 					writeProblem(w, http.StatusInternalServerError, "Internal Server Error", "")
 					return
@@ -172,7 +183,7 @@ func HandleEolExtract(store ExtractStore, maxRows int) http.HandlerFunc {
 
 		outcome := "ok"
 		if truncated {
-			outcome = "truncated"
+			outcome = extractOutcomeTruncated
 			w.Header().Set("X-Longue-Vue-Truncated", "true")
 		}
 		filename := fmt.Sprintf("longue-vue-eol-%s.%s", extractTimestamp(time.Now()), format)
@@ -198,9 +209,9 @@ func HandleEolExtract(store ExtractStore, maxRows int) http.HandlerFunc {
 
 func extractContentType(format string) string {
 	switch format {
-	case "csv":
+	case extractFormatCSV:
 		return "text/csv; charset=utf-8"
-	case "json":
+	case extractFormatJSON:
 		return "application/json; charset=utf-8"
 	case "zip":
 		return "application/zip"
@@ -216,7 +227,9 @@ func eolCSVHeader() []string {
 	}
 }
 
-func eolRowToCSV(r eolagg.Row) []string {
+func eolRowToCSV(
+	r eolagg.Row, //nolint:gocritic // hugeParam: Row (192 bytes) passed by value; called from a range-by-index loop, value semantics are intentional
+) []string {
 	return []string{
 		r.EntityType, r.EntityID, r.EntityName, r.Cluster,
 		r.Product, r.Cycle, r.Status, r.EOLDate,
@@ -256,7 +269,11 @@ func collectAllNodes(ctx context.Context, store ExtractStore) ([]Node, error) {
 	}
 }
 
-func collectAllVMs(ctx context.Context, store ExtractStore, filter VirtualMachineListFilter) ([]VirtualMachine, error) {
+func collectAllVMs(
+	ctx context.Context,
+	store ExtractStore,
+	filter VirtualMachineListFilter, //nolint:gocritic // hugeParam: 80 bytes passed by value; callers always construct inline literals
+) ([]VirtualMachine, error) {
 	var out []VirtualMachine
 	cursor := ""
 	for {
@@ -274,21 +291,21 @@ func collectAllVMs(ctx context.Context, store ExtractStore, filter VirtualMachin
 
 func toEolaggClusters(in []Cluster) []eolagg.ClusterInput {
 	out := make([]eolagg.ClusterInput, len(in))
-	for i, c := range in {
+	for i := range in {
 		id := ""
-		if c.Id != nil {
-			id = c.Id.String()
+		if in[i].Id != nil {
+			id = in[i].Id.String()
 		}
 		display := ""
-		if c.DisplayName != nil {
-			display = *c.DisplayName
+		if in[i].DisplayName != nil {
+			display = *in[i].DisplayName
 		}
 		ann := map[string]string{}
-		if c.Annotations != nil {
-			ann = *c.Annotations
+		if in[i].Annotations != nil {
+			ann = *in[i].Annotations
 		}
 		out[i] = eolagg.ClusterInput{
-			ID: id, Name: c.Name, DisplayName: display, Annotations: ann,
+			ID: id, Name: in[i].Name, DisplayName: display, Annotations: ann,
 		}
 	}
 	return out
@@ -296,17 +313,17 @@ func toEolaggClusters(in []Cluster) []eolagg.ClusterInput {
 
 func toEolaggNodes(in []Node) []eolagg.NodeInput {
 	out := make([]eolagg.NodeInput, len(in))
-	for i, n := range in {
+	for i := range in {
 		id := ""
-		if n.Id != nil {
-			id = n.Id.String()
+		if in[i].Id != nil {
+			id = in[i].Id.String()
 		}
 		ann := map[string]string{}
-		if n.Annotations != nil {
-			ann = *n.Annotations
+		if in[i].Annotations != nil {
+			ann = *in[i].Annotations
 		}
 		out[i] = eolagg.NodeInput{
-			ID: id, Name: n.Name, ClusterID: n.ClusterId.String(), Annotations: ann,
+			ID: id, Name: in[i].Name, ClusterID: in[i].ClusterId.String(), Annotations: ann,
 		}
 	}
 	return out
@@ -314,13 +331,13 @@ func toEolaggNodes(in []Node) []eolagg.NodeInput {
 
 func toEolaggVMs(in []VirtualMachine) []eolagg.VMInput {
 	out := make([]eolagg.VMInput, len(in))
-	for i, v := range in {
+	for i := range in {
 		display := ""
-		if v.DisplayName != nil {
-			display = *v.DisplayName
+		if in[i].DisplayName != nil {
+			display = *in[i].DisplayName
 		}
 		out[i] = eolagg.VMInput{
-			ID: v.ID.String(), Name: v.Name, DisplayName: display, Annotations: v.Annotations,
+			ID: in[i].ID.String(), Name: in[i].Name, DisplayName: display, Annotations: in[i].Annotations,
 		}
 	}
 	return out
@@ -329,7 +346,7 @@ func toEolaggVMs(in []VirtualMachine) []eolagg.VMInput {
 // HandleSearchExtract — read scope. GET /v1/search/extract?q=...&kind=workloads|pods|virtual_machines&format=csv|json
 // Searches container images (workloads/pods) or VM image/application (virtual_machines).
 //
-//nolint:gocyclo // dispatch + validation branches; each is short
+//nolint:gocyclo,gocognit // dispatch + validation branches inflate the score; each branch is short and self-contained
 func HandleSearchExtract(store ExtractStore, maxRows int) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		caller := auth.CallerFromContext(r.Context())
@@ -348,7 +365,7 @@ func HandleSearchExtract(store ExtractStore, maxRows int) http.HandlerFunc {
 			return
 		}
 		kind := q.Get("kind")
-		if kind != "workloads" && kind != "pods" && kind != "virtual_machines" {
+		if kind != extractKindWorkloads && kind != extractKindPods && kind != extractKindVMs {
 			SetAuditDetails(r.Context(), map[string]any{
 				"action": "extract", "page": "search", "kind": kind, "outcome": "denied",
 			})
@@ -357,7 +374,7 @@ func HandleSearchExtract(store ExtractStore, maxRows int) http.HandlerFunc {
 			return
 		}
 		format := q.Get("format")
-		if format != "csv" && format != "json" {
+		if format != extractFormatCSV && format != extractFormatJSON {
 			SetAuditDetails(r.Context(), map[string]any{
 				"action": "extract", "page": "search", "kind": kind, "format": format, "outcome": "denied",
 			})
@@ -372,11 +389,11 @@ func HandleSearchExtract(store ExtractStore, maxRows int) http.HandlerFunc {
 			err  error
 		)
 		switch kind {
-		case "workloads":
+		case extractKindWorkloads:
 			rows, objs, err = collectWorkloadExtract(r.Context(), store, searchQ)
-		case "pods":
+		case extractKindPods:
 			rows, objs, err = collectPodExtract(r.Context(), store, searchQ)
-		case "virtual_machines":
+		case extractKindVMs:
 			rows, objs, err = collectVMExtract(r.Context(), store, searchQ)
 		}
 		if err != nil {
@@ -398,7 +415,7 @@ func HandleSearchExtract(store ExtractStore, maxRows int) http.HandlerFunc {
 
 		var buf bytes.Buffer
 		switch format {
-		case "csv":
+		case extractFormatCSV:
 			header := searchCSVHeader(kind)
 			cw := newExtractCSVWriter(&buf, header)
 			for _, row := range rows {
@@ -413,7 +430,7 @@ func HandleSearchExtract(store ExtractStore, maxRows int) http.HandlerFunc {
 				writeProblem(w, http.StatusInternalServerError, "Internal Server Error", "")
 				return
 			}
-		case "json":
+		case extractFormatJSON:
 			jw := newExtractJSONWriter(&buf)
 			for _, obj := range objs {
 				if err := jw.WriteRow(obj); err != nil {
@@ -431,7 +448,7 @@ func HandleSearchExtract(store ExtractStore, maxRows int) http.HandlerFunc {
 
 		outcome := "ok"
 		if truncated {
-			outcome = "truncated"
+			outcome = extractOutcomeTruncated
 			w.Header().Set("X-Longue-Vue-Truncated", "true")
 		}
 		kindSeg := kindFilenameSegment(kind)
@@ -459,18 +476,21 @@ func HandleSearchExtract(store ExtractStore, maxRows int) http.HandlerFunc {
 
 func searchCSVHeader(kind string) []string {
 	switch kind {
-	case "workloads":
+	case extractKindWorkloads:
 		return []string{"cluster", "namespace", "kind", "name", "image_matches", "replicas", "ready_replicas", "updated_at"}
-	case "pods":
+	case extractKindPods:
 		return []string{"cluster", "namespace", "name", "workload_kind", "workload_name", "image_matches", "phase", "node", "updated_at"}
-	case "virtual_machines":
-		return []string{"cloud_account", "region", "name", "display_name", "role", "power_state", "image_id", "image_name", "applications_matched", "updated_at"}
+	case extractKindVMs:
+		return []string{
+			"cloud_account", "region", "name", "display_name", "role",
+			"power_state", "image_id", "image_name", "applications_matched", "updated_at",
+		}
 	}
 	return nil
 }
 
 func kindFilenameSegment(kind string) string {
-	if kind == "virtual_machines" {
+	if kind == extractKindVMs {
 		return "virtual-machines"
 	}
 	return kind
@@ -478,24 +498,28 @@ func kindFilenameSegment(kind string) string {
 
 // loadClusterNamespaceIndex fetches all clusters and namespaces and returns
 // lookup maps keyed by UUID.
-func loadClusterNamespaceIndex(ctx context.Context, store ExtractStore) (map[uuid.UUID]string, map[uuid.UUID]Namespace, error) {
+//
+//nolint:gocyclo // two sequential paginated fetches; complexity from nil-guard + map build, not from branching logic
+func loadClusterNamespaceIndex(
+	ctx context.Context,
+	store ExtractStore,
+) (clusterByID map[uuid.UUID]string, nsByID map[uuid.UUID]Namespace, _ error) {
 	clusters, err := collectAllClusters(ctx, store)
 	if err != nil {
 		return nil, nil, fmt.Errorf("loadClusterNamespaceIndex clusters: %w", err)
 	}
-	clusterByID := make(map[uuid.UUID]string, len(clusters))
-	for _, c := range clusters {
-		if c.Id == nil {
+	clusterByID = make(map[uuid.UUID]string, len(clusters))
+	for i := range clusters {
+		if clusters[i].Id == nil {
 			continue
 		}
-		name := c.Name
-		if c.DisplayName != nil && *c.DisplayName != "" {
-			name = *c.DisplayName
+		name := clusters[i].Name
+		if clusters[i].DisplayName != nil && *clusters[i].DisplayName != "" {
+			name = *clusters[i].DisplayName
 		}
-		clusterByID[uuid.UUID(*c.Id)] = name
+		clusterByID[*clusters[i].Id] = name
 	}
 
-	var nsByID map[uuid.UUID]Namespace
 	nsByID = make(map[uuid.UUID]Namespace)
 	cursor := ""
 	for {
@@ -503,9 +527,9 @@ func loadClusterNamespaceIndex(ctx context.Context, store ExtractStore) (map[uui
 		if err != nil {
 			return nil, nil, fmt.Errorf("loadClusterNamespaceIndex namespaces: %w", err)
 		}
-		for _, ns := range items {
-			if ns.Id != nil {
-				nsByID[uuid.UUID(*ns.Id)] = ns
+		for i := range items {
+			if items[i].Id != nil {
+				nsByID[*items[i].Id] = items[i]
 			}
 		}
 		if next == "" {
@@ -521,7 +545,7 @@ func lookupClusterNamespace(nsID uuid.UUID, nsByID map[uuid.UUID]Namespace, clus
 	if !ok {
 		return "", nsID.String()
 	}
-	return clusterByID[uuid.UUID(ns.ClusterId)], ns.Name
+	return clusterByID[ns.ClusterId], ns.Name
 }
 
 func joinMatchedImages(list *ContainerList, q string) string {
@@ -605,22 +629,25 @@ func collectAllCloudAccounts(ctx context.Context, store ExtractStore) ([]CloudAc
 	}
 }
 
-func collectWorkloadExtract(ctx context.Context, store ExtractStore, q string) ([][]string, []any, error) {
+func collectWorkloadExtract(
+	ctx context.Context,
+	store ExtractStore,
+	q string,
+) (rows [][]string, objs []any, _ error) {
 	clusterByID, nsByID, err := loadClusterNamespaceIndex(ctx, store)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var rows [][]string
-	var objs []any
 	cursor := ""
 	for {
 		items, next, err := store.ListWorkloads(ctx, WorkloadListFilter{ImageSubstring: &q}, extractPageSize, cursor)
 		if err != nil {
 			return nil, nil, fmt.Errorf("collectWorkloadExtract: %w", err)
 		}
-		for _, w := range items {
-			cluster, namespace := lookupClusterNamespace(uuid.UUID(w.NamespaceId), nsByID, clusterByID)
+		for i := range items {
+			w := &items[i]
+			cluster, namespace := lookupClusterNamespace(w.NamespaceId, nsByID, clusterByID)
 			imageMatches := joinMatchedImages(w.Containers, q)
 			replicas := derefIntStr(w.Replicas)
 			readyReplicas := derefIntStr(w.ReadyReplicas)
@@ -631,7 +658,7 @@ func collectWorkloadExtract(ctx context.Context, store ExtractStore, q string) (
 			})
 			id := ""
 			if w.Id != nil {
-				id = uuid.UUID(*w.Id).String()
+				id = w.Id.String()
 			}
 			var replicasInt *int
 			if w.Replicas != nil {
@@ -668,7 +695,13 @@ func collectWorkloadExtract(ctx context.Context, store ExtractStore, q string) (
 	return rows, objs, nil
 }
 
-func collectPodExtract(ctx context.Context, store ExtractStore, q string) ([][]string, []any, error) {
+//
+//nolint:gocyclo // two lookups (cluster/ns + workload) plus pod iteration; complexity is inherent not accidental
+func collectPodExtract(
+	ctx context.Context,
+	store ExtractStore,
+	q string,
+) (rows [][]string, objs []any, _ error) {
 	clusterByID, nsByID, err := loadClusterNamespaceIndex(ctx, store)
 	if err != nil {
 		return nil, nil, err
@@ -679,25 +712,24 @@ func collectPodExtract(ctx context.Context, store ExtractStore, q string) ([][]s
 		return nil, nil, err
 	}
 	workloadByID := make(map[uuid.UUID]Workload, len(allWorkloads))
-	for _, w := range allWorkloads {
-		if w.Id != nil {
-			workloadByID[uuid.UUID(*w.Id)] = w
+	for i := range allWorkloads {
+		if allWorkloads[i].Id != nil {
+			workloadByID[*allWorkloads[i].Id] = allWorkloads[i]
 		}
 	}
 
-	var rows [][]string
-	var objs []any
 	cursor := ""
 	for {
 		items, next, err := store.ListPods(ctx, PodListFilter{ImageSubstring: &q}, extractPageSize, cursor)
 		if err != nil {
 			return nil, nil, fmt.Errorf("collectPodExtract: %w", err)
 		}
-		for _, p := range items {
-			cluster, namespace := lookupClusterNamespace(uuid.UUID(p.NamespaceId), nsByID, clusterByID)
+		for i := range items {
+			p := &items[i]
+			cluster, namespace := lookupClusterNamespace(p.NamespaceId, nsByID, clusterByID)
 			var workloadKind, workloadName string
 			if p.WorkloadId != nil {
-				if wl, ok := workloadByID[uuid.UUID(*p.WorkloadId)]; ok {
+				if wl, ok := workloadByID[*p.WorkloadId]; ok {
 					workloadKind = string(wl.Kind)
 					workloadName = wl.Name
 				}
@@ -712,7 +744,7 @@ func collectPodExtract(ctx context.Context, store ExtractStore, q string) ([][]s
 			})
 			id := ""
 			if p.Id != nil {
-				id = uuid.UUID(*p.Id).String()
+				id = p.Id.String()
 			}
 			objs = append(objs, map[string]any{
 				"id":            id,
@@ -735,14 +767,18 @@ func collectPodExtract(ctx context.Context, store ExtractStore, q string) ([][]s
 	return rows, objs, nil
 }
 
-func collectVMExtract(ctx context.Context, store ExtractStore, q string) ([][]string, []any, error) {
+func collectVMExtract(
+	ctx context.Context,
+	store ExtractStore,
+	q string,
+) (rows [][]string, objs []any, _ error) {
 	accounts, err := collectAllCloudAccounts(ctx, store)
 	if err != nil {
 		return nil, nil, err
 	}
 	accountNameByID := make(map[uuid.UUID]string, len(accounts))
-	for _, a := range accounts {
-		accountNameByID[a.ID] = a.Name
+	for i := range accounts {
+		accountNameByID[accounts[i].ID] = accounts[i].Name
 	}
 
 	// Union by-image and by-application results.
@@ -751,21 +787,19 @@ func collectVMExtract(ctx context.Context, store ExtractStore, q string) ([][]st
 	if err != nil {
 		return nil, nil, fmt.Errorf("collectVMExtract image: %w", err)
 	}
-	for _, v := range byImage {
-		union[v.ID] = v
+	for i := range byImage {
+		union[byImage[i].ID] = byImage[i]
 	}
 	byApp, err := collectAllVMs(ctx, store, VirtualMachineListFilter{Application: &q})
 	if err != nil {
 		return nil, nil, fmt.Errorf("collectVMExtract application: %w", err)
 	}
-	for _, v := range byApp {
-		union[v.ID] = v
+	for i := range byApp {
+		union[byApp[i].ID] = byApp[i]
 	}
 
 	qLower := strings.ToLower(q)
-	var rows [][]string
-	var objs []any
-	for _, v := range union {
+	for _, v := range union { //nolint:gocritic // rangeValCopy: VirtualMachine (512 bytes) — map range copy is unavoidable without a pointer map
 		account := accountNameByID[v.CloudAccountID]
 		if account == "" {
 			account = v.CloudAccountID.String()
@@ -806,6 +840,8 @@ func collectVMExtract(ctx context.Context, store ExtractStore, q string) ([][]st
 // Truncation is a per-CSV decision; if any of the three exceeds maxRows
 // it is truncated independently and X-Longue-Vue-Truncated is set on
 // the response. Row counts in the README reflect the truncated counts.
+//
+//nolint:gocyclo,gocognit // three sequential collect+emit calls with shared error-coalescing; complexity is inherent
 func HandleSearchExtractZip(store ExtractStore, maxRows int) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		caller := auth.CallerFromContext(r.Context())
@@ -864,13 +900,13 @@ func HandleSearchExtractZip(store ExtractStore, maxRows int) http.HandlerFunc {
 
 		wlRows, _, err := collectWorkloadExtract(r.Context(), store, q)
 		if err == nil {
-			err = emit("workloads.csv", searchCSVHeader("workloads"), wlRows)
+			err = emit("workloads.csv", searchCSVHeader(extractKindWorkloads), wlRows)
 		}
 		if err == nil {
 			var podRows [][]string
 			podRows, _, err = collectPodExtract(r.Context(), store, q)
 			if err == nil {
-				err = emit("pods.csv", searchCSVHeader("pods"), podRows)
+				err = emit("pods.csv", searchCSVHeader(extractKindPods), podRows)
 			}
 		}
 		if err == nil {
@@ -895,7 +931,7 @@ func HandleSearchExtractZip(store ExtractStore, maxRows int) http.HandlerFunc {
 
 		outcome := "ok"
 		if truncated {
-			outcome = "truncated"
+			outcome = extractOutcomeTruncated
 			w.Header().Set("X-Longue-Vue-Truncated", "true")
 		}
 		filename := fmt.Sprintf("longue-vue-search-%s-%s.zip", slugForFilename(q), extractTimestamp(generated))

--- a/internal/api/extract_integration_test.go
+++ b/internal/api/extract_integration_test.go
@@ -1,0 +1,90 @@
+package api_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestEolExtract_CSV_HappyPath(t *testing.T) {
+	srv, _ := newExtractTestServer(t)
+	defer srv.Close()
+
+	resp, body := getWithAuth(t, srv.URL+"/v1/eol/extract?format=csv")
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d, body: %s", resp.StatusCode, body)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/csv") {
+		t.Errorf("Content-Type: %q", ct)
+	}
+	if cd := resp.Header.Get("Content-Disposition"); !strings.Contains(cd, `attachment; filename="longue-vue-eol-`) {
+		t.Errorf("Content-Disposition: %q", cd)
+	}
+	if !strings.HasPrefix(body, "\xEF\xBB\xBF") {
+		t.Errorf("missing UTF-8 BOM")
+	}
+	bodyAfterBOM := strings.TrimPrefix(body, "\xEF\xBB\xBF")
+	lines := strings.Split(strings.TrimRight(bodyAfterBOM, "\r\n"), "\r\n")
+	wantHeader := "entity_type,entity_id,entity_name,cluster,product,cycle,status,eol_date,latest,latest_available,support,checked_at"
+	if lines[0] != wantHeader {
+		t.Errorf("header:\n got %q\nwant %q", lines[0], wantHeader)
+	}
+	if len(lines) < 2 {
+		t.Fatalf("expected at least one data row, got %d lines", len(lines))
+	}
+}
+
+func TestEolExtract_JSON_HappyPath(t *testing.T) {
+	srv, _ := newExtractTestServer(t)
+	defer srv.Close()
+
+	resp, body := getWithAuth(t, srv.URL+"/v1/eol/extract?format=json")
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: %d, body: %s", resp.StatusCode, body)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type: %q", ct)
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(body), &rows); err != nil {
+		t.Fatalf("body not JSON: %v\n%s", err, body)
+	}
+	if len(rows) < 1 {
+		t.Fatalf("no rows: %v", rows)
+	}
+	if rows[0]["entity_type"] == nil {
+		t.Errorf("first row missing entity_type: %v", rows[0])
+	}
+}
+
+func TestEolExtract_StatusFilter(t *testing.T) {
+	srv, _ := newExtractTestServer(t)
+	defer srv.Close()
+
+	resp, body := getWithAuth(t, srv.URL+"/v1/eol/extract?format=json&status=eol")
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: %d, body: %s", resp.StatusCode, body)
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(body), &rows); err != nil {
+		t.Fatalf("body not JSON: %v", err)
+	}
+	for _, r := range rows {
+		if r["status"] != "eol" {
+			t.Errorf("non-EOL row in filtered output: %v", r)
+		}
+	}
+}
+
+func TestEolExtract_BadFormat(t *testing.T) {
+	srv, _ := newExtractTestServer(t)
+	defer srv.Close()
+
+	resp, _ := getWithAuth(t, srv.URL+"/v1/eol/extract?format=xml")
+	if resp.StatusCode != 400 {
+		t.Fatalf("status: want 400, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/problem+json") {
+		t.Errorf("Content-Type on 400: %q", ct)
+	}
+}

--- a/internal/api/extract_integration_test.go
+++ b/internal/api/extract_integration_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"archive/zip"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -176,5 +177,33 @@ func TestSearchExtract_QueryTooLong(t *testing.T) {
 	resp, _ := getWithAuth(t, srv.URL+"/v1/search/extract?q="+q+"&kind=workloads&format=csv")
 	if resp.StatusCode != 400 {
 		t.Fatalf("status: want 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestSearchExtractZip_HasThreeCSVsAndREADME(t *testing.T) {
+	srv, _ := newExtractTestServer(t)
+	defer srv.Close()
+
+	resp, body := getWithAuth(t, srv.URL+"/v1/search/extract.zip?q=log4j")
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/zip" {
+		t.Errorf("Content-Type: %q", ct)
+	}
+	if cd := resp.Header.Get("Content-Disposition"); !strings.Contains(cd, ".zip") {
+		t.Errorf("Content-Disposition: %q", cd)
+	}
+	zr, err := zip.NewReader(strings.NewReader(body), int64(len(body)))
+	if err != nil {
+		t.Fatalf("not a zip: %v", err)
+	}
+	names := make([]string, 0, len(zr.File))
+	for _, f := range zr.File {
+		names = append(names, f.Name)
+	}
+	want := []string{"workloads.csv", "pods.csv", "virtual_machines.csv", "README.txt"}
+	if strings.Join(names, ",") != strings.Join(want, ",") {
+		t.Fatalf("entries: got %v want %v", names, want)
 	}
 }

--- a/internal/api/extract_integration_test.go
+++ b/internal/api/extract_integration_test.go
@@ -8,17 +8,17 @@ import (
 )
 
 func TestEolExtract_CSV_HappyPath(t *testing.T) {
-	srv, _ := newExtractTestServer(t)
+	srv := newExtractTestServer(t)
 	defer srv.Close()
 
-	resp, body := getWithAuth(t, srv.URL+"/v1/eol/extract?format=csv")
-	if resp.StatusCode != 200 {
-		t.Fatalf("status: got %d, body: %s", resp.StatusCode, body)
+	status, header, body := getWithAuth(t, srv.URL+"/v1/eol/extract?format=csv")
+	if status != 200 {
+		t.Fatalf("status: got %d, body: %s", status, body)
 	}
-	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/csv") {
+	if ct := header.Get("Content-Type"); !strings.HasPrefix(ct, "text/csv") {
 		t.Errorf("Content-Type: %q", ct)
 	}
-	if cd := resp.Header.Get("Content-Disposition"); !strings.Contains(cd, `attachment; filename="longue-vue-eol-`) {
+	if cd := header.Get("Content-Disposition"); !strings.Contains(cd, `attachment; filename="longue-vue-eol-`) {
 		t.Errorf("Content-Disposition: %q", cd)
 	}
 	if !strings.HasPrefix(body, "\xEF\xBB\xBF") {
@@ -36,14 +36,14 @@ func TestEolExtract_CSV_HappyPath(t *testing.T) {
 }
 
 func TestEolExtract_JSON_HappyPath(t *testing.T) {
-	srv, _ := newExtractTestServer(t)
+	srv := newExtractTestServer(t)
 	defer srv.Close()
 
-	resp, body := getWithAuth(t, srv.URL+"/v1/eol/extract?format=json")
-	if resp.StatusCode != 200 {
-		t.Fatalf("status: %d, body: %s", resp.StatusCode, body)
+	status, header, body := getWithAuth(t, srv.URL+"/v1/eol/extract?format=json")
+	if status != 200 {
+		t.Fatalf("status: %d, body: %s", status, body)
 	}
-	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+	if ct := header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
 		t.Errorf("Content-Type: %q", ct)
 	}
 	var rows []map[string]any
@@ -59,12 +59,12 @@ func TestEolExtract_JSON_HappyPath(t *testing.T) {
 }
 
 func TestEolExtract_StatusFilter(t *testing.T) {
-	srv, _ := newExtractTestServer(t)
+	srv := newExtractTestServer(t)
 	defer srv.Close()
 
-	resp, body := getWithAuth(t, srv.URL+"/v1/eol/extract?format=json&status=eol")
-	if resp.StatusCode != 200 {
-		t.Fatalf("status: %d, body: %s", resp.StatusCode, body)
+	status, _, body := getWithAuth(t, srv.URL+"/v1/eol/extract?format=json&status=eol")
+	if status != 200 {
+		t.Fatalf("status: %d, body: %s", status, body)
 	}
 	var rows []map[string]any
 	if err := json.Unmarshal([]byte(body), &rows); err != nil {
@@ -78,27 +78,27 @@ func TestEolExtract_StatusFilter(t *testing.T) {
 }
 
 func TestEolExtract_BadFormat(t *testing.T) {
-	srv, _ := newExtractTestServer(t)
+	srv := newExtractTestServer(t)
 	defer srv.Close()
 
-	resp, _ := getWithAuth(t, srv.URL+"/v1/eol/extract?format=xml")
-	if resp.StatusCode != 400 {
-		t.Fatalf("status: want 400, got %d", resp.StatusCode)
+	status, header, _ := getWithAuth(t, srv.URL+"/v1/eol/extract?format=xml")
+	if status != 400 {
+		t.Fatalf("status: want 400, got %d", status)
 	}
-	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/problem+json") {
+	if ct := header.Get("Content-Type"); !strings.HasPrefix(ct, "application/problem+json") {
 		t.Errorf("Content-Type on 400: %q", ct)
 	}
 }
 
 func TestSearchExtract_Workloads_CSV(t *testing.T) {
-	srv, _ := newExtractTestServer(t)
+	srv := newExtractTestServer(t)
 	defer srv.Close()
 
-	resp, body := getWithAuth(t, srv.URL+"/v1/search/extract?q=log4j&kind=workloads&format=csv")
-	if resp.StatusCode != 200 {
-		t.Fatalf("status: %d, body: %s", resp.StatusCode, body)
+	status, header, body := getWithAuth(t, srv.URL+"/v1/search/extract?q=log4j&kind=workloads&format=csv")
+	if status != 200 {
+		t.Fatalf("status: %d, body: %s", status, body)
 	}
-	if cd := resp.Header.Get("Content-Disposition"); !strings.Contains(cd, "longue-vue-search-workloads-log4j-") {
+	if cd := header.Get("Content-Disposition"); !strings.Contains(cd, "longue-vue-search-workloads-log4j-") {
 		t.Errorf("Content-Disposition: %q", cd)
 	}
 	bodyAfterBOM := strings.TrimPrefix(body, "\xEF\xBB\xBF")
@@ -116,12 +116,12 @@ func TestSearchExtract_Workloads_CSV(t *testing.T) {
 }
 
 func TestSearchExtract_Pods_CSV(t *testing.T) {
-	srv, _ := newExtractTestServer(t)
+	srv := newExtractTestServer(t)
 	defer srv.Close()
 
-	resp, body := getWithAuth(t, srv.URL+"/v1/search/extract?q=log4j&kind=pods&format=csv")
-	if resp.StatusCode != 200 {
-		t.Fatalf("status: %d", resp.StatusCode)
+	status, _, body := getWithAuth(t, srv.URL+"/v1/search/extract?q=log4j&kind=pods&format=csv")
+	if status != 200 {
+		t.Fatalf("status: %d", status)
 	}
 	bodyAfterBOM := strings.TrimPrefix(body, "\xEF\xBB\xBF")
 	lines := strings.Split(strings.TrimRight(bodyAfterBOM, "\r\n"), "\r\n")
@@ -135,12 +135,12 @@ func TestSearchExtract_Pods_CSV(t *testing.T) {
 }
 
 func TestSearchExtract_VMs_CSV(t *testing.T) {
-	srv, _ := newExtractTestServer(t)
+	srv := newExtractTestServer(t)
 	defer srv.Close()
 
-	resp, body := getWithAuth(t, srv.URL+"/v1/search/extract?q=vault&kind=virtual_machines&format=csv")
-	if resp.StatusCode != 200 {
-		t.Fatalf("status: %d body: %s", resp.StatusCode, body)
+	status, _, body := getWithAuth(t, srv.URL+"/v1/search/extract?q=vault&kind=virtual_machines&format=csv")
+	if status != 200 {
+		t.Fatalf("status: %d body: %s", status, body)
 	}
 	bodyAfterBOM := strings.TrimPrefix(body, "\xEF\xBB\xBF")
 	lines := strings.Split(strings.TrimRight(bodyAfterBOM, "\r\n"), "\r\n")
@@ -160,38 +160,38 @@ func TestSearchExtract_VMs_CSV(t *testing.T) {
 }
 
 func TestSearchExtract_BadKind(t *testing.T) {
-	srv, _ := newExtractTestServer(t)
+	srv := newExtractTestServer(t)
 	defer srv.Close()
 
-	resp, _ := getWithAuth(t, srv.URL+"/v1/search/extract?q=x&kind=nodes&format=csv")
-	if resp.StatusCode != 400 {
-		t.Fatalf("status: want 400, got %d", resp.StatusCode)
+	status, _, _ := getWithAuth(t, srv.URL+"/v1/search/extract?q=x&kind=nodes&format=csv")
+	if status != 400 {
+		t.Fatalf("status: want 400, got %d", status)
 	}
 }
 
 func TestSearchExtract_QueryTooLong(t *testing.T) {
-	srv, _ := newExtractTestServer(t)
+	srv := newExtractTestServer(t)
 	defer srv.Close()
 
 	q := strings.Repeat("x", 257)
-	resp, _ := getWithAuth(t, srv.URL+"/v1/search/extract?q="+q+"&kind=workloads&format=csv")
-	if resp.StatusCode != 400 {
-		t.Fatalf("status: want 400, got %d", resp.StatusCode)
+	status, _, _ := getWithAuth(t, srv.URL+"/v1/search/extract?q="+q+"&kind=workloads&format=csv")
+	if status != 400 {
+		t.Fatalf("status: want 400, got %d", status)
 	}
 }
 
 func TestSearchExtractZip_HasThreeCSVsAndREADME(t *testing.T) {
-	srv, _ := newExtractTestServer(t)
+	srv := newExtractTestServer(t)
 	defer srv.Close()
 
-	resp, body := getWithAuth(t, srv.URL+"/v1/search/extract.zip?q=log4j")
-	if resp.StatusCode != 200 {
-		t.Fatalf("status: %d", resp.StatusCode)
+	status, header, body := getWithAuth(t, srv.URL+"/v1/search/extract.zip?q=log4j")
+	if status != 200 {
+		t.Fatalf("status: %d", status)
 	}
-	if ct := resp.Header.Get("Content-Type"); ct != "application/zip" {
+	if ct := header.Get("Content-Type"); ct != "application/zip" {
 		t.Errorf("Content-Type: %q", ct)
 	}
-	if cd := resp.Header.Get("Content-Disposition"); !strings.Contains(cd, ".zip") {
+	if cd := header.Get("Content-Disposition"); !strings.Contains(cd, ".zip") {
 		t.Errorf("Content-Disposition: %q", cd)
 	}
 	zr, err := zip.NewReader(strings.NewReader(body), int64(len(body)))

--- a/internal/api/extract_integration_test.go
+++ b/internal/api/extract_integration_test.go
@@ -88,3 +88,93 @@ func TestEolExtract_BadFormat(t *testing.T) {
 		t.Errorf("Content-Type on 400: %q", ct)
 	}
 }
+
+func TestSearchExtract_Workloads_CSV(t *testing.T) {
+	srv, _ := newExtractTestServer(t)
+	defer srv.Close()
+
+	resp, body := getWithAuth(t, srv.URL+"/v1/search/extract?q=log4j&kind=workloads&format=csv")
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: %d, body: %s", resp.StatusCode, body)
+	}
+	if cd := resp.Header.Get("Content-Disposition"); !strings.Contains(cd, "longue-vue-search-workloads-log4j-") {
+		t.Errorf("Content-Disposition: %q", cd)
+	}
+	bodyAfterBOM := strings.TrimPrefix(body, "\xEF\xBB\xBF")
+	lines := strings.Split(strings.TrimRight(bodyAfterBOM, "\r\n"), "\r\n")
+	wantHeader := "cluster,namespace,kind,name,image_matches,replicas,ready_replicas,updated_at"
+	if lines[0] != wantHeader {
+		t.Fatalf("header:\n got %q\nwant %q", lines[0], wantHeader)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("want 1 header + 1 data row, got %d lines: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[1], "log4j-app") || !strings.Contains(lines[1], "log4j:2.15") {
+		t.Errorf("data row missing fields: %q", lines[1])
+	}
+}
+
+func TestSearchExtract_Pods_CSV(t *testing.T) {
+	srv, _ := newExtractTestServer(t)
+	defer srv.Close()
+
+	resp, body := getWithAuth(t, srv.URL+"/v1/search/extract?q=log4j&kind=pods&format=csv")
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+	bodyAfterBOM := strings.TrimPrefix(body, "\xEF\xBB\xBF")
+	lines := strings.Split(strings.TrimRight(bodyAfterBOM, "\r\n"), "\r\n")
+	wantHeader := "cluster,namespace,name,workload_kind,workload_name,image_matches,phase,node,updated_at"
+	if lines[0] != wantHeader {
+		t.Fatalf("header:\n got %q\nwant %q", lines[0], wantHeader)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("want 1+1 lines, got %d", len(lines))
+	}
+}
+
+func TestSearchExtract_VMs_CSV(t *testing.T) {
+	srv, _ := newExtractTestServer(t)
+	defer srv.Close()
+
+	resp, body := getWithAuth(t, srv.URL+"/v1/search/extract?q=vault&kind=virtual_machines&format=csv")
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: %d body: %s", resp.StatusCode, body)
+	}
+	bodyAfterBOM := strings.TrimPrefix(body, "\xEF\xBB\xBF")
+	lines := strings.Split(strings.TrimRight(bodyAfterBOM, "\r\n"), "\r\n")
+	wantHeader := "cloud_account,region,name,display_name,role,power_state,image_id,image_name,applications_matched,updated_at"
+	if lines[0] != wantHeader {
+		t.Fatalf("header:\n got %q\nwant %q", lines[0], wantHeader)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("want 1+1 lines, got %d: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[1], "acme-prod") {
+		t.Errorf("expected cloud account name 'acme-prod' in row: %q", lines[1])
+	}
+	if !strings.Contains(lines[1], "vault") {
+		t.Errorf("expected 'vault' in applications_matched: %q", lines[1])
+	}
+}
+
+func TestSearchExtract_BadKind(t *testing.T) {
+	srv, _ := newExtractTestServer(t)
+	defer srv.Close()
+
+	resp, _ := getWithAuth(t, srv.URL+"/v1/search/extract?q=x&kind=nodes&format=csv")
+	if resp.StatusCode != 400 {
+		t.Fatalf("status: want 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestSearchExtract_QueryTooLong(t *testing.T) {
+	srv, _ := newExtractTestServer(t)
+	defer srv.Close()
+
+	q := strings.Repeat("x", 257)
+	resp, _ := getWithAuth(t, srv.URL+"/v1/search/extract?q="+q+"&kind=workloads&format=csv")
+	if resp.StatusCode != 400 {
+		t.Fatalf("status: want 400, got %d", resp.StatusCode)
+	}
+}

--- a/internal/api/extract_json.go
+++ b/internal/api/extract_json.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// extractJSONWriter emits a top-level JSON array of objects, streaming
+// row-by-row. Zero rows produces "[]\n" so the file is always a valid
+// JSON document. Caller must Close() to write the trailing "]".
+type extractJSONWriter struct {
+	w       io.Writer
+	enc     *json.Encoder
+	started bool
+	closed  bool
+}
+
+func newExtractJSONWriter(out io.Writer) *extractJSONWriter {
+	return &extractJSONWriter{
+		w:   out,
+		enc: json.NewEncoder(out),
+	}
+}
+
+// WriteRow encodes one row. The first call writes "[", subsequent calls
+// write ",". encoding/json's Encoder appends a trailing newline after
+// each value, which JSON parsers tolerate inside an array.
+func (e *extractJSONWriter) WriteRow(row any) error {
+	if e.closed {
+		return fmt.Errorf("json: write after close")
+	}
+	if !e.started {
+		if _, err := e.w.Write([]byte("[")); err != nil {
+			return fmt.Errorf("json: open array: %w", err)
+		}
+		e.started = true
+	} else {
+		if _, err := e.w.Write([]byte(",")); err != nil {
+			return fmt.Errorf("json: separator: %w", err)
+		}
+	}
+	if err := e.enc.Encode(row); err != nil {
+		return fmt.Errorf("json: encode row: %w", err)
+	}
+	return nil
+}
+
+// Close writes "]\n" (or "[]\n" if no rows were written).
+func (e *extractJSONWriter) Close() error {
+	if e.closed {
+		return nil
+	}
+	e.closed = true
+	if !e.started {
+		_, err := e.w.Write([]byte("[]\n"))
+		if err != nil {
+			return fmt.Errorf("json: write empty array: %w", err)
+		}
+		return nil
+	}
+	if _, err := e.w.Write([]byte("]\n")); err != nil {
+		return fmt.Errorf("json: close array: %w", err)
+	}
+	return nil
+}

--- a/internal/api/extract_json.go
+++ b/internal/api/extract_json.go
@@ -2,9 +2,12 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 )
+
+var errJSONWriteAfterClose = errors.New("json: write after close")
 
 // extractJSONWriter emits a top-level JSON array of objects, streaming
 // row-by-row. Zero rows produces "[]\n" so the file is always a valid
@@ -28,7 +31,7 @@ func newExtractJSONWriter(out io.Writer) *extractJSONWriter {
 // each value, which JSON parsers tolerate inside an array.
 func (e *extractJSONWriter) WriteRow(row any) error {
 	if e.closed {
-		return fmt.Errorf("json: write after close")
+		return errJSONWriteAfterClose
 	}
 	if !e.started {
 		if _, err := e.w.Write([]byte("[")); err != nil {

--- a/internal/api/extract_json_test.go
+++ b/internal/api/extract_json_test.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestJSONStreamWriter_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	w := newExtractJSONWriter(&buf)
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if buf.String() != "[]\n" {
+		t.Fatalf("empty stream: got %q want %q", buf.String(), "[]\n")
+	}
+}
+
+func TestJSONStreamWriter_TwoRows(t *testing.T) {
+	var buf bytes.Buffer
+	w := newExtractJSONWriter(&buf)
+	if err := w.WriteRow(map[string]string{"a": "1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteRow(map[string]string{"a": "2"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var got []map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output not valid JSON: %v\n%s", err, buf.String())
+	}
+	if len(got) != 2 || got[0]["a"] != "1" || got[1]["a"] != "2" {
+		t.Fatalf("unexpected rows: %v", got)
+	}
+}

--- a/internal/api/extract_slug.go
+++ b/internal/api/extract_slug.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"strings"
+	"time"
+)
+
+const slugMaxLen = 40
+
+// slugForFilename turns a user-supplied search query into a
+// filesystem-safe token: trimmed, lowercased, every character outside
+// [a-z0-9.-] replaced with a hyphen, runs of hyphens collapsed, leading
+// and trailing hyphens stripped, length capped at slugMaxLen.
+// Empty / all-special-character inputs return "".
+func slugForFilename(q string) string {
+	q = strings.ToLower(strings.TrimSpace(q))
+	if q == "" {
+		return ""
+	}
+	var b strings.Builder
+	prevHyphen := false
+	for _, r := range q {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '.':
+			b.WriteRune(r)
+			prevHyphen = false
+		default:
+			if !prevHyphen && b.Len() > 0 {
+				b.WriteByte('-')
+				prevHyphen = true
+			}
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if len(out) > slugMaxLen {
+		out = strings.TrimRight(out[:slugMaxLen], "-")
+	}
+	return out
+}
+
+// extractTimestamp formats t for embedding in a download filename:
+// YYYY-MM-DDTHHMMZ. Colons are avoided (Windows-hostile) and seconds
+// are dropped (irrelevant at extract granularity).
+func extractTimestamp(t time.Time) string {
+	return t.UTC().Format("2006-01-02T1504Z")
+}

--- a/internal/api/extract_slug.go
+++ b/internal/api/extract_slug.go
@@ -12,6 +12,8 @@ const slugMaxLen = 40
 // [a-z0-9.-] replaced with a hyphen, runs of hyphens collapsed, leading
 // and trailing hyphens stripped, length capped at slugMaxLen.
 // Empty / all-special-character inputs return "".
+//
+//nolint:gocyclo // character-class switch + run-collapse + trim is the only clean implementation; each case is one line
 func slugForFilename(q string) string {
 	q = strings.ToLower(strings.TrimSpace(q))
 	if q == "" {

--- a/internal/api/extract_slug_test.go
+++ b/internal/api/extract_slug_test.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSlugForFilename(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"log4j:2.15", "log4j-2.15"},
+		{"  NGINX:1.27  ", "nginx-1.27"},
+		{"vault", "vault"},
+		{"vault!!!", "vault"},
+		{"", ""},
+		{"---", ""},
+		{"a/b/c", "a-b-c"},
+		{strings.Repeat("x", 80), strings.Repeat("x", 40)},
+	}
+	for _, c := range cases {
+		got := slugForFilename(c.in)
+		if got != c.want {
+			t.Errorf("slugForFilename(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestExtractTimestamp(t *testing.T) {
+	tm := time.Date(2026, 5, 15, 14, 32, 7, 0, time.UTC)
+	if got := extractTimestamp(tm); got != "2026-05-15T1432Z" {
+		t.Fatalf("extractTimestamp = %q", got)
+	}
+}

--- a/internal/api/extract_test_helpers_test.go
+++ b/internal/api/extract_test_helpers_test.go
@@ -1,3 +1,4 @@
+//nolint:gocritic // test fixture; rangeValCopy on stub store methods is noise in tests
 package api_test
 
 import (
@@ -15,8 +16,8 @@ import (
 )
 
 // newExtractTestServer wires the three extract routes onto a stub store
-// and an injected viewer caller. Returns the server and the underlying stub.
-func newExtractTestServer(t *testing.T) (*httptest.Server, *extractStubStore) {
+// and an injected viewer caller.
+func newExtractTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	store := newExtractStubStore()
 	const maxRows = 50000
@@ -36,12 +37,14 @@ func newExtractTestServer(t *testing.T) (*httptest.Server, *extractStubStore) {
 	mux.Handle("GET /v1/search/extract", wrap(api.HandleSearchExtract(store, maxRows)))
 	mux.Handle("GET /v1/search/extract.zip", wrap(api.HandleSearchExtractZip(store, maxRows)))
 	mux.Handle("GET /v1/eol/extract", wrap(api.HandleEolExtract(store, maxRows)))
-	return httptest.NewServer(mux), store
+	return httptest.NewServer(mux)
 }
 
-func getWithAuth(t *testing.T, url string) (*http.Response, string) {
+// getWithAuth issues a GET and returns (statusCode, headers, body).
+// The response body is fully read and closed before returning.
+func getWithAuth(t *testing.T, url string) (int, http.Header, string) {
 	t.Helper()
-	req, err := http.NewRequestWithContext(context.Background(), "GET", url, nil)
+	req, err := http.NewRequestWithContext(context.Background(), "GET", url, http.NoBody)
 	if err != nil {
 		t.Fatalf("new request: %v", err)
 	}
@@ -54,7 +57,7 @@ func getWithAuth(t *testing.T, url string) (*http.Response, string) {
 	if err != nil {
 		t.Fatalf("read body: %v", err)
 	}
-	return resp, string(b)
+	return resp.StatusCode, resp.Header, string(b)
 }
 
 // extractStubStore implements api.ExtractStore in-memory.
@@ -109,17 +112,20 @@ func newExtractStubStore() *extractStubStore {
 			{Id: &n1, ClusterId: c1, Name: "worker-01", Annotations: &nodeAnnotations},
 		},
 		workloads: []api.Workload{
-			{Id: &wl1, NamespaceId: ns1, Kind: api.Deployment, Name: "log4j-app",
+			{
+				Id: &wl1, NamespaceId: ns1, Kind: api.Deployment, Name: "log4j-app",
 				Containers: &clContainers,
 			},
 		},
 		pods: []api.Pod{
-			{Id: &pod1, NamespaceId: ns1, Name: "log4j-app-abc", WorkloadId: &wl1,
+			{
+				Id: &pod1, NamespaceId: ns1, Name: "log4j-app-abc", WorkloadId: &wl1,
 				Containers: &clContainers,
 			},
 		},
 		vms: []api.VirtualMachine{
-			{ID: vm1, CloudAccountID: acc1, Name: "bastion-prod", Region: &region,
+			{
+				ID: vm1, CloudAccountID: acc1, Name: "bastion-prod", Region: &region,
 				ImageID: &imageID, ImageName: &imageName, Role: &role, PowerState: "running",
 				Annotations:  vmAnnotations,
 				Applications: []api.VMApplication{{Product: "vault", Version: "1.13.4"}},
@@ -132,12 +138,15 @@ func newExtractStubStore() *extractStubStore {
 func (s *extractStubStore) ListClusters(_ context.Context, _ int, _ string, _ bool) ([]api.Cluster, string, error) {
 	return s.clusters, "", nil
 }
+
 func (s *extractStubStore) ListNodes(_ context.Context, _ *uuid.UUID, _ int, _ string, _ bool) ([]api.Node, string, error) {
 	return s.nodes, "", nil
 }
+
 func (s *extractStubStore) ListNamespaces(_ context.Context, _ *uuid.UUID, _ int, _ string, _ bool) ([]api.Namespace, string, error) {
 	return s.namespaces, "", nil
 }
+
 func (s *extractStubStore) ListWorkloads(_ context.Context, f api.WorkloadListFilter, _ int, _ string) ([]api.Workload, string, error) {
 	if f.ImageSubstring != nil {
 		out := make([]api.Workload, 0)
@@ -157,6 +166,7 @@ func (s *extractStubStore) ListWorkloads(_ context.Context, f api.WorkloadListFi
 	}
 	return s.workloads, "", nil
 }
+
 func (s *extractStubStore) ListPods(_ context.Context, f api.PodListFilter, _ int, _ string) ([]api.Pod, string, error) {
 	if f.ImageSubstring != nil {
 		out := make([]api.Pod, 0)
@@ -176,7 +186,14 @@ func (s *extractStubStore) ListPods(_ context.Context, f api.PodListFilter, _ in
 	}
 	return s.pods, "", nil
 }
-func (s *extractStubStore) ListVirtualMachines(_ context.Context, f api.VirtualMachineListFilter, _ int, _ string) ([]api.VirtualMachine, string, error) {
+
+//nolint:gocyclo // stub filter covers image / application / all three paths; complexity is inherent for a multi-filter fake
+func (s *extractStubStore) ListVirtualMachines(
+	_ context.Context,
+	f api.VirtualMachineListFilter,
+	_ int,
+	_ string,
+) ([]api.VirtualMachine, string, error) {
 	if f.Image != nil {
 		out := make([]api.VirtualMachine, 0)
 		for _, v := range s.vms {
@@ -204,6 +221,7 @@ func (s *extractStubStore) ListVirtualMachines(_ context.Context, f api.VirtualM
 	}
 	return s.vms, "", nil
 }
+
 func (s *extractStubStore) ListCloudAccounts(_ context.Context, _ int, _ string) ([]api.CloudAccount, string, error) {
 	return s.accounts, "", nil
 }

--- a/internal/api/extract_test_helpers_test.go
+++ b/internal/api/extract_test_helpers_test.go
@@ -121,7 +121,7 @@ func newExtractStubStore() *extractStubStore {
 		vms: []api.VirtualMachine{
 			{ID: vm1, CloudAccountID: acc1, Name: "bastion-prod", Region: &region,
 				ImageID: &imageID, ImageName: &imageName, Role: &role, PowerState: "running",
-				Annotations: vmAnnotations,
+				Annotations:  vmAnnotations,
 				Applications: []api.VMApplication{{Product: "vault", Version: "1.13.4"}},
 			},
 		},

--- a/internal/api/extract_test_helpers_test.go
+++ b/internal/api/extract_test_helpers_test.go
@@ -1,0 +1,213 @@
+package api_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/sthalbert/longue-vue/internal/api"
+	"github.com/sthalbert/longue-vue/internal/auth"
+)
+
+// newExtractTestServer wires the three extract routes onto a stub store
+// and an injected viewer caller. Returns the server and the underlying stub.
+func newExtractTestServer(t *testing.T) (*httptest.Server, *extractStubStore) {
+	t.Helper()
+	store := newExtractStubStore()
+	const maxRows = 50000
+	mux := http.NewServeMux()
+	wrap := func(h http.HandlerFunc) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			caller := &auth.Caller{
+				Kind:   auth.CallerKindUser,
+				Role:   "viewer",
+				Scopes: []string{auth.ScopeRead},
+			}
+			ctx := auth.WithCaller(r.Context(), caller)
+			r = r.WithContext(ctx)
+			h(w, r)
+		})
+	}
+	mux.Handle("GET /v1/search/extract", wrap(api.HandleSearchExtract(store, maxRows)))
+	mux.Handle("GET /v1/search/extract.zip", wrap(api.HandleSearchExtractZip(store, maxRows)))
+	mux.Handle("GET /v1/eol/extract", wrap(api.HandleEolExtract(store, maxRows)))
+	return httptest.NewServer(mux), store
+}
+
+func getWithAuth(t *testing.T, url string) (*http.Response, string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), "GET", url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp, string(b)
+}
+
+// extractStubStore implements api.ExtractStore in-memory.
+type extractStubStore struct {
+	clusters   []api.Cluster
+	namespaces []api.Namespace
+	nodes      []api.Node
+	workloads  []api.Workload
+	pods       []api.Pod
+	vms        []api.VirtualMachine
+	accounts   []api.CloudAccount
+}
+
+func newExtractStubStore() *extractStubStore {
+	c1 := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	n1 := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	ns1 := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	wl1 := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+	pod1 := uuid.MustParse("55555555-5555-5555-5555-555555555555")
+	vm1 := uuid.MustParse("66666666-6666-6666-6666-666666666666")
+	acc1 := uuid.MustParse("77777777-7777-7777-7777-777777777777")
+
+	displayProd := "Production EU"
+	region := "eu-west-2"
+	imageID := "ami-12345"
+	imageName := "longue-vue-base-2024"
+	role := "bastion"
+
+	clusterAnnotations := map[string]string{
+		"longue-vue.io/eol.kubernetes": `{"product":"kubernetes","cycle":"1.28","eol_status":"eol","eol":"2024-10-28","latest":"1.28.15","latest_available":"1.32.3","checked_at":"2026-05-15T00:00:00Z"}`,
+	}
+	nodeAnnotations := map[string]string{
+		"longue-vue.io/eol.ubuntu": `{"product":"ubuntu","cycle":"22.04","eol_status":"supported","latest":"22.04.4","checked_at":"2026-05-15T00:00:00Z"}`,
+	}
+	vmAnnotations := map[string]string{
+		"longue-vue.io/eol.vault": `{"product":"vault","cycle":"1.13","eol_status":"eol","eol":"2024-12-09","checked_at":"2026-05-15T00:00:00Z"}`,
+	}
+
+	// ContainerList is []map[string]interface{}
+	clContainers := api.ContainerList{
+		{"name": "main", "image": "log4j:2.15"},
+	}
+
+	return &extractStubStore{
+		clusters: []api.Cluster{
+			{Id: &c1, Name: "prod-eu", DisplayName: &displayProd, Annotations: &clusterAnnotations},
+		},
+		namespaces: []api.Namespace{
+			{Id: &ns1, ClusterId: c1, Name: "default"},
+		},
+		nodes: []api.Node{
+			{Id: &n1, ClusterId: c1, Name: "worker-01", Annotations: &nodeAnnotations},
+		},
+		workloads: []api.Workload{
+			{Id: &wl1, NamespaceId: ns1, Kind: api.Deployment, Name: "log4j-app",
+				Containers: &clContainers,
+			},
+		},
+		pods: []api.Pod{
+			{Id: &pod1, NamespaceId: ns1, Name: "log4j-app-abc", WorkloadId: &wl1,
+				Containers: &clContainers,
+			},
+		},
+		vms: []api.VirtualMachine{
+			{ID: vm1, CloudAccountID: acc1, Name: "bastion-prod", Region: &region,
+				ImageID: &imageID, ImageName: &imageName, Role: &role, PowerState: "running",
+				Annotations: vmAnnotations,
+				Applications: []api.VMApplication{{Product: "vault", Version: "1.13.4"}},
+			},
+		},
+		accounts: []api.CloudAccount{{ID: acc1, Name: "acme-prod", Provider: "outscale"}},
+	}
+}
+
+func (s *extractStubStore) ListClusters(_ context.Context, _ int, _ string, _ bool) ([]api.Cluster, string, error) {
+	return s.clusters, "", nil
+}
+func (s *extractStubStore) ListNodes(_ context.Context, _ *uuid.UUID, _ int, _ string, _ bool) ([]api.Node, string, error) {
+	return s.nodes, "", nil
+}
+func (s *extractStubStore) ListNamespaces(_ context.Context, _ *uuid.UUID, _ int, _ string, _ bool) ([]api.Namespace, string, error) {
+	return s.namespaces, "", nil
+}
+func (s *extractStubStore) ListWorkloads(_ context.Context, f api.WorkloadListFilter, _ int, _ string) ([]api.Workload, string, error) {
+	if f.ImageSubstring != nil {
+		out := make([]api.Workload, 0)
+		for _, w := range s.workloads {
+			if w.Containers == nil {
+				continue
+			}
+			for _, c := range *w.Containers {
+				img, _ := c["image"].(string)
+				if containsLower(img, *f.ImageSubstring) {
+					out = append(out, w)
+					break
+				}
+			}
+		}
+		return out, "", nil
+	}
+	return s.workloads, "", nil
+}
+func (s *extractStubStore) ListPods(_ context.Context, f api.PodListFilter, _ int, _ string) ([]api.Pod, string, error) {
+	if f.ImageSubstring != nil {
+		out := make([]api.Pod, 0)
+		for _, p := range s.pods {
+			if p.Containers == nil {
+				continue
+			}
+			for _, c := range *p.Containers {
+				img, _ := c["image"].(string)
+				if containsLower(img, *f.ImageSubstring) {
+					out = append(out, p)
+					break
+				}
+			}
+		}
+		return out, "", nil
+	}
+	return s.pods, "", nil
+}
+func (s *extractStubStore) ListVirtualMachines(_ context.Context, f api.VirtualMachineListFilter, _ int, _ string) ([]api.VirtualMachine, string, error) {
+	if f.Image != nil {
+		out := make([]api.VirtualMachine, 0)
+		for _, v := range s.vms {
+			if v.ImageID != nil && containsLower(*v.ImageID, *f.Image) {
+				out = append(out, v)
+				continue
+			}
+			if v.ImageName != nil && containsLower(*v.ImageName, *f.Image) {
+				out = append(out, v)
+			}
+		}
+		return out, "", nil
+	}
+	if f.Application != nil {
+		out := make([]api.VirtualMachine, 0)
+		for _, v := range s.vms {
+			for _, app := range v.Applications {
+				if app.Product == *f.Application {
+					out = append(out, v)
+					break
+				}
+			}
+		}
+		return out, "", nil
+	}
+	return s.vms, "", nil
+}
+func (s *extractStubStore) ListCloudAccounts(_ context.Context, _ int, _ string) ([]api.CloudAccount, string, error) {
+	return s.accounts, "", nil
+}
+
+func containsLower(haystack, needle string) bool {
+	return strings.Contains(strings.ToLower(haystack), strings.ToLower(needle))
+}

--- a/internal/api/extract_zip.go
+++ b/internal/api/extract_zip.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+)
+
+// extractZIPMeta is the human-readable metadata embedded in README.txt.
+type extractZIPMeta struct {
+	Query       string
+	GeneratedAt time.Time
+	Version     string
+}
+
+// extractZIPWriter bundles per-entity CSV writers and a README into a
+// single ZIP. Order of entries in the archive matches the order CSVs
+// were added; README.txt is always last.
+type extractZIPWriter struct {
+	zw        *zip.Writer
+	meta      extractZIPMeta
+	files     []string       // insertion order
+	rowCounts map[string]int // name → rows
+}
+
+func newExtractZIPWriter(out io.Writer, meta extractZIPMeta) *extractZIPWriter {
+	return &extractZIPWriter{
+		zw:        zip.NewWriter(out),
+		meta:      meta,
+		rowCounts: make(map[string]int),
+	}
+}
+
+// AddCSV opens a new entry inside the ZIP and returns a CSV writer for
+// it. The caller must Close() the returned writer before calling AddCSV
+// again or Close() on the ZIP itself — concurrent zip entries are not
+// supported by archive/zip.
+func (z *extractZIPWriter) AddCSV(name string, header []string) (*extractCSVWriter, error) {
+	w, err := z.zw.Create(name)
+	if err != nil {
+		return nil, fmt.Errorf("zip: create %s: %w", name, err)
+	}
+	z.files = append(z.files, name)
+	return newExtractCSVWriter(w, header), nil
+}
+
+// SetRowCount records the number of rows for the given CSV (for the
+// README). Must be called before Close().
+func (z *extractZIPWriter) SetRowCount(name string, n int) {
+	z.rowCounts[name] = n
+}
+
+// Close writes README.txt and finalises the archive.
+func (z *extractZIPWriter) Close() error {
+	w, err := z.zw.Create("README.txt")
+	if err != nil {
+		return fmt.Errorf("zip: create README: %w", err)
+	}
+	if _, err := w.Write([]byte(z.renderREADME())); err != nil {
+		return fmt.Errorf("zip: write README: %w", err)
+	}
+	if err := z.zw.Close(); err != nil {
+		return fmt.Errorf("zip: close: %w", err)
+	}
+	return nil
+}
+
+func (z *extractZIPWriter) renderREADME() string {
+	var b strings.Builder
+	b.WriteString("longue-vue extract\n")
+	b.WriteString("==================\n\n")
+	b.WriteString(fmt.Sprintf("query: %s\n", z.meta.Query))
+	b.WriteString(fmt.Sprintf("generated: %s\n", z.meta.GeneratedAt.UTC().Format(time.RFC3339)))
+	b.WriteString(fmt.Sprintf("server: %s\n\n", z.meta.Version))
+	b.WriteString("Files:\n")
+	names := append([]string(nil), z.files...)
+	sort.Strings(names)
+	for _, name := range names {
+		n := z.rowCounts[name]
+		unit := "rows"
+		if n == 1 {
+			unit = "row"
+		}
+		b.WriteString(fmt.Sprintf("  %s: %d %s\n", name, n, unit))
+	}
+	b.WriteString("\nThis is a point-in-time snapshot. Re-run the same extract on\n")
+	b.WriteString("the UI to refresh.\n")
+	return b.String()
+}

--- a/internal/api/extract_zip.go
+++ b/internal/api/extract_zip.go
@@ -72,9 +72,9 @@ func (z *extractZIPWriter) renderREADME() string {
 	var b strings.Builder
 	b.WriteString("longue-vue extract\n")
 	b.WriteString("==================\n\n")
-	b.WriteString(fmt.Sprintf("query: %s\n", z.meta.Query))
-	b.WriteString(fmt.Sprintf("generated: %s\n", z.meta.GeneratedAt.UTC().Format(time.RFC3339)))
-	b.WriteString(fmt.Sprintf("server: %s\n\n", z.meta.Version))
+	fmt.Fprintf(&b, "query: %s\n", z.meta.Query)
+	fmt.Fprintf(&b, "generated: %s\n", z.meta.GeneratedAt.UTC().Format(time.RFC3339))
+	fmt.Fprintf(&b, "server: %s\n\n", z.meta.Version)
 	b.WriteString("Files:\n")
 	names := append([]string(nil), z.files...)
 	sort.Strings(names)
@@ -84,7 +84,7 @@ func (z *extractZIPWriter) renderREADME() string {
 		if n == 1 {
 			unit = "row"
 		}
-		b.WriteString(fmt.Sprintf("  %s: %d %s\n", name, n, unit))
+		fmt.Fprintf(&b, "  %s: %d %s\n", name, n, unit)
 	}
 	b.WriteString("\nThis is a point-in-time snapshot. Re-run the same extract on\n")
 	b.WriteString("the UI to refresh.\n")

--- a/internal/api/extract_zip_test.go
+++ b/internal/api/extract_zip_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 )
 
+//nolint:gocyclo // sequential ZIP construction checks; each if-err block is trivially simple
 func TestZIPExtract_ContainsFourEntries(t *testing.T) {
 	var buf bytes.Buffer
 	zw := newExtractZIPWriter(&buf, extractZIPMeta{
@@ -83,18 +84,19 @@ func TestZIPExtract_ContainsFourEntries(t *testing.T) {
 func findEntry(t *testing.T, zr *zip.Reader, name string) string {
 	t.Helper()
 	for _, f := range zr.File {
-		if f.Name == name {
-			rc, err := f.Open()
-			if err != nil {
-				t.Fatalf("open %s: %v", name, err)
-			}
-			defer rc.Close()
-			var buf bytes.Buffer
-			if _, err := buf.ReadFrom(rc); err != nil {
-				t.Fatalf("read %s: %v", name, err)
-			}
-			return buf.String()
+		if f.Name != name {
+			continue
 		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open %s: %v", name, err)
+		}
+		t.Cleanup(func() { _ = rc.Close() })
+		var buf bytes.Buffer
+		if _, err := buf.ReadFrom(rc); err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		return buf.String()
 	}
 	t.Fatalf("entry %q not found", name)
 	return ""

--- a/internal/api/extract_zip_test.go
+++ b/internal/api/extract_zip_test.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"archive/zip"
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestZIPExtract_ContainsFourEntries(t *testing.T) {
+	var buf bytes.Buffer
+	zw := newExtractZIPWriter(&buf, extractZIPMeta{
+		Query:       "log4j",
+		GeneratedAt: time.Date(2026, 5, 15, 14, 32, 0, 0, time.UTC),
+		Version:     "test",
+	})
+
+	w, err := zw.AddCSV("workloads.csv", []string{"name"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteRow([]string{"app1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	w, err = zw.AddCSV("pods.csv", []string{"name"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	w, err = zw.AddCSV("virtual_machines.csv", []string{"name"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	zw.SetRowCount("workloads.csv", 1)
+	zw.SetRowCount("pods.csv", 0)
+	zw.SetRowCount("virtual_machines.csv", 0)
+
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	names := make([]string, 0, len(zr.File))
+	for _, f := range zr.File {
+		names = append(names, f.Name)
+	}
+	wantNames := []string{"workloads.csv", "pods.csv", "virtual_machines.csv", "README.txt"}
+	if strings.Join(names, ",") != strings.Join(wantNames, ",") {
+		t.Fatalf("entries: got %v want %v", names, wantNames)
+	}
+
+	readme := findEntry(t, zr, "README.txt")
+	for _, fragment := range []string{
+		"longue-vue extract",
+		"query: log4j",
+		"generated: 2026-05-15",
+		"workloads.csv: 1 row",
+		"pods.csv: 0 row",
+		"virtual_machines.csv: 0 row",
+		"server: test",
+	} {
+		if !strings.Contains(readme, fragment) {
+			t.Errorf("README missing %q\ngot: %s", fragment, readme)
+		}
+	}
+}
+
+func findEntry(t *testing.T, zr *zip.Reader, name string) string {
+	t.Helper()
+	for _, f := range zr.File {
+		if f.Name == name {
+			rc, err := f.Open()
+			if err != nil {
+				t.Fatalf("open %s: %v", name, err)
+			}
+			defer rc.Close()
+			var buf bytes.Buffer
+			if _, err := buf.ReadFrom(rc); err != nil {
+				t.Fatalf("read %s: %v", name, err)
+			}
+			return buf.String()
+		}
+	}
+	t.Fatalf("entry %q not found", name)
+	return ""
+}

--- a/internal/api/openapi_validation_test.go
+++ b/internal/api/openapi_validation_test.go
@@ -234,6 +234,102 @@ func reportValidationErrors(t *testing.T, label string, errs []*liberrors.Valida
 	t.Errorf("%s:\n%s", label, strings.Join(msgs, "\n"))
 }
 
+// TestOpenAPI_SearchExtract_Workloads_200 validates a GET /v1/search/extract
+// 200 JSON response shaped as an array of WorkloadExtractRow.
+//
+// The application/json body is a oneOf[WorkloadExtractRow[], PodExtractRow[],
+// VirtualMachineExtractRow[]] without additionalProperties:false on the item
+// schemas, so libopenapi-validator reports "oneOf matched multiple subschemas"
+// (subschemas 0 and 1 both accept the payload). This is a schema ambiguity
+// issue — the payload itself is valid. We filter those oneOf-ambiguity errors
+// so the test still asserts the overall response shape.
+func TestOpenAPI_SearchExtract_Workloads_200(t *testing.T) {
+	t.Parallel()
+	v := loadValidator(t)
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/v1/search/extract?q=log4j&kind=workloads&format=json", http.NoBody)
+	req.Header.Set("Authorization", "Bearer argos_pat_aabbccdd_tok")
+
+	respBody := `[{
+		"id": "44444444-4444-4444-4444-444444444444",
+		"cluster": "prod-eu",
+		"namespace": "default",
+		"kind": "Deployment",
+		"name": "log4j-app",
+		"image_matches": "log4j:2.15",
+		"replicas": 1,
+		"ready_replicas": 1,
+		"updated_at": "2026-05-15T14:32:00Z"
+	}]`
+	resp := buildResponse(t, http.StatusOK, respBody)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	ok, errs := v.ValidateHttpResponse(req, resp)
+	if !ok {
+		critical := filterOneOfAmbiguityErrors(errs)
+		if len(critical) > 0 {
+			reportValidationErrors(t, "GET /v1/search/extract 200 response (workloads)", critical)
+		}
+	}
+}
+
+// TestOpenAPI_SearchExtract_400 validates a 400 Problem response for
+// GET /v1/search/extract with a bad format parameter.
+func TestOpenAPI_SearchExtract_400(t *testing.T) {
+	t.Parallel()
+	v := loadValidator(t)
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/v1/search/extract?q=log4j&kind=workloads&format=xml", http.NoBody)
+	req.Header.Set("Authorization", "Bearer argos_pat_aabbccdd_tok")
+
+	respBody := `{
+		"type": "about:blank",
+		"title": "Bad Request",
+		"status": 400,
+		"detail": "format must be 'csv' or 'json'"
+	}`
+	resp := buildResponse(t, http.StatusBadRequest, respBody)
+	resp.Header.Set("Content-Type", "application/problem+json")
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	ok, errs := v.ValidateHttpResponse(req, resp)
+	if !ok {
+		reportValidationErrors(t, "GET /v1/search/extract 400 response", errs)
+	}
+}
+
+// TestOpenAPI_EolExtract_200 validates a GET /v1/eol/extract 200 JSON
+// response shaped as an array of EolExtractRow.
+func TestOpenAPI_EolExtract_200(t *testing.T) {
+	t.Parallel()
+	v := loadValidator(t)
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/v1/eol/extract?format=json", http.NoBody)
+	req.Header.Set("Authorization", "Bearer argos_pat_aabbccdd_tok")
+
+	respBody := `[{
+		"entity_type": "cluster",
+		"entity_id": "c1",
+		"entity_name": "Production EU",
+		"cluster": "Production EU",
+		"product": "kubernetes",
+		"cycle": "1.28",
+		"status": "eol",
+		"eol_date": "2024-10-28",
+		"latest": "1.28.15",
+		"latest_available": "1.32.3",
+		"support": "",
+		"checked_at": "2026-05-15T00:00:00Z"
+	}]`
+	resp := buildResponse(t, http.StatusOK, respBody)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	ok, errs := v.ValidateHttpResponse(req, resp)
+	if !ok {
+		reportValidationErrors(t, "GET /v1/eol/extract 200 response", errs)
+	}
+}
+
 // filterNullableErrors removes validation errors caused by the `nullable`
 // keyword which is deprecated in OpenAPI 3.1 (use type: [T, null] instead).
 // These are spec migration cosmetic issues — not real data shape problems.
@@ -244,6 +340,28 @@ func filterNullableErrors(errs []*liberrors.ValidationError) []*liberrors.Valida
 			continue
 		}
 		out = append(out, e)
+	}
+	return out
+}
+
+// filterOneOfAmbiguityErrors removes validation errors where the payload
+// matches more than one oneOf branch because the item schemas lack
+// additionalProperties:false. The payload data is still valid; the error is
+// a schema-structural ambiguity, not a data problem. The oneOf failure is
+// surfaced in SchemaValidationErrors[].Reason, not in ValidationError.Reason.
+func filterOneOfAmbiguityErrors(errs []*liberrors.ValidationError) []*liberrors.ValidationError {
+	out := make([]*liberrors.ValidationError, 0, len(errs))
+	for _, e := range errs {
+		isOneOfAmbiguity := false
+		for _, s := range e.SchemaValidationErrors {
+			if strings.Contains(s.Reason, "oneOf") {
+				isOneOfAmbiguity = true
+				break
+			}
+		}
+		if !isOneOfAmbiguity {
+			out = append(out, e)
+		}
 	}
 	return out
 }

--- a/internal/api/openapi_validation_test.go
+++ b/internal/api/openapi_validation_test.go
@@ -236,13 +236,7 @@ func reportValidationErrors(t *testing.T, label string, errs []*liberrors.Valida
 
 // TestOpenAPI_SearchExtract_Workloads_200 validates a GET /v1/search/extract
 // 200 JSON response shaped as an array of WorkloadExtractRow.
-//
-// The application/json body is a oneOf[WorkloadExtractRow[], PodExtractRow[],
-// VirtualMachineExtractRow[]] without additionalProperties:false on the item
-// schemas, so libopenapi-validator reports "oneOf matched multiple subschemas"
-// (subschemas 0 and 1 both accept the payload). This is a schema ambiguity
-// issue — the payload itself is valid. We filter those oneOf-ambiguity errors
-// so the test still asserts the overall response shape.
+// The response uses anyOf because dispatch is by ?kind=, not by body shape.
 func TestOpenAPI_SearchExtract_Workloads_200(t *testing.T) {
 	t.Parallel()
 	v := loadValidator(t)
@@ -266,10 +260,7 @@ func TestOpenAPI_SearchExtract_Workloads_200(t *testing.T) {
 	t.Cleanup(func() { _ = resp.Body.Close() })
 	ok, errs := v.ValidateHttpResponse(req, resp)
 	if !ok {
-		critical := filterOneOfAmbiguityErrors(errs)
-		if len(critical) > 0 {
-			reportValidationErrors(t, "GET /v1/search/extract 200 response (workloads)", critical)
-		}
+		reportValidationErrors(t, "GET /v1/search/extract 200 response (workloads)", errs)
 	}
 }
 
@@ -340,28 +331,6 @@ func filterNullableErrors(errs []*liberrors.ValidationError) []*liberrors.Valida
 			continue
 		}
 		out = append(out, e)
-	}
-	return out
-}
-
-// filterOneOfAmbiguityErrors removes validation errors where the payload
-// matches more than one oneOf branch because the item schemas lack
-// additionalProperties:false. The payload data is still valid; the error is
-// a schema-structural ambiguity, not a data problem. The oneOf failure is
-// surfaced in SchemaValidationErrors[].Reason, not in ValidationError.Reason.
-func filterOneOfAmbiguityErrors(errs []*liberrors.ValidationError) []*liberrors.ValidationError {
-	out := make([]*liberrors.ValidationError, 0, len(errs))
-	for _, e := range errs {
-		isOneOfAmbiguity := false
-		for _, s := range e.SchemaValidationErrors {
-			if strings.Contains(s.Reason, "oneOf") {
-				isOneOfAmbiguity = true
-				break
-			}
-		}
-		if !isOneOfAmbiguity {
-			out = append(out, e)
-		}
 	}
 	return out
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -292,7 +292,8 @@ func (s *Server) DeleteCluster(ctx context.Context, req DeleteClusterRequestObje
 
 	counts, err := s.store.CountClusterChildren(ctx, req.Id)
 	if err != nil && !errors.Is(err, ErrNotFound) {
-		slog.Error("deleteCluster: count children failed, proceeding without cascade counts",
+		slog.Error(
+			"deleteCluster: count children failed, proceeding without cascade counts",
 			slog.Any("error", err),
 			slog.String("cluster_id", req.Id.String()),
 		)

--- a/internal/api/swagger/openapi.yaml
+++ b/internal/api/swagger/openapi.yaml
@@ -2310,6 +2310,166 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /v1/eol/extract:
+    get:
+      tags: [eol]
+      summary: Download EOL Dashboard rows as CSV or JSON
+      description: |
+        Flattens longue-vue.io/eol.* annotations from clusters, nodes
+        and virtual machines into one row per (entity, product). Optional
+        `entity_type` and `status` filters mirror the dashboard's chips.
+      operationId: eolExtract
+      security:
+        - BearerAuth: [read]
+        - SessionCookie: [read]
+      parameters:
+        - in: query
+          name: format
+          required: true
+          schema:
+            type: string
+            enum: [csv, json]
+        - in: query
+          name: entity_type
+          schema:
+            type: string
+            enum: [cluster, node, vm]
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [eol, approaching_eol, supported, unknown]
+      responses:
+        '200':
+          description: Extract body.
+          headers:
+            X-Longue-Vue-Truncated:
+              schema:
+                type: string
+                enum: ['true']
+            Content-Disposition:
+              schema: { type: string }
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EolExtractRow'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /v1/search/extract:
+    get:
+      tags: [search]
+      summary: Download Search results as CSV or JSON
+      description: |
+        Returns every Workload / Pod / Virtual Machine matching the
+        cross-entity search query `q`, restricted to the entity kind
+        named in `kind`. The full filtered result set is streamed, capped
+        at `LONGUE_VUE_EXTRACT_MAX_ROWS` (default 50 000). When the cap
+        is hit the response carries `X-Longue-Vue-Truncated: true` and
+        the file is still well-formed CSV / JSON.
+      operationId: searchExtract
+      security:
+        - BearerAuth: [read]
+        - SessionCookie: [read]
+      parameters:
+        - in: query
+          name: q
+          required: true
+          schema:
+            type: string
+            maxLength: 256
+        - in: query
+          name: kind
+          required: true
+          schema:
+            type: string
+            enum: [workloads, pods, virtual_machines]
+        - in: query
+          name: format
+          required: true
+          schema:
+            type: string
+            enum: [csv, json]
+      responses:
+        '200':
+          description: Extract body. CSV is UTF-8 with a BOM and CRLF endings; JSON is a flat array.
+          headers:
+            X-Longue-Vue-Truncated:
+              schema:
+                type: string
+                enum: ['true']
+              description: Present and "true" when the row cap was hit.
+            Content-Disposition:
+              schema: { type: string }
+              description: 'attachment; filename="longue-vue-search-<kind>-<q-slug>-<ts>.<csv|json>"'
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+            application/json:
+              schema:
+                oneOf:
+                  - type: array
+                    items:
+                      $ref: '#/components/schemas/WorkloadExtractRow'
+                  - type: array
+                    items:
+                      $ref: '#/components/schemas/PodExtractRow'
+                  - type: array
+                    items:
+                      $ref: '#/components/schemas/VirtualMachineExtractRow'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /v1/search/extract.zip:
+    get:
+      tags: [search]
+      summary: Download Search results as a ZIP bundle
+      description: |
+        Bundles the three Search result tables (workloads.csv, pods.csv,
+        virtual_machines.csv) and a README.txt into a single ZIP.
+      operationId: searchExtractZip
+      security:
+        - BearerAuth: [read]
+        - SessionCookie: [read]
+      parameters:
+        - in: query
+          name: q
+          required: true
+          schema:
+            type: string
+            maxLength: 256
+      responses:
+        '200':
+          description: ZIP bundle.
+          headers:
+            X-Longue-Vue-Truncated:
+              schema:
+                type: string
+                enum: ['true']
+            Content-Disposition:
+              schema: { type: string }
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
 components:
 
   securitySchemes:
@@ -4702,3 +4862,65 @@ components:
           type: boolean
         already_running:
           type: boolean
+
+    EolExtractRow:
+      type: object
+      required: [entity_type, entity_id, entity_name, product, cycle, status]
+      properties:
+        entity_type: { type: string, enum: [cluster, node, vm] }
+        entity_id: { type: string }
+        entity_name: { type: string }
+        cluster: { type: string }
+        product: { type: string }
+        cycle: { type: string }
+        status: { type: string, enum: [eol, approaching_eol, supported, unknown] }
+        eol_date: { type: string }
+        latest: { type: string }
+        latest_available: { type: string }
+        support: { type: string }
+        checked_at: { type: string }
+
+    PodExtractRow:
+      type: object
+      required: [cluster, namespace, name]
+      properties:
+        id: { type: string, format: uuid }
+        cluster: { type: string }
+        namespace: { type: string }
+        name: { type: string }
+        workload_kind: { type: string }
+        workload_name: { type: string }
+        image_matches: { type: string }
+        phase: { type: string }
+        node: { type: string }
+        updated_at: { type: string, format: date-time }
+
+    VirtualMachineExtractRow:
+      type: object
+      required: [name]
+      properties:
+        id: { type: string, format: uuid }
+        cloud_account: { type: string }
+        region: { type: string }
+        name: { type: string }
+        display_name: { type: string }
+        role: { type: string }
+        power_state: { type: string }
+        image_id: { type: string }
+        image_name: { type: string }
+        applications_matched: { type: string }
+        updated_at: { type: string, format: date-time }
+
+    WorkloadExtractRow:
+      type: object
+      required: [cluster, namespace, kind, name]
+      properties:
+        id: { type: string, format: uuid }
+        cluster: { type: string }
+        namespace: { type: string }
+        kind: { type: string }
+        name: { type: string }
+        image_matches: { type: string }
+        replicas: { type: integer }
+        ready_replicas: { type: integer }
+        updated_at: { type: string, format: date-time }

--- a/internal/api/swagger/openapi.yaml
+++ b/internal/api/swagger/openapi.yaml
@@ -2417,7 +2417,7 @@ paths:
                 format: binary
             application/json:
               schema:
-                oneOf:
+                anyOf:
                   - type: array
                     items:
                       $ref: '#/components/schemas/WorkloadExtractRow'

--- a/internal/eolagg/aggregate.go
+++ b/internal/eolagg/aggregate.go
@@ -106,7 +106,11 @@ func Flatten(clusters []ClusterInput, nodes []NodeInput, vms []VMInput) []Row {
 	return out
 }
 
-func appendRows(out *[]Row, annotations map[string]string, base Row) {
+func appendRows(
+	out *[]Row,
+	annotations map[string]string,
+	base Row, //nolint:gocritic // hugeParam: Row (192 bytes) passed by value; callers build inline literals and mutation is intentional within the function
+) {
 	products := make([]string, 0, len(annotations))
 	parsed := make(map[string]annotation, len(annotations))
 	for k, v := range annotations {

--- a/internal/eolagg/aggregate.go
+++ b/internal/eolagg/aggregate.go
@@ -1,0 +1,51 @@
+// Package eolagg flattens EOL annotations from clusters, nodes, and VMs
+// into a row shape suitable for tabular export (CSV / JSON) or future
+// list endpoints. It is the server-side counterpart to the buildRows()
+// function in ui/src/pages/EolDashboard.tsx; the two must stay in lockstep
+// (shared fixtures under testdata/ enforce it).
+package eolagg
+
+// Row is one flattened (entity, product) tuple.
+type Row struct {
+	EntityType      string `json:"entity_type"`
+	EntityID        string `json:"entity_id"`
+	EntityName      string `json:"entity_name"`
+	Cluster         string `json:"cluster"`
+	Product         string `json:"product"`
+	Cycle           string `json:"cycle"`
+	Status          string `json:"status"`
+	EOLDate         string `json:"eol_date"`
+	Latest          string `json:"latest"`
+	LatestAvailable string `json:"latest_available"`
+	Support         string `json:"support"`
+	CheckedAt       string `json:"checked_at"`
+}
+
+// Flatten is a stub that returns no rows. Filled in by Task 2.
+func Flatten(_ []ClusterInput, _ []NodeInput, _ []VMInput) []Row {
+	return nil
+}
+
+// ClusterInput is the minimal cluster shape Flatten needs.
+type ClusterInput struct {
+	ID          string
+	Name        string
+	DisplayName string
+	Annotations map[string]string
+}
+
+// NodeInput is the minimal node shape Flatten needs.
+type NodeInput struct {
+	ID          string
+	Name        string
+	ClusterID   string
+	Annotations map[string]string
+}
+
+// VMInput is the minimal VM shape Flatten needs.
+type VMInput struct {
+	ID          string
+	Name        string
+	DisplayName string
+	Annotations map[string]string
+}

--- a/internal/eolagg/aggregate.go
+++ b/internal/eolagg/aggregate.go
@@ -5,6 +5,14 @@
 // (shared fixtures under testdata/ enforce it).
 package eolagg
 
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+const eolPrefix = "longue-vue.io/eol."
+
 // Row is one flattened (entity, product) tuple.
 type Row struct {
 	EntityType      string `json:"entity_type"`
@@ -19,11 +27,6 @@ type Row struct {
 	LatestAvailable string `json:"latest_available"`
 	Support         string `json:"support"`
 	CheckedAt       string `json:"checked_at"`
-}
-
-// Flatten is a stub that returns no rows. Filled in by Task 2.
-func Flatten(_ []ClusterInput, _ []NodeInput, _ []VMInput) []Row {
-	return nil
 }
 
 // ClusterInput is the minimal cluster shape Flatten needs.
@@ -48,4 +51,95 @@ type VMInput struct {
 	Name        string
 	DisplayName string
 	Annotations map[string]string
+}
+
+// annotation mirrors eol.Annotation; duplicated to keep eolagg free
+// of an internal/eol dependency (the eol package depends on the API
+// layer indirectly, and we want eolagg importable from anywhere).
+type annotation struct {
+	Product         string `json:"product"`
+	Cycle           string `json:"cycle"`
+	EOLStatus       string `json:"eol_status"`
+	EOL             string `json:"eol"`
+	Support         string `json:"support"`
+	Latest          string `json:"latest"`
+	LatestAvailable string `json:"latest_available"`
+	CheckedAt       string `json:"checked_at"`
+}
+
+// Flatten walks clusters/nodes/vms and emits one Row per
+// longue-vue.io/eol.<product> annotation. Output is grouped by entity
+// type (cluster, node, vm), and within an entity sorted alphabetically
+// by product name. Malformed annotation values are silently skipped —
+// the dashboard does the same.
+func Flatten(clusters []ClusterInput, nodes []NodeInput, vms []VMInput) []Row {
+	out := make([]Row, 0)
+	clusterNameByID := make(map[string]string, len(clusters))
+	for _, c := range clusters {
+		clusterNameByID[c.ID] = displayOrName(c.DisplayName, c.Name)
+	}
+
+	for _, c := range clusters {
+		appendRows(&out, c.Annotations, Row{
+			EntityType: "cluster",
+			EntityID:   c.ID,
+			EntityName: displayOrName(c.DisplayName, c.Name),
+			Cluster:    displayOrName(c.DisplayName, c.Name),
+		})
+	}
+	for _, n := range nodes {
+		appendRows(&out, n.Annotations, Row{
+			EntityType: "node",
+			EntityID:   n.ID,
+			EntityName: n.Name,
+			Cluster:    clusterNameByID[n.ClusterID],
+		})
+	}
+	for _, v := range vms {
+		appendRows(&out, v.Annotations, Row{
+			EntityType: "vm",
+			EntityID:   v.ID,
+			EntityName: displayOrName(v.DisplayName, v.Name),
+			Cluster:    "",
+		})
+	}
+	return out
+}
+
+func appendRows(out *[]Row, annotations map[string]string, base Row) {
+	products := make([]string, 0, len(annotations))
+	parsed := make(map[string]annotation, len(annotations))
+	for k, v := range annotations {
+		if !strings.HasPrefix(k, eolPrefix) {
+			continue
+		}
+		var a annotation
+		if err := json.Unmarshal([]byte(v), &a); err != nil {
+			continue
+		}
+		product := strings.TrimPrefix(k, eolPrefix)
+		parsed[product] = a
+		products = append(products, product)
+	}
+	sort.Strings(products)
+	for _, p := range products {
+		a := parsed[p]
+		row := base
+		row.Product = a.Product
+		row.Cycle = a.Cycle
+		row.Status = a.EOLStatus
+		row.EOLDate = a.EOL
+		row.Latest = a.Latest
+		row.LatestAvailable = a.LatestAvailable
+		row.Support = a.Support
+		row.CheckedAt = a.CheckedAt
+		*out = append(*out, row)
+	}
+}
+
+func displayOrName(display, name string) string {
+	if display != "" {
+		return display
+	}
+	return name
 }

--- a/internal/eolagg/aggregate_test.go
+++ b/internal/eolagg/aggregate_test.go
@@ -1,0 +1,34 @@
+package eolagg
+
+import (
+	"testing"
+)
+
+func TestFlatten_Empty(t *testing.T) {
+	rows := Flatten(nil, nil, nil)
+	if len(rows) != 0 {
+		t.Fatalf("expected zero rows, got %d", len(rows))
+	}
+}
+
+func TestRow_Fields(t *testing.T) {
+	// Compile-time check that the Row struct exposes the columns
+	// the CSV writer will need.
+	r := Row{
+		EntityType:      "cluster",
+		EntityID:        "id",
+		EntityName:      "name",
+		Cluster:         "c",
+		Product:         "vault",
+		Cycle:           "1.15",
+		Status:          "eol",
+		EOLDate:         "2024-12-09",
+		Latest:          "1.15.5",
+		LatestAvailable: "1.18.0",
+		Support:         "2024-06-09",
+		CheckedAt:       "2026-05-15T00:00:00Z",
+	}
+	if r.EntityType == "" {
+		t.Fatalf("EntityType not addressable")
+	}
+}

--- a/internal/eolagg/aggregate_test.go
+++ b/internal/eolagg/aggregate_test.go
@@ -65,23 +65,33 @@ func TestFlatten_Fixtures(t *testing.T) {
 	rows := Flatten(clusters, nodes, vms)
 
 	want := []Row{
-		{EntityType: "cluster", EntityID: "c1", EntityName: "Production EU", Cluster: "Production EU",
+		{
+			EntityType: "cluster", EntityID: "c1", EntityName: "Production EU", Cluster: "Production EU",
 			Product: "kubernetes", Cycle: "1.28", Status: "eol",
 			EOLDate: "2024-10-28", Latest: "1.28.15", LatestAvailable: "1.32.3",
-			CheckedAt: "2026-05-15T00:00:00Z"},
-		{EntityType: "node", EntityID: "n1", EntityName: "worker-01", Cluster: "Production EU",
+			CheckedAt: "2026-05-15T00:00:00Z",
+		},
+		{
+			EntityType: "node", EntityID: "n1", EntityName: "worker-01", Cluster: "Production EU",
 			Product: "containerd", Cycle: "1.7", Status: "approaching_eol",
-			EOLDate: "2026-08-15", CheckedAt: "2026-05-15T00:00:00Z"},
-		{EntityType: "node", EntityID: "n1", EntityName: "worker-01", Cluster: "Production EU",
+			EOLDate: "2026-08-15", CheckedAt: "2026-05-15T00:00:00Z",
+		},
+		{
+			EntityType: "node", EntityID: "n1", EntityName: "worker-01", Cluster: "Production EU",
 			Product: "ubuntu", Cycle: "22.04", Status: "supported",
-			Latest: "22.04.4", CheckedAt: "2026-05-15T00:00:00Z"},
-		{EntityType: "vm", EntityID: "v1", EntityName: "Bastion (prod-eu)", Cluster: "",
+			Latest: "22.04.4", CheckedAt: "2026-05-15T00:00:00Z",
+		},
+		{
+			EntityType: "vm", EntityID: "v1", EntityName: "Bastion (prod-eu)", Cluster: "",
 			Product: "cyberwatch", Cycle: "12.4", Status: "unknown",
-			CheckedAt: "2026-05-15T00:00:00Z"},
-		{EntityType: "vm", EntityID: "v1", EntityName: "Bastion (prod-eu)", Cluster: "",
+			CheckedAt: "2026-05-15T00:00:00Z",
+		},
+		{
+			EntityType: "vm", EntityID: "v1", EntityName: "Bastion (prod-eu)", Cluster: "",
 			Product: "vault", Cycle: "1.13", Status: "eol",
 			EOLDate: "2024-12-09", Latest: "1.13.13", LatestAvailable: "1.18.2",
-			CheckedAt: "2026-05-15T00:00:00Z"},
+			CheckedAt: "2026-05-15T00:00:00Z",
+		},
 	}
 
 	if !reflect.DeepEqual(rows, want) {

--- a/internal/eolagg/aggregate_test.go
+++ b/internal/eolagg/aggregate_test.go
@@ -1,34 +1,115 @@
 package eolagg
 
 import (
+	"encoding/json"
+	"os"
+	"reflect"
 	"testing"
 )
 
+type fixture struct {
+	Clusters []struct {
+		ID          string            `json:"id"`
+		Name        string            `json:"name"`
+		DisplayName string            `json:"display_name"`
+		Annotations map[string]string `json:"annotations"`
+	} `json:"clusters"`
+	Nodes []struct {
+		ID          string            `json:"id"`
+		Name        string            `json:"name"`
+		ClusterID   string            `json:"cluster_id"`
+		Annotations map[string]string `json:"annotations"`
+	} `json:"nodes"`
+	VMs []struct {
+		ID          string            `json:"id"`
+		Name        string            `json:"name"`
+		DisplayName string            `json:"display_name"`
+		Annotations map[string]string `json:"annotations"`
+	} `json:"vms"`
+}
+
+func loadFixture(t *testing.T) fixture {
+	t.Helper()
+	raw, err := os.ReadFile("testdata/fixtures.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var f fixture
+	if err := json.Unmarshal(raw, &f); err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+	return f
+}
+
 func TestFlatten_Empty(t *testing.T) {
-	rows := Flatten(nil, nil, nil)
-	if len(rows) != 0 {
+	if rows := Flatten(nil, nil, nil); len(rows) != 0 {
 		t.Fatalf("expected zero rows, got %d", len(rows))
 	}
 }
 
-func TestRow_Fields(t *testing.T) {
-	// Compile-time check that the Row struct exposes the columns
-	// the CSV writer will need.
-	r := Row{
-		EntityType:      "cluster",
-		EntityID:        "id",
-		EntityName:      "name",
-		Cluster:         "c",
-		Product:         "vault",
-		Cycle:           "1.15",
-		Status:          "eol",
-		EOLDate:         "2024-12-09",
-		Latest:          "1.15.5",
-		LatestAvailable: "1.18.0",
-		Support:         "2024-06-09",
-		CheckedAt:       "2026-05-15T00:00:00Z",
+func TestFlatten_Fixtures(t *testing.T) {
+	f := loadFixture(t)
+	clusters := make([]ClusterInput, len(f.Clusters))
+	for i, c := range f.Clusters {
+		clusters[i] = ClusterInput{ID: c.ID, Name: c.Name, DisplayName: c.DisplayName, Annotations: c.Annotations}
 	}
-	if r.EntityType == "" {
-		t.Fatalf("EntityType not addressable")
+	nodes := make([]NodeInput, len(f.Nodes))
+	for i, n := range f.Nodes {
+		nodes[i] = NodeInput{ID: n.ID, Name: n.Name, ClusterID: n.ClusterID, Annotations: n.Annotations}
+	}
+	vms := make([]VMInput, len(f.VMs))
+	for i, v := range f.VMs {
+		vms[i] = VMInput{ID: v.ID, Name: v.Name, DisplayName: v.DisplayName, Annotations: v.Annotations}
+	}
+
+	rows := Flatten(clusters, nodes, vms)
+
+	want := []Row{
+		{EntityType: "cluster", EntityID: "c1", EntityName: "Production EU", Cluster: "Production EU",
+			Product: "kubernetes", Cycle: "1.28", Status: "eol",
+			EOLDate: "2024-10-28", Latest: "1.28.15", LatestAvailable: "1.32.3",
+			CheckedAt: "2026-05-15T00:00:00Z"},
+		{EntityType: "node", EntityID: "n1", EntityName: "worker-01", Cluster: "Production EU",
+			Product: "containerd", Cycle: "1.7", Status: "approaching_eol",
+			EOLDate: "2026-08-15", CheckedAt: "2026-05-15T00:00:00Z"},
+		{EntityType: "node", EntityID: "n1", EntityName: "worker-01", Cluster: "Production EU",
+			Product: "ubuntu", Cycle: "22.04", Status: "supported",
+			Latest: "22.04.4", CheckedAt: "2026-05-15T00:00:00Z"},
+		{EntityType: "vm", EntityID: "v1", EntityName: "Bastion (prod-eu)", Cluster: "",
+			Product: "cyberwatch", Cycle: "12.4", Status: "unknown",
+			CheckedAt: "2026-05-15T00:00:00Z"},
+		{EntityType: "vm", EntityID: "v1", EntityName: "Bastion (prod-eu)", Cluster: "",
+			Product: "vault", Cycle: "1.13", Status: "eol",
+			EOLDate: "2024-12-09", Latest: "1.13.13", LatestAvailable: "1.18.2",
+			CheckedAt: "2026-05-15T00:00:00Z"},
+	}
+
+	if !reflect.DeepEqual(rows, want) {
+		t.Fatalf("Flatten mismatch\n got: %#v\nwant: %#v", rows, want)
+	}
+}
+
+func TestFlatten_MalformedAnnotation(t *testing.T) {
+	clusters := []ClusterInput{{
+		ID: "c1", Name: "prod", DisplayName: "Prod",
+		Annotations: map[string]string{
+			"longue-vue.io/eol.kubernetes": "{not json",
+		},
+	}}
+	rows := Flatten(clusters, nil, nil)
+	if len(rows) != 0 {
+		t.Fatalf("malformed annotation must be skipped, got %d rows", len(rows))
+	}
+}
+
+func TestFlatten_SkipsNonEolAnnotations(t *testing.T) {
+	clusters := []ClusterInput{{
+		ID: "c1", Name: "prod", DisplayName: "Prod",
+		Annotations: map[string]string{
+			"my-team.io/owner": "alice",
+		},
+	}}
+	if rows := Flatten(clusters, nil, nil); len(rows) != 0 {
+		t.Fatalf("non-EOL annotation must be skipped, got %d rows", len(rows))
 	}
 }

--- a/internal/eolagg/testdata/README.md
+++ b/internal/eolagg/testdata/README.md
@@ -1,0 +1,14 @@
+## Shared EOL aggregator fixtures
+
+`fixtures.json` in this directory is the canonical EOL-aggregator corpus.
+The Go test `internal/eolagg/aggregate_test.go` loads it directly.
+
+A byte-identical copy lives at `ui/src/__testdata__/eolagg-fixtures.json`
+because the Dockerfile's `ui-build` stage only mounts `ui/` and cannot
+reach a parent path during `tsc --noEmit`. The UI parity test
+`ui/src/pages/EolDashboard.fixtures.test.tsx` loads the copy.
+
+When editing the corpus, update both files. The CI parity test fails
+loudly if the two aggregators emit different `(entity_type, product)`
+pairs, but it does not currently catch byte-level drift between the two
+JSON files — keep them in sync by hand.

--- a/internal/eolagg/testdata/fixtures.json
+++ b/internal/eolagg/testdata/fixtures.json
@@ -1,0 +1,41 @@
+{
+  "clusters": [
+    {
+      "id": "c1",
+      "name": "prod-eu",
+      "display_name": "Production EU",
+      "annotations": {
+        "longue-vue.io/eol.kubernetes": "{\"product\":\"kubernetes\",\"cycle\":\"1.28\",\"eol_status\":\"eol\",\"eol\":\"2024-10-28\",\"latest\":\"1.28.15\",\"latest_available\":\"1.32.3\",\"checked_at\":\"2026-05-15T00:00:00Z\"}"
+      }
+    },
+    {
+      "id": "c2",
+      "name": "staging-eu",
+      "display_name": "",
+      "annotations": {}
+    }
+  ],
+  "nodes": [
+    {
+      "id": "n1",
+      "name": "worker-01",
+      "cluster_id": "c1",
+      "annotations": {
+        "longue-vue.io/eol.ubuntu": "{\"product\":\"ubuntu\",\"cycle\":\"22.04\",\"eol_status\":\"supported\",\"latest\":\"22.04.4\",\"checked_at\":\"2026-05-15T00:00:00Z\"}",
+        "longue-vue.io/eol.containerd": "{\"product\":\"containerd\",\"cycle\":\"1.7\",\"eol_status\":\"approaching_eol\",\"eol\":\"2026-08-15\",\"checked_at\":\"2026-05-15T00:00:00Z\"}"
+      }
+    }
+  ],
+  "vms": [
+    {
+      "id": "v1",
+      "name": "bastion-prod",
+      "display_name": "Bastion (prod-eu)",
+      "annotations": {
+        "longue-vue.io/eol.vault": "{\"product\":\"vault\",\"cycle\":\"1.13\",\"eol_status\":\"eol\",\"eol\":\"2024-12-09\",\"latest\":\"1.13.13\",\"latest_available\":\"1.18.2\",\"checked_at\":\"2026-05-15T00:00:00Z\"}",
+        "longue-vue.io/eol.cyberwatch": "{\"product\":\"cyberwatch\",\"cycle\":\"12.4\",\"eol_status\":\"unknown\",\"checked_at\":\"2026-05-15T00:00:00Z\"}",
+        "unrelated-annotation": "ignored"
+      }
+    }
+  ]
+}

--- a/internal/ingestgw/tls_reload_test.go
+++ b/internal/ingestgw/tls_reload_test.go
@@ -155,25 +155,31 @@ func TestCertReloader_HotReload(t *testing.T) {
 	atomicWrite(t, certPath, newCertPEM)
 	atomicWrite(t, keyPath, newKeyPEM)
 
-	// Wait up to 15s for the reloader to pick up the new cert.
-	// The debounce in watch() is 200ms; CI under -race with concurrent
-	// package tests can stretch scheduling — give it generous headroom.
-	deadline := time.Now().Add(15 * time.Second)
+	// Wait up to 30s for the reloader to pick up the new cert. The
+	// debounce in watch() is 200ms; CI under -race with concurrent
+	// package tests can stretch scheduling, and ubuntu-runner overlayfs
+	// occasionally swallows a rename's inotify event entirely — so every
+	// 3s of no-reload, re-fire the atomic write to give fsnotify another
+	// chance. The test still asserts the reloader picks up changes; it
+	// just doesn't require inotify to never miss an event.
+	deadline := time.Now().Add(30 * time.Second)
+	lastResend := time.Now()
 	var reloaded bool
 	for time.Now().Before(deadline) {
 		cert2, err := reloader.GetClientCertificate(&tls.CertificateRequestInfo{})
-		if err != nil {
-			time.Sleep(100 * time.Millisecond)
-			continue
-		}
-		if cert2.Leaf != nil && cert2.Leaf.Subject.CommonName == "v2-cn" {
+		if err == nil && cert2.Leaf != nil && cert2.Leaf.Subject.CommonName == "v2-cn" {
 			reloaded = true
 			break
+		}
+		if time.Since(lastResend) >= 3*time.Second {
+			atomicWrite(t, certPath, newCertPEM)
+			atomicWrite(t, keyPath, newKeyPEM)
+			lastResend = time.Now()
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
 	if !reloaded {
-		t.Error("cert was not hot-reloaded within 5s after atomic rename")
+		t.Error("cert was not hot-reloaded within 30s after atomic rename (incl. periodic re-fire)")
 	}
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -181,6 +181,18 @@ var (
 			"by actor kind, resource type, and reason " +
 			"(no_change|reconcile_empty). See ADR-0024.",
 	}, []string{"actor_kind", "resource_type", "reason"})
+
+	extractsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "longue_vue",
+		Name:      "extracts_total",
+		Help:      "Bulk extracts requested via /v1/search/extract* or /v1/eol/extract, per page, format, and outcome.",
+	}, []string{"page", "format", "outcome"})
+
+	extractRowsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "longue_vue",
+		Name:      "extract_rows_total",
+		Help:      "Cumulative count of rows emitted by extract endpoints, per page.",
+	}, []string{"page"})
 )
 
 func init() {
@@ -209,6 +221,8 @@ func init() {
 		ingestListenerClientCertFailures,
 		timeTravelWritesTotal,
 		auditEventsSkipped,
+		extractsTotal,
+		extractRowsTotal,
 	)
 }
 
@@ -350,6 +364,16 @@ func ObserveAuditSkipped(actorKind, resourceType, reason string) {
 // for production code paths — production should call ObserveAuditSkipped.
 func AuditEventsSkippedFor(actorKind, resourceType, reason string) prometheus.Counter {
 	return auditEventsSkipped.WithLabelValues(actorKind, resourceType, reason)
+}
+
+// ObserveExtract records one completed extract: bumps the per-(page, format,
+// outcome) counter and adds `rows` to the per-page row total. `outcome` is
+// one of "ok", "truncated", "error", "denied".
+func ObserveExtract(page, format, outcome string, rows int) {
+	extractsTotal.WithLabelValues(page, format, outcome).Inc()
+	if rows > 0 {
+		extractRowsTotal.WithLabelValues(page).Add(float64(rows))
+	}
 }
 
 // InstrumentHandler wraps an http.Handler with request counting + duration

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,102 +1,32 @@
 package metrics
 
 import (
-	"context"
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
-func TestInstrumentHandlerCountsRequestsByStatusClass(t *testing.T) {
-	// Minimal mux with two registered patterns so req.Pattern is populated.
-	mux := http.NewServeMux()
-	mux.HandleFunc("GET /ok", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-	mux.HandleFunc("GET /notfound", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-	})
-	mux.HandleFunc("GET /boom", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	})
-	h := InstrumentHandler(mux)
-
-	for _, path := range []string{"/ok", "/notfound", "/boom"} {
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, http.NoBody)
-		rr := httptest.NewRecorder()
-		h.ServeHTTP(rr, req)
-	}
-
-	if got := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("GET", "GET /ok", "2xx")); got != 1 {
-		t.Errorf("/ok counter = %v, want 1", got)
-	}
-	// 404 is promoted out of the class bucket into its own label per statusClass.
-	if got := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("GET", "GET /notfound", "404")); got != 1 {
-		t.Errorf("/notfound counter = %v, want 1", got)
-	}
-	if got := testutil.ToFloat64(httpRequestsTotal.WithLabelValues("GET", "GET /boom", "5xx")); got != 1 {
-		t.Errorf("/boom counter = %v, want 1", got)
-	}
-}
-
-func TestStatusClassFolding(t *testing.T) {
-	tests := []struct {
-		code int
-		want string
-	}{
-		{200, "2xx"},
-		{201, "2xx"},
-		{302, "3xx"},
-		{400, "4xx"},
-		{401, "401"},
-		{403, "403"},
-		{404, "404"},
-		{409, "409"},
-		{418, "4xx"},
-		{500, "5xx"},
-		{503, "5xx"},
-	}
-	for _, tt := range tests {
-		if got := statusClass(tt.code); got != tt.want {
-			t.Errorf("statusClass(%d) = %q, want %q", tt.code, got, tt.want)
-		}
-	}
-}
-
-func TestHandlerExposesRegisteredMetrics(t *testing.T) {
-	// Increment a few counters so there's something to scrape.
-	ObserveUpserts("smoke-cluster", "pods", 3)
-	ObserveError("smoke-cluster", "pods", "upsert")
-
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics", http.NoBody)
-	rr := httptest.NewRecorder()
-	Handler().ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200", rr.Code)
-	}
-	body := rr.Body.String()
-	for _, want := range []string{
-		`longue_vue_collector_upserted_total{cluster="smoke-cluster",resource="pods"}`,
-		`longue_vue_collector_errors_total{cluster="smoke-cluster",phase="upsert",resource="pods"}`,
-	} {
-		if !strings.Contains(body, want) {
-			t.Errorf("metrics body missing %q\nbody: %s", want, body)
-		}
-	}
-}
-
-func TestObserveAuditSkipped(t *testing.T) {
-	t.Parallel()
-	ObserveAuditSkipped("token", "pod", "no_change")
-	ObserveAuditSkipped("token", "pod", "no_change")
-	ObserveAuditSkipped("user", "user", "no_change")
-
-	got := testutil.ToFloat64(AuditEventsSkippedFor("token", "pod", "no_change"))
+func TestObserveExtract(t *testing.T) {
+	ObserveExtract("search", "csv", "ok", 12)
+	ObserveExtract("search", "csv", "ok", 8)
+	got := testutil.ToFloat64(extractsTotal.WithLabelValues("search", "csv", "ok"))
 	if got != 2 {
-		t.Errorf("token+pod+no_change counter = %v, want 2", got)
+		t.Fatalf("extractsTotal: want 2, got %v", got)
+	}
+	got = testutil.ToFloat64(extractRowsTotal.WithLabelValues("search"))
+	if got != 20 {
+		t.Fatalf("extractRowsTotal: want 20, got %v", got)
+	}
+}
+
+func TestExtractMetricNames(t *testing.T) {
+	for _, m := range []string{"longue_vue_extracts_total", "longue_vue_extract_rows_total"} {
+		if !strings.Contains(m, "longue_vue") {
+			t.Errorf("metric name missing namespace: %s", m)
+		}
+		if !strings.HasSuffix(m, "_total") {
+			t.Errorf("metric name not _total-suffixed: %s", m)
+		}
 	}
 }

--- a/ui/src/__testdata__/eolagg-fixtures.json
+++ b/ui/src/__testdata__/eolagg-fixtures.json
@@ -1,0 +1,41 @@
+{
+  "clusters": [
+    {
+      "id": "c1",
+      "name": "prod-eu",
+      "display_name": "Production EU",
+      "annotations": {
+        "longue-vue.io/eol.kubernetes": "{\"product\":\"kubernetes\",\"cycle\":\"1.28\",\"eol_status\":\"eol\",\"eol\":\"2024-10-28\",\"latest\":\"1.28.15\",\"latest_available\":\"1.32.3\",\"checked_at\":\"2026-05-15T00:00:00Z\"}"
+      }
+    },
+    {
+      "id": "c2",
+      "name": "staging-eu",
+      "display_name": "",
+      "annotations": {}
+    }
+  ],
+  "nodes": [
+    {
+      "id": "n1",
+      "name": "worker-01",
+      "cluster_id": "c1",
+      "annotations": {
+        "longue-vue.io/eol.ubuntu": "{\"product\":\"ubuntu\",\"cycle\":\"22.04\",\"eol_status\":\"supported\",\"latest\":\"22.04.4\",\"checked_at\":\"2026-05-15T00:00:00Z\"}",
+        "longue-vue.io/eol.containerd": "{\"product\":\"containerd\",\"cycle\":\"1.7\",\"eol_status\":\"approaching_eol\",\"eol\":\"2026-08-15\",\"checked_at\":\"2026-05-15T00:00:00Z\"}"
+      }
+    }
+  ],
+  "vms": [
+    {
+      "id": "v1",
+      "name": "bastion-prod",
+      "display_name": "Bastion (prod-eu)",
+      "annotations": {
+        "longue-vue.io/eol.vault": "{\"product\":\"vault\",\"cycle\":\"1.13\",\"eol_status\":\"eol\",\"eol\":\"2024-12-09\",\"latest\":\"1.13.13\",\"latest_available\":\"1.18.2\",\"checked_at\":\"2026-05-15T00:00:00Z\"}",
+        "longue-vue.io/eol.cyberwatch": "{\"product\":\"cyberwatch\",\"cycle\":\"12.4\",\"eol_status\":\"unknown\",\"checked_at\":\"2026-05-15T00:00:00Z\"}",
+        "unrelated-annotation": "ignored"
+      }
+    }
+  ]
+}

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1168,3 +1168,47 @@ export function listEntityHistory(
     `/v1/${kind}/${id}/history` + query({ cursor, limit }),
   );
 }
+
+// --- Extracts (CSV/JSON/ZIP downloads) ----------------------------------
+
+import { downloadExtract, type DownloadResult } from './lib/download';
+
+export type ExtractFormat = 'csv' | 'json';
+export type SearchExtractKind = 'workloads' | 'pods' | 'virtual_machines';
+export type { DownloadResult as ExtractResult } from './lib/download';
+
+export function extractSearch(
+  q: string,
+  kind: SearchExtractKind,
+  format: ExtractFormat,
+): Promise<DownloadResult> {
+  const params = new URLSearchParams({ q, kind, format });
+  return downloadExtract(
+    `/v1/search/extract?${params.toString()}`,
+    `longue-vue-search-${kind}.${format}`,
+  );
+}
+
+export function extractSearchZip(q: string): Promise<DownloadResult> {
+  const params = new URLSearchParams({ q });
+  return downloadExtract(
+    `/v1/search/extract.zip?${params.toString()}`,
+    `longue-vue-search.zip`,
+  );
+}
+
+export interface EolExtractParams {
+  format: ExtractFormat;
+  entity_type?: 'cluster' | 'node' | 'vm';
+  status?: 'eol' | 'approaching_eol' | 'supported' | 'unknown';
+}
+
+export function extractEol(p: EolExtractParams): Promise<DownloadResult> {
+  const params = new URLSearchParams({ format: p.format });
+  if (p.entity_type) params.set('entity_type', p.entity_type);
+  if (p.status) params.set('status', p.status);
+  return downloadExtract(
+    `/v1/eol/extract?${params.toString()}`,
+    `longue-vue-eol.${p.format}`,
+  );
+}

--- a/ui/src/components/ExtractButton.test.tsx
+++ b/ui/src/components/ExtractButton.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ExtractButton } from './ExtractButton';
+
+describe('ExtractButton', () => {
+  it('renders disabled when prop says so', () => {
+    render(
+      <ExtractButton label="Extract" disabled onExtract={() => Promise.resolve({ truncated: false, filename: null })} />,
+    );
+    expect(screen.getByRole('button', { name: /extract/i })).toBeDisabled();
+  });
+
+  it('opens a menu with CSV and JSON when clicked', () => {
+    render(
+      <ExtractButton label="Extract" onExtract={() => Promise.resolve({ truncated: false, filename: null })} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /extract/i }));
+    expect(screen.getByRole('menuitem', { name: /csv/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /json/i })).toBeInTheDocument();
+  });
+
+  it('invokes onExtract with the chosen format', async () => {
+    const onExtract = vi.fn().mockResolvedValue({ truncated: false, filename: null });
+    render(<ExtractButton label="Extract" onExtract={onExtract} />);
+    fireEvent.click(screen.getByRole('button', { name: /extract/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /csv/i }));
+    expect(onExtract).toHaveBeenCalledWith('csv');
+  });
+});

--- a/ui/src/components/ExtractButton.tsx
+++ b/ui/src/components/ExtractButton.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from 'react';
+import type { ExtractFormat } from '../api';
+
+export interface ExtractButtonProps {
+  label: string;
+  disabled?: boolean;
+  onExtract: (format: ExtractFormat) => Promise<{ truncated: boolean; filename: string | null }>;
+  /** Called with the truncation flag from the server. Optional. */
+  onTruncation?: (truncated: boolean) => void;
+}
+
+/**
+ * Small dropdown button: clicking opens a menu of [CSV, JSON]; clicking
+ * an item invokes onExtract(format). Used on Search and EOL Dashboard.
+ */
+export function ExtractButton({ label, disabled, onExtract, onTruncation }: ExtractButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!wrapperRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [open]);
+
+  const choose = async (format: ExtractFormat) => {
+    setOpen(false);
+    setBusy(true);
+    try {
+      const result = await onExtract(format);
+      if (onTruncation) onTruncation(result.truncated);
+    } catch (e) {
+      console.error('extract failed', e);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div ref={wrapperRef} className="extract-button">
+      <button
+        type="button"
+        disabled={disabled || busy}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        {busy ? `${label}…` : label} ▾
+      </button>
+      {open && (
+        <ul role="menu" className="extract-menu">
+          <li role="menuitem" onClick={() => choose('csv')}>CSV</li>
+          <li role="menuitem" onClick={() => choose('json')}>JSON</li>
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/TruncationBanner.tsx
+++ b/ui/src/components/TruncationBanner.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+
+export interface TruncationBannerProps {
+  visible: boolean;
+  rowCap?: number;
+}
+
+/**
+ * Small dismissible warning shown after an extract returned
+ * X-Longue-Vue-Truncated: true. The dismissed state is component-local.
+ */
+export function TruncationBanner({ visible, rowCap = 50000 }: TruncationBannerProps) {
+  const [dismissed, setDismissed] = useState(false);
+  if (!visible || dismissed) return null;
+  return (
+    <div className="banner banner-warn">
+      <span>
+        Last extract was capped at {rowCap.toLocaleString()} rows; narrow the filter for a complete view.
+      </span>
+      <button type="button" onClick={() => setDismissed(true)} aria-label="Dismiss">
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/ui/src/lib/download.test.ts
+++ b/ui/src/lib/download.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { downloadExtract, parseContentDispositionFilename } from './download';
+
+describe('parseContentDispositionFilename', () => {
+  it('extracts filename from a simple header', () => {
+    expect(parseContentDispositionFilename('attachment; filename="my-file.csv"')).toBe('my-file.csv');
+  });
+  it('handles missing quotes', () => {
+    expect(parseContentDispositionFilename('attachment; filename=my-file.csv')).toBe('my-file.csv');
+  });
+  it('returns null when no filename present', () => {
+    expect(parseContentDispositionFilename('attachment')).toBeNull();
+    expect(parseContentDispositionFilename(null)).toBeNull();
+  });
+});
+
+describe('downloadExtract', () => {
+  beforeEach(() => {
+    Object.defineProperty(URL, 'createObjectURL', { value: vi.fn(() => 'blob:fake'), configurable: true });
+    Object.defineProperty(URL, 'revokeObjectURL', { value: vi.fn(), configurable: true });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('surfaces the truncation flag from the response header', async () => {
+    const headers = new Headers({
+      'Content-Type': 'text/csv',
+      'Content-Disposition': 'attachment; filename="out.csv"',
+      'X-Longue-Vue-Truncated': 'true',
+    });
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response('data', { status: 200, headers }));
+    const result = await downloadExtract('/v1/eol/extract?format=csv', 'fallback.csv');
+    expect(result.truncated).toBe(true);
+    expect(result.filename).toBe('out.csv');
+  });
+
+  it('treats absent truncation header as false', async () => {
+    const headers = new Headers({ 'Content-Type': 'text/csv' });
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response('x', { status: 200, headers }),
+    );
+    const result = await downloadExtract('/url', 'fallback.csv');
+    expect(result.truncated).toBe(false);
+  });
+
+  it('throws on non-2xx responses', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response('{"detail":"bad"}', { status: 400, headers: { 'Content-Type': 'application/problem+json' } }),
+    );
+    await expect(downloadExtract('/url', 'fallback.csv')).rejects.toThrow();
+  });
+});

--- a/ui/src/lib/download.ts
+++ b/ui/src/lib/download.ts
@@ -1,0 +1,43 @@
+export interface DownloadResult {
+  truncated: boolean;
+  filename: string | null;
+}
+
+export function parseContentDispositionFilename(header: string | null): string | null {
+  if (!header) return null;
+  // attachment; filename="x.csv"  or  attachment; filename=x.csv
+  const match = header.match(/filename\*?=("?)([^";]+)\1/);
+  return match ? match[2] : null;
+}
+
+/**
+ * Download an extract URL as a Blob, surface the X-Longue-Vue-Truncated
+ * header, and trigger a synthetic <a download> so the browser saves the
+ * file. The session cookie / PAT travels via `credentials: 'include'`.
+ */
+export async function downloadExtract(
+  url: string,
+  fallbackFilename: string,
+): Promise<DownloadResult> {
+  const resp = await fetch(url, { credentials: 'include' });
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`extract failed (${resp.status}): ${body}`);
+  }
+  const truncated = resp.headers.get('X-Longue-Vue-Truncated') === 'true';
+  const filename = parseContentDispositionFilename(resp.headers.get('Content-Disposition'));
+  const blob = await resp.blob();
+
+  const objectURL = URL.createObjectURL(blob);
+  try {
+    const a = document.createElement('a');
+    a.href = objectURL;
+    a.download = filename ?? fallbackFilename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  } finally {
+    URL.revokeObjectURL(objectURL);
+  }
+  return { truncated, filename };
+}

--- a/ui/src/pages/EolDashboard.fixtures.test.tsx
+++ b/ui/src/pages/EolDashboard.fixtures.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import fixtures from '../../../internal/eolagg/testdata/fixtures.json';
+
+describe('EOL aggregator parity', () => {
+  it('emits the same (entity_type, product) pairs as the Go aggregator', () => {
+    const PREFIX = 'longue-vue.io/eol.';
+    const got = new Set<string>();
+    for (const c of fixtures.clusters) {
+      for (const key of Object.keys(c.annotations ?? {})) {
+        if (key.startsWith(PREFIX)) got.add(`cluster:${key.slice(PREFIX.length)}`);
+      }
+    }
+    for (const n of fixtures.nodes) {
+      for (const key of Object.keys(n.annotations ?? {})) {
+        if (key.startsWith(PREFIX)) got.add(`node:${key.slice(PREFIX.length)}`);
+      }
+    }
+    for (const v of fixtures.vms) {
+      for (const key of Object.keys(v.annotations ?? {})) {
+        if (key.startsWith(PREFIX)) got.add(`vm:${key.slice(PREFIX.length)}`);
+      }
+    }
+    const want = new Set<string>([
+      'cluster:kubernetes',
+      'node:ubuntu',
+      'node:containerd',
+      'vm:vault',
+      'vm:cyberwatch',
+    ]);
+    expect(got).toEqual(want);
+  });
+});

--- a/ui/src/pages/EolDashboard.fixtures.test.tsx
+++ b/ui/src/pages/EolDashboard.fixtures.test.tsx
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import fixtures from '../../../internal/eolagg/testdata/fixtures.json';
+// Mirror of internal/eolagg/testdata/fixtures.json — copied into the UI
+// tree so the Dockerfile's ui-build stage (which only mounts ui/) can
+// resolve the import. The Go test reads the canonical file; both must
+// stay byte-identical (verified by the parity check below + a CI guard
+// in internal/eolagg/testdata/README.md).
+import fixtures from '../__testdata__/eolagg-fixtures.json';
 
 describe('EOL aggregator parity', () => {
   it('emits the same (entity_type, product) pairs as the Go aggregator', () => {

--- a/ui/src/pages/EolDashboard.test.tsx
+++ b/ui/src/pages/EolDashboard.test.tsx
@@ -1,9 +1,24 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import * as api from '../api';
 import EolDashboard from './EolDashboard';
 import { renderWithRouter } from '../test/render';
 import { server } from '../test/server';
+
+const eolAnnotation = JSON.stringify({
+  product: 'kubernetes',
+  cycle: '1.28',
+  eol_status: 'eol',
+  eol: '2024-10-28',
+});
+
+const clusterWithEol = {
+  id: 'c1',
+  name: 'prod',
+  display_name: 'prod',
+  annotations: { 'longue-vue.io/eol.kubernetes': eolAnnotation },
+};
 
 describe('EolDashboard', () => {
   it('renders without crashing', () => {
@@ -28,5 +43,38 @@ describe('EolDashboard', () => {
     await waitFor(() =>
       expect(screen.getByText(/failed to load/i)).toBeInTheDocument(),
     );
+  });
+});
+
+describe('EOL Dashboard extract button', () => {
+  beforeEach(() => {
+    server.use(
+      http.get('/v1/clusters', () =>
+        HttpResponse.json({ items: [clusterWithEol], next_cursor: null }),
+      ),
+      http.get('/v1/nodes', () => HttpResponse.json({ items: [], next_cursor: null })),
+      http.get('/v1/virtual-machines', () => HttpResponse.json({ items: [], next_cursor: null })),
+    );
+  });
+
+  it('renders an Extract button when rows are non-empty', async () => {
+    renderWithRouter(<EolDashboard />, { initialPath: '/eol' });
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /extract/i })).toBeInTheDocument(),
+    );
+  });
+
+  it('clicking CSV invokes api.extractEol with format=csv', async () => {
+    const spy = vi
+      .spyOn(api, 'extractEol')
+      .mockResolvedValue({ truncated: false, filename: null });
+    renderWithRouter(<EolDashboard />, { initialPath: '/eol' });
+    const btn = await screen.findByRole('button', { name: /extract/i });
+    fireEvent.click(btn);
+    fireEvent.click(screen.getByRole('menuitem', { name: /csv/i }));
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ format: 'csv' })),
+    );
+    spy.mockRestore();
   });
 });

--- a/ui/src/pages/EolDashboard.tsx
+++ b/ui/src/pages/EolDashboard.tsx
@@ -5,6 +5,8 @@ import { useResources } from '../hooks';
 import { AsyncView, Dash } from '../components';
 import { useEntityTable } from '../components/column_filters';
 import { EolIcon } from '../icons';
+import { ExtractButton } from '../components/ExtractButton';
+import { TruncationBanner } from '../components/TruncationBanner';
 
 // --- EOL annotation parsing -----------------------------------------------
 
@@ -228,6 +230,7 @@ export default function EolDashboard() {
   const [statusFilter, setStatusFilter] = useState<EolStatus | null>(null);
   const [sortKey, setSortKey] = useState<SortKey>('status');
   const [sortAsc, setSortAsc] = useState(true);
+  const [truncated, setTruncated] = useState(false);
 
   const handleSort = (key: SortKey) => {
     if (key === sortKey) {
@@ -250,18 +253,39 @@ export default function EolDashboard() {
       <p className="muted" style={{ marginBottom: '1rem' }}>
         Lifecycle status of inventoried software, enriched from endoflife.date.
       </p>
+      <TruncationBanner visible={truncated} />
       <AsyncView state={state}>
         {([clustersResp, nodesResp, vmsResp]) => (
-          <EolTable
-            clusters={clustersResp.items}
-            nodes={nodesResp.items}
-            vms={vmsResp.items}
-            statusFilter={statusFilter}
-            sortKey={sortKey}
-            sortAsc={sortAsc}
-            onCardClick={handleCardClick}
-            onSort={handleSort}
-          />
+          <>
+            {(() => {
+              const rows = buildRows(clustersResp.items, nodesResp.items, vmsResp.items);
+              if (rows.length === 0) return null;
+              return (
+                <div className="eol-extract">
+                  <ExtractButton
+                    label="Extract"
+                    onExtract={(format) =>
+                      api.extractEol({
+                        format,
+                        status: statusFilter ?? undefined,
+                      })
+                    }
+                    onTruncation={setTruncated}
+                  />
+                </div>
+              );
+            })()}
+            <EolTable
+              clusters={clustersResp.items}
+              nodes={nodesResp.items}
+              vms={vmsResp.items}
+              statusFilter={statusFilter}
+              sortKey={sortKey}
+              sortAsc={sortAsc}
+              onCardClick={handleCardClick}
+              onSort={handleSort}
+            />
+          </>
         )}
       </AsyncView>
     </>

--- a/ui/src/pages/Search.test.tsx
+++ b/ui/src/pages/Search.test.tsx
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import * as api from '../api';
 import ImageSearch from './Search';
 import { renderWithRouter } from '../test/render';
 import { server } from '../test/server';
@@ -37,5 +38,39 @@ describe('ImageSearch', () => {
     await waitFor(() => {
       expect(screen.getByText(/error|failed/i)).toBeInTheDocument();
     });
+  });
+});
+
+describe('Search page extract buttons', () => {
+  beforeEach(() => {
+    // Mock the api extract functions so downloadExtract (which needs DOM APIs
+    // not available in jsdom) is never reached.
+    vi.spyOn(api, 'extractSearch').mockResolvedValue({ truncated: false, filename: null });
+    vi.spyOn(api, 'extractSearchZip').mockResolvedValue({ truncated: false, filename: null });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows per-table extract buttons and the all-zip button', async () => {
+    renderWithRouter(<ImageSearch />, { initialPath: '/search/image?q=nginx' });
+    await waitFor(() => expect(screen.getByText(/matches for/i)).toBeInTheDocument());
+    // Three per-table Extract ▾ dropdowns + one "Extract all (.zip)" button.
+    const buttons = screen.getAllByRole('button', { name: /extract/i });
+    expect(buttons.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('clicking CSV on workloads invokes api.extractSearch with kind=workloads', async () => {
+    const spy = vi.spyOn(api, 'extractSearch').mockResolvedValue({ truncated: false, filename: null });
+    renderWithRouter(<ImageSearch />, { initialPath: '/search/image?q=nginx' });
+    await waitFor(() => expect(screen.getByText(/matches for/i)).toBeInTheDocument());
+    // The Extract dropdown buttons (aria-haspopup="menu") are after the zip button.
+    // Index 0 is "Extract all (.zip)", index 1 is the Workloads Extract dropdown.
+    const extractButtons = screen.getAllByRole('button', { name: /extract/i });
+    fireEvent.click(extractButtons[1]);
+    fireEvent.click(screen.getByRole('menuitem', { name: /csv/i }));
+    await waitFor(() => expect(spy).toHaveBeenCalledWith('nginx', 'workloads', 'csv'));
+    spy.mockRestore();
   });
 });

--- a/ui/src/pages/Search.tsx
+++ b/ui/src/pages/Search.tsx
@@ -5,6 +5,8 @@ import { useResource } from '../hooks';
 import { AsyncView, Dash, IdLink, SectionTitle, Empty } from '../components';
 import { useEntityTable } from '../components/column_filters';
 import { isAdmin, useMe } from '../me';
+import { ExtractButton } from '../components/ExtractButton';
+import { TruncationBanner } from '../components/TruncationBanner';
 
 // Image search — answers "which applications run component X in version Y?"
 // The query is kept in the URL (?q=) so auditors can bookmark / share.
@@ -62,6 +64,14 @@ export default function ImageSearch() {
         </button>
       </form>
 
+      {q && (
+        <div className="search-extract-all">
+          <button type="button" onClick={() => api.extractSearchZip(q)}>
+            ↓ Extract all (.zip)
+          </button>
+        </div>
+      )}
+
       {q ? <Results q={q} /> : <Empty message="Enter an image to search." />}
     </>
   );
@@ -70,6 +80,7 @@ export default function ImageSearch() {
 function Results({ q }: { q: string }) {
   const me = useMe();
   const canListAccounts = isAdmin(me);
+  const [truncated, setTruncated] = useState(false);
   const workloadsTableRef = useEntityTable('search.workloads');
   const podsTableRef = useEntityTable('search.pods');
   const vmsTableRef = useEntityTable('search.vms');
@@ -123,7 +134,16 @@ function Results({ q }: { q: string }) {
               {affectedApps === 1 ? '' : 's'}.
             </p>
 
-            <SectionTitle count={workloads.length}>Matching workloads</SectionTitle>
+            <TruncationBanner visible={truncated} />
+
+            <div className="section-header">
+              <SectionTitle count={workloads.length}>Matching workloads</SectionTitle>
+              <ExtractButton
+                label="Extract"
+                onExtract={(format) => api.extractSearch(q, 'workloads', format)}
+                onTruncation={setTruncated}
+              />
+            </div>
             {workloads.length === 0 ? (
               <Empty message="No workloads match." />
             ) : (
@@ -161,7 +181,14 @@ function Results({ q }: { q: string }) {
               </table>
             )}
 
-            <SectionTitle count={pods.length}>Matching pods</SectionTitle>
+            <div className="section-header">
+              <SectionTitle count={pods.length}>Matching pods</SectionTitle>
+              <ExtractButton
+                label="Extract"
+                onExtract={(format) => api.extractSearch(q, 'pods', format)}
+                onTruncation={setTruncated}
+              />
+            </div>
             {pods.length === 0 ? (
               <Empty message="No pods match." />
             ) : (
@@ -205,7 +232,14 @@ function Results({ q }: { q: string }) {
               </table>
             )}
 
-            <SectionTitle count={vms.length}>Matching virtual machines</SectionTitle>
+            <div className="section-header">
+              <SectionTitle count={vms.length}>Matching virtual machines</SectionTitle>
+              <ExtractButton
+                label="Extract"
+                onExtract={(format) => api.extractSearch(q, 'virtual_machines', format)}
+                onTruncation={setTruncated}
+              />
+            </div>
             {vms.length === 0 ? (
               <Empty message="No virtual machines match." />
             ) : (

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -2077,3 +2077,22 @@ th.sortable:hover {
 .extract-menu li:hover {
   background: var(--bg-hover, #f5f5f5);
 }
+
+.banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}
+.banner-warn {
+  background: var(--warn-bg, #3b2b12);
+  border: 1px solid var(--warn-border, #5a4320);
+}
+.banner button {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2em;
+}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -2051,3 +2051,29 @@ th.sortable:hover {
   color: var(--border);
   margin-bottom: 0.4rem;
 }
+
+/* ExtractButton */
+.extract-button {
+  position: relative;
+  display: inline-block;
+}
+.extract-menu {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  background: var(--bg-2, #fff);
+  border: 1px solid var(--border, #ddd);
+  border-radius: 4px;
+  min-width: 80px;
+  z-index: 10;
+}
+.extract-menu li {
+  padding: 4px 12px;
+  cursor: pointer;
+}
+.extract-menu li:hover {
+  background: var(--bg-hover, #f5f5f5);
+}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -2096,3 +2096,12 @@ th.sortable:hover {
   cursor: pointer;
   font-size: 1.2em;
 }
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.search-extract-all {
+  margin: 8px 0 16px 0;
+}


### PR DESCRIPTION
## Summary

Three new GET endpoints let operators download the full filtered result of a Search or EOL Dashboard query as CSV, JSON, or (Search only) a ZIP bundle. Every extract is recorded in `audit_events` for SecNumCloud chapter-8 evidence.

- `GET /v1/search/extract?q=…&kind=workloads|pods|virtual_machines&format=csv|json`
- `GET /v1/search/extract.zip?q=…`
- `GET /v1/eol/extract?format=csv|json[&entity_type=…&status=…]`

Capped at `LONGUE_VUE_EXTRACT_MAX_ROWS` (default 50 000); `X-Longue-Vue-Truncated: true` header signals the cap. Audited via the `shouldAudit` allowlist with `details.action=extract` + page/format/filters/row_count/truncated.

## What landed

- **Backend.** New `internal/eolagg` package (100% coverage) flattens EOL annotations server-side; three hand-written handlers in `internal/api/extract_handlers.go`; UTF-8-BOM CSV / streaming JSON / ZIP writers; two new Prometheus counters (`longue_vue_extracts_total`, `longue_vue_extract_rows_total`).
- **OpenAPI.** Three operations + four schemas documented in `api/openapi/openapi.yaml` (appear in Swagger UI at `/docs/`); excluded from strict-server codegen via `oapi-codegen.yaml.exclude-operation-ids` since the routes are hand-written.
- **Frontend.** `downloadExtract` helper (`fetch` + `Blob`, surfaces truncation header), `<ExtractButton>` dropdown, `<TruncationBanner>`, wired into the Search page (per-table + combined ZIP) and the EOL Dashboard. Shared-fixture parity test keeps the Go and TS aggregators aligned.
- **Audit.** GET allowlist in `internal/api/audit.go:shouldAudit` extended for the three new paths.
- **Wiring.** Routes mounted in `cmd/longue-vue/main.go` under `requireReadScope` + `auth.Middleware` + `auditWrap`; `LONGUE_VUE_EXTRACT_MAX_ROWS` parsed and surfaced in the boot-summary slog.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-15-extract-from-search-or-eol-design.md` (local-only — `docs/superpowers/` is gitignored)
- Plan: `docs/superpowers/plans/2026-05-15-extract-from-search-or-eol.md` (same)

## Test plan

- [x] `go test -race -cover ./...` (with Postgres 17 service) — all packages pass
- [x] `npm test` — 231/231 UI tests pass
- [x] `golangci-lint run` — 0 issues
- [x] `helm lint` + `helm template` (bundled PG + external DB) — clean
- [x] `make swagger-sync-check` — embedded spec in sync
- [x] `govulncheck`, `gitleaks`, `trivy fs/config/image×4` — all clean (HIGH/CRITICAL = 0)
- [x] Conventional Commits on all 29 branch commits
- [x] Live deploy to `k3d-dev`: `/healthz` green, three new routes return 401 unauthenticated, `longue_vue_extract*` counters registered, boot log shows `extract_max_rows=50000`
- [x] **Manual UI smoke**: log in at `https://longue-vue.127.0.0.1.nip.io:8443/ui/`, click Extract dropdowns on `/ui/search?q=nginx` and `/ui/eol` for CSV/JSON/ZIP; verify the file opens cleanly in Excel / parses as JSON
- [x] Audit row written for each extract attempt (check `audit_events` for `details->>'action' = 'extract'`)