### PR TITLE
fix(store): cascade-delete cluster children + auto-restore in EnsureCluster

### DIFF
--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -68,15 +68,22 @@ type Store interface {
 	// Ping verifies that the underlying database is reachable.
 	Ping(ctx context.Context) error
 
-	// EnsureCluster inserts a cluster if no row with the same name exists, or
-	// returns the existing row unchanged when one does. The created flag is
-	// true when a new row was inserted, false when an existing row was
-	// returned. The request body is ignored on hit — callers wanting to
-	// update fields on an existing cluster must follow up with UpdateCluster.
+	// EnsureCluster reconciles a cluster row keyed by name with one of three
+	// outcomes:
+	//   - CREATE: no row exists, a new one is inserted and created=true.
+	//   - NO-OP: a live row exists, it is returned unchanged with created=false.
+	//   - RESTORE: a soft-deleted row exists (terminated_at IS NOT NULL); its
+	//     terminated_at is cleared, a change_type='restore' history row is
+	//     written, and created=false is returned.
+	//
+	// The request body is otherwise ignored on hit — callers wanting to update
+	// fields on an existing cluster must follow up with UpdateCluster.
 	//
 	// EnsureCluster never returns ErrConflict; concurrent inserts of the same
 	// name are serialised at the database via INSERT ... ON CONFLICT DO
-	// NOTHING, falling back to a SELECT for the losing writer.
+	// NOTHING, falling back to a SELECT for the losing writer. Lightweight
+	// in-memory implementations that do not track terminated_at may safely
+	// skip the RESTORE branch and treat any existing row as NO-OP.
 	EnsureCluster(ctx context.Context, in ClusterCreate) (cluster Cluster, created bool, err error)
 
 	// GetCluster fetches a cluster by id. Returns ErrNotFound if absent.

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -1359,8 +1359,9 @@ func (p *PG) DeleteNamespace(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
-// SoftDeleteNamespace soft-deletes the namespace and its workloads.
-// Pods/services/ingresses/PVCs are not touched (Phase 2 follow-up).
+// SoftDeleteNamespace soft-deletes the namespace and its workloads, and
+// hard-deletes its unhistoried children (pods, services, ingresses, PVCs).
+// PVs are cluster-scoped, not namespace-scoped, so they are unaffected.
 //
 //nolint:gocyclo // history capture adds branches; acceptable here
 func (p *PG) SoftDeleteNamespace(ctx context.Context, id uuid.UUID) error {
@@ -1375,6 +1376,25 @@ func (p *PG) SoftDeleteNamespace(ctx context.Context, id uuid.UUID) error {
 	wlIDs, err := liveWorkloadIDsForNamespace(ctx, tx, id)
 	if err != nil {
 		return fmt.Errorf("list workloads for soft-delete namespace: %w", err)
+	}
+
+	// Hard-delete the unhistoried namespace-scoped children. FK ON DELETE
+	// CASCADE does not fire under soft-delete; do it manually.
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM pods WHERE namespace_id = $1`, id); err != nil {
+		return fmt.Errorf("cascade-delete pods: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM services WHERE namespace_id = $1`, id); err != nil {
+		return fmt.Errorf("cascade-delete services: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM ingresses WHERE namespace_id = $1`, id); err != nil {
+		return fmt.Errorf("cascade-delete ingresses: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM persistent_volume_claims WHERE namespace_id = $1`, id); err != nil {
+		return fmt.Errorf("cascade-delete persistent_volume_claims: %w", err)
 	}
 
 	if _, err := tx.Exec(ctx,

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -663,10 +663,12 @@ func scanUUIDs(rows pgx.Rows) ([]uuid.UUID, error) {
 	return ids, nil
 }
 
-// CountClusterChildren counts every child resource that ON DELETE CASCADE
-// will remove when the cluster is deleted. A single round-trip multi-CTE
-// query keeps the cost bounded regardless of how many resource types
-// exist (ADR-0010).
+// CountClusterChildren counts every child resource attached to the cluster
+// at the time of the call. Used by the audit log to snapshot the pre-delete
+// inventory before SoftDeleteCluster removes pods / services / ingresses /
+// PVCs / PVs (Fix 1, see SoftDeleteCluster) and soft-deletes the cluster /
+// namespaces / nodes / workloads. A single round-trip multi-CTE query keeps
+// the cost bounded regardless of how many resource types exist (ADR-0010).
 func (p *PG) CountClusterChildren(ctx context.Context, clusterID uuid.UUID) (api.CascadeCounts, error) {
 	const q = `
 		WITH ns_ids AS (

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -446,11 +446,12 @@ func (p *PG) DeleteCluster(ctx context.Context, id uuid.UUID) error {
 // SoftDeleteCluster marks the cluster and all its live children
 // (namespaces, nodes, workloads) as terminated in a single transaction.
 // Mirrors ADR-0021 §IMP-007. Children that are already terminated are
-// skipped via the AND terminated_at IS NULL guard. Pods, services,
-// ingresses, PVs, and PVCs are unaffected here — they continue to be
-// reaped by the FK ON DELETE CASCADE chain only when the cluster is
-// hard-deleted; under soft-delete they remain attached to the (now
-// soft-deleted) parent. Phase 2 reconsiders pod-level reconciliation.
+// skipped via the AND terminated_at IS NULL guard.
+//
+// Pods, services, ingresses, PVCs (per namespace) and PVs (per cluster)
+// are out-of-scope for time-travel history (ADR-0021 §IMP-007) and are
+// HARD-DELETED here. Without this step they would remain in the DB
+// attached to a terminated parent and still be queryable.
 //
 //nolint:gocyclo // cascade + history capture per entity-kind add branches; acceptable here
 func (p *PG) SoftDeleteCluster(ctx context.Context, id uuid.UUID) error {
@@ -474,6 +475,34 @@ func (p *PG) SoftDeleteCluster(ctx context.Context, id uuid.UUID) error {
 	nodeIDs, err := liveNodeIDsForCluster(ctx, tx, id)
 	if err != nil {
 		return fmt.Errorf("list nodes for soft-delete cluster: %w", err)
+	}
+
+	// Hard-delete the unhistoried children first. These tables have ON
+	// DELETE CASCADE from cluster/namespace, but FK CASCADE only fires
+	// on hard-delete; since we soft-delete the parent it never fires.
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM pods
+		   WHERE namespace_id IN (SELECT id FROM namespaces WHERE cluster_id = $1)`, id); err != nil {
+		return fmt.Errorf("cascade-delete pods: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM services
+		   WHERE namespace_id IN (SELECT id FROM namespaces WHERE cluster_id = $1)`, id); err != nil {
+		return fmt.Errorf("cascade-delete services: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM ingresses
+		   WHERE namespace_id IN (SELECT id FROM namespaces WHERE cluster_id = $1)`, id); err != nil {
+		return fmt.Errorf("cascade-delete ingresses: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM persistent_volume_claims
+		   WHERE namespace_id IN (SELECT id FROM namespaces WHERE cluster_id = $1)`, id); err != nil {
+		return fmt.Errorf("cascade-delete persistent_volume_claims: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM persistent_volumes WHERE cluster_id = $1`, id); err != nil {
+		return fmt.Errorf("cascade-delete persistent_volumes: %w", err)
 	}
 
 	if _, err := tx.Exec(ctx,

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -123,15 +123,22 @@ func (r scanRowWith) Scan(dest ...any) error {
 	return nil
 }
 
-// EnsureCluster inserts a cluster row when no row with the same name exists,
-// or returns the existing row unchanged when one does. The returned bool is
-// true when a new row was inserted, false when an existing row was returned.
+// EnsureCluster is idempotent on the cluster name. It has three branches:
 //
-// Concurrent inserts of the same name are resolved by INSERT ... ON CONFLICT
-// (name) DO NOTHING: the winner inserts and gets RETURNING rows, the losing
-// writer falls back to a SELECT for the existing row.
+//   - RESTORE — a terminated row already exists. Clear terminated_at,
+//     write a `restore` history row, return the existing row. Mirrors
+//     the auto-restore behaviour of UpsertNamespace/Node/Workload so a
+//     collector that keeps pushing after a soft-delete resurrects the
+//     cluster instead of being silently ignored (Fix 2 in the spec at
+//     docs/superpowers/specs/2026-05-18-cluster-cascade-delete-design.md).
+//   - NO-OP — a live row already exists. Return it unchanged. No history.
+//   - CREATE — no row exists. INSERT and capture create history.
 //
-//nolint:gocritic // hugeParam: Store interface requires value param
+// The returned bool is true only on CREATE. Concurrent inserts of the
+// same name are resolved by INSERT … ON CONFLICT (name) DO NOTHING:
+// the loser falls through to a re-fetch (still false).
+//
+//nolint:gocyclo,gocritic // branch-heavy idempotent insert; hugeParam: Store interface
 func (p *PG) EnsureCluster(ctx context.Context, in api.ClusterCreate) (api.Cluster, bool, error) {
 	id := uuid.New()
 	now := time.Now().UTC()
@@ -142,11 +149,59 @@ func (p *PG) EnsureCluster(ctx context.Context, in api.ClusterCreate) (api.Clust
 	}
 	annotationsJSON, err := marshalLabels(in.Annotations)
 	if err != nil {
-		// marshalLabels' own message says "marshal labels"; rewrap so
-		// the operator-facing error points at annotations instead.
 		return api.Cluster{}, false, fmt.Errorf("marshal cluster annotations: %w", err)
 	}
 
+	tx, err := p.pool.Begin(ctx)
+	if err != nil {
+		return api.Cluster{}, false, fmt.Errorf("begin ensure cluster: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	actor := timetravel.ActorFromContext(ctx)
+
+	// Snapshot any existing row by name so we can pick a branch.
+	var prevID *uuid.UUID
+	var prevTerminatedAt *time.Time
+	_ = tx.QueryRow(ctx,
+		`SELECT id, terminated_at FROM clusters WHERE name=$1`,
+		in.Name,
+	).Scan(&prevID, &prevTerminatedAt)
+
+	// Branch RESTORE: terminated row exists → clear terminated_at + history.
+	if prevID != nil && prevTerminatedAt != nil {
+		if _, err := tx.Exec(ctx,
+			`UPDATE clusters SET terminated_at = NULL, updated_at = $1 WHERE id = $2`,
+			now, *prevID); err != nil {
+			return api.Cluster{}, false, fmt.Errorf("restore cluster: %w", err)
+		}
+		if snap, err := clusterRowMapNoLock(ctx, tx, *prevID); err == nil {
+			_ = timetravel.Capture(ctx, tx, timetravel.KindCluster, *prevID, nil, snap, changeTypeRestore, actor)
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return api.Cluster{}, false, fmt.Errorf("commit ensure cluster (restore): %w", err)
+		}
+		restored, getErr := p.GetClusterByName(ctx, in.Name)
+		if getErr != nil {
+			return api.Cluster{}, false, fmt.Errorf("ensure cluster %q: fetch restored: %w", in.Name, getErr)
+		}
+		return restored, false, nil
+	}
+
+	// Branch NO-OP: live row exists → return as-is.
+	if prevID != nil {
+		if err := tx.Commit(ctx); err != nil {
+			return api.Cluster{}, false, fmt.Errorf("commit ensure cluster (existing): %w", err)
+		}
+		existing, getErr := p.GetClusterByName(ctx, in.Name)
+		if getErr != nil {
+			return api.Cluster{}, false, fmt.Errorf("ensure cluster %q: fetch existing: %w", in.Name, getErr)
+		}
+		return existing, false, nil
+	}
+
+	// Branch CREATE: insert. Use ON CONFLICT DO NOTHING to absorb a race
+	// where two transactions reach this point with the same name.
 	const q = `
 		INSERT INTO clusters (
 			id, name, display_name, environment, provider, region,
@@ -157,13 +212,6 @@ func (p *PG) EnsureCluster(ctx context.Context, in api.ClusterCreate) (api.Clust
 		ON CONFLICT (name) DO NOTHING
 		RETURNING id
 	`
-
-	tx, err := p.pool.Begin(ctx)
-	if err != nil {
-		return api.Cluster{}, false, fmt.Errorf("begin ensure cluster: %w", err)
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
-
 	var insertedID uuid.UUID
 	scanErr := tx.QueryRow(ctx, q,
 		id, in.Name, in.DisplayName, in.Environment, in.Provider, in.Region,
@@ -173,10 +221,7 @@ func (p *PG) EnsureCluster(ctx context.Context, in api.ClusterCreate) (api.Clust
 	).Scan(&insertedID)
 	switch {
 	case scanErr == nil:
-		// New row was inserted. Capture create history.
-		snap, snapErr := clusterRowMapNoLock(ctx, tx, insertedID)
-		if snapErr == nil {
-			actor := timetravel.ActorFromContext(ctx)
+		if snap, err := clusterRowMapNoLock(ctx, tx, insertedID); err == nil {
 			_ = timetravel.Capture(ctx, tx, timetravel.KindCluster, insertedID, nil, snap, changeTypeCreate, actor)
 		}
 		if err := tx.Commit(ctx); err != nil {
@@ -201,13 +246,14 @@ func (p *PG) EnsureCluster(ctx context.Context, in api.ClusterCreate) (api.Clust
 			UpdatedAt:         &now,
 		}, true, nil
 	case errors.Is(scanErr, pgx.ErrNoRows):
-		// ON CONFLICT DO NOTHING — row already exists. Commit (no-op tx) and read it back.
+		// Race: a concurrent tx inserted between our pre-snapshot and INSERT.
+		// Commit (the tx has no effect) and re-fetch.
 		if err := tx.Commit(ctx); err != nil {
-			return api.Cluster{}, false, fmt.Errorf("commit ensure cluster (existing): %w", err)
+			return api.Cluster{}, false, fmt.Errorf("commit ensure cluster (race): %w", err)
 		}
 		existing, getErr := p.GetClusterByName(ctx, in.Name)
 		if getErr != nil {
-			return api.Cluster{}, false, fmt.Errorf("ensure cluster %q: fetch existing: %w", in.Name, getErr)
+			return api.Cluster{}, false, fmt.Errorf("ensure cluster %q: fetch existing after race: %w", in.Name, getErr)
 		}
 		return existing, false, nil
 	default:

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -3638,7 +3638,11 @@ func TestPGSoftDeleteCluster_CascadesToChildren(t *testing.T) {
 }
 
 // TestPGSoftDeleteNamespace_CascadesToWorkloads verifies the namespace
-// soft-delete cascade soft-deletes its live workloads.
+// soft-delete cascade soft-deletes its live workloads and hard-deletes
+// pods, services, ingresses, and PVCs that are out-of-scope for
+// time-travel history (ADR-0021 §IMP-007).
+//
+//nolint:gocyclo // test-fixture sequence
 func TestPGSoftDeleteNamespace_CascadesToWorkloads(t *testing.T) {
 	pg := newTestPG(t)
 	ctx := context.Background()
@@ -3655,11 +3659,28 @@ func TestPGSoftDeleteNamespace_CascadesToWorkloads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("workload: %v", err)
 	}
+	pod, err := pg.CreatePod(ctx, api.PodCreate{NamespaceId: *ns.Id, Name: "web-0"})
+	if err != nil {
+		t.Fatalf("pod: %v", err)
+	}
+	svc, err := pg.CreateService(ctx, api.ServiceCreate{NamespaceId: *ns.Id, Name: "web"})
+	if err != nil {
+		t.Fatalf("service: %v", err)
+	}
+	ing, err := pg.CreateIngress(ctx, api.IngressCreate{NamespaceId: *ns.Id, Name: "web"})
+	if err != nil {
+		t.Fatalf("ingress: %v", err)
+	}
+	pvc, err := pg.CreatePersistentVolumeClaim(ctx, api.PersistentVolumeClaimCreate{NamespaceId: *ns.Id, Name: "pvc-a"})
+	if err != nil {
+		t.Fatalf("pvc: %v", err)
+	}
 
 	if err := pg.SoftDeleteNamespace(ctx, *ns.Id); err != nil {
 		t.Fatalf("SoftDeleteNamespace: %v", err)
 	}
 
+	// Namespace + its workloads are soft-deleted.
 	var nsTerm, wlTerm bool
 	if err := pg.pool.QueryRow(ctx,
 		`SELECT terminated_at IS NOT NULL FROM namespaces WHERE id=$1`, *ns.Id).Scan(&nsTerm); err != nil {
@@ -3672,6 +3693,23 @@ func TestPGSoftDeleteNamespace_CascadesToWorkloads(t *testing.T) {
 	if !nsTerm || !wlTerm {
 		t.Fatalf("cascade missed: ns=%v wl=%v", nsTerm, wlTerm)
 	}
+
+	// Pods / services / ingresses / PVCs are hard-deleted.
+	assertGone := func(table string, id uuid.UUID) {
+		t.Helper()
+		var exists bool
+		q := fmt.Sprintf(`SELECT EXISTS(SELECT 1 FROM %s WHERE id=$1)`, table)
+		if err := pg.pool.QueryRow(ctx, q, id).Scan(&exists); err != nil {
+			t.Fatalf("scan %s: %v", table, err)
+		}
+		if exists {
+			t.Errorf("%s row %s should have been hard-deleted by namespace cascade", table, id)
+		}
+	}
+	assertGone("pods", *pod.Id)
+	assertGone("services", *svc.Id)
+	assertGone("ingresses", *ing.Id)
+	assertGone("persistent_volume_claims", *pvc.Id)
 
 	if err := pg.SoftDeleteNamespace(ctx, uuid.New()); !errors.Is(err, api.ErrNotFound) {
 		t.Fatalf("expected ErrNotFound for unknown id, got %v", err)

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -553,6 +553,82 @@ func TestPGUpsertNode_ResurrectsTerminated(t *testing.T) {
 	}
 }
 
+// TestPGEnsureCluster_ResurrectsTerminated verifies the design in
+// docs/superpowers/specs/2026-05-18-cluster-cascade-delete-design.md
+// (Fix 2): when a still-pushing collector calls EnsureCluster on a
+// soft-deleted cluster, the row is restored (terminated_at cleared)
+// and the existing id is preserved. A `restore` history row is captured.
+func TestPGEnsureCluster_ResurrectsTerminated(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	first, created, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "resurrect-cluster"})
+	if err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	if !created {
+		t.Fatalf("first ensure should report created=true")
+	}
+
+	if err := pg.SoftDeleteCluster(ctx, *first.Id); err != nil {
+		t.Fatalf("soft-delete: %v", err)
+	}
+
+	var terminated *time.Time
+	if err := pg.pool.QueryRow(ctx,
+		"SELECT terminated_at FROM clusters WHERE id=$1", *first.Id).Scan(&terminated); err != nil {
+		t.Fatalf("scan terminated_at: %v", err)
+	}
+	if terminated == nil {
+		t.Fatalf("terminated_at should be non-NULL after soft-delete")
+	}
+
+	resurrected, created, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "resurrect-cluster"})
+	if err != nil {
+		t.Fatalf("resurrect ensure: %v", err)
+	}
+	if created {
+		t.Errorf("resurrect ensure must report created=false (id %s preserved)", *first.Id)
+	}
+	if *resurrected.Id != *first.Id {
+		t.Errorf("id changed across resurrect: first=%s now=%s", *first.Id, *resurrected.Id)
+	}
+
+	if err := pg.pool.QueryRow(ctx,
+		"SELECT terminated_at FROM clusters WHERE id=$1", *first.Id).Scan(&terminated); err != nil {
+		t.Fatalf("scan terminated_at post-ensure: %v", err)
+	}
+	if terminated != nil {
+		t.Fatalf("terminated_at=%v want NULL after resurrection", terminated)
+	}
+
+	// A restore history row must have been captured (ADR-0021 §5).
+	var restoreCount int
+	if err := pg.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM clusters_history WHERE entity_id=$1 AND change_type='restore'`,
+		*first.Id).Scan(&restoreCount); err != nil {
+		t.Fatalf("scan clusters_history: %v", err)
+	}
+	if restoreCount != 1 {
+		t.Errorf("expected exactly 1 restore history row, got %d", restoreCount)
+	}
+
+	// And a third ensure on a live row is a true no-op (no extra history).
+	if _, created, err := pg.EnsureCluster(ctx, api.ClusterCreate{Name: "resurrect-cluster"}); err != nil {
+		t.Fatalf("third ensure: %v", err)
+	} else if created {
+		t.Errorf("third ensure on live row should report created=false")
+	}
+	if err := pg.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM clusters_history WHERE entity_id=$1 AND change_type='restore'`,
+		*first.Id).Scan(&restoreCount); err != nil {
+		t.Fatalf("re-scan clusters_history: %v", err)
+	}
+	if restoreCount != 1 {
+		t.Errorf("no-op ensure must not write another restore row, got %d", restoreCount)
+	}
+}
+
 // TestPGUpsertNamespace_ResurrectsTerminated mirrors the node test for
 // namespaces.
 func TestPGUpsertNamespace_ResurrectsTerminated(t *testing.T) {

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strconv"
 	"testing"
@@ -3539,10 +3540,6 @@ func TestPGNodeCuratedMetadata(t *testing.T) {
 	}
 }
 
-// TestPGSoftDeleteCluster_CascadesToChildren verifies ADR-0021 §IMP-007:
-// SoftDeleteCluster soft-deletes the cluster plus its live namespaces,
-// nodes, and workloads in a single transaction.
-//
 //nolint:gocyclo // test-fixture sequence; complexity from straight-line setup-then-assertions
 func TestPGSoftDeleteCluster_CascadesToChildren(t *testing.T) {
 	pg := newTestPG(t)
@@ -3564,11 +3561,32 @@ func TestPGSoftDeleteCluster_CascadesToChildren(t *testing.T) {
 	if err != nil {
 		t.Fatalf("workload: %v", err)
 	}
+	pod, err := pg.CreatePod(ctx, api.PodCreate{NamespaceId: *ns.Id, Name: "web-0"})
+	if err != nil {
+		t.Fatalf("pod: %v", err)
+	}
+	svc, err := pg.CreateService(ctx, api.ServiceCreate{NamespaceId: *ns.Id, Name: "web"})
+	if err != nil {
+		t.Fatalf("service: %v", err)
+	}
+	ing, err := pg.CreateIngress(ctx, api.IngressCreate{NamespaceId: *ns.Id, Name: "web"})
+	if err != nil {
+		t.Fatalf("ingress: %v", err)
+	}
+	pv, err := pg.CreatePersistentVolume(ctx, api.PersistentVolumeCreate{ClusterId: *cluster.Id, Name: "pv-a"})
+	if err != nil {
+		t.Fatalf("pv: %v", err)
+	}
+	pvc, err := pg.CreatePersistentVolumeClaim(ctx, api.PersistentVolumeClaimCreate{NamespaceId: *ns.Id, Name: "pvc-a"})
+	if err != nil {
+		t.Fatalf("pvc: %v", err)
+	}
 
 	if err := pg.SoftDeleteCluster(ctx, *cluster.Id); err != nil {
 		t.Fatalf("SoftDeleteCluster: %v", err)
 	}
 
+	// 1. Parent + soft-deletable children stay alive with terminated_at set.
 	var clusterTerm, nsTerm, nodeTerm, wlTerm bool
 	if err := pg.pool.QueryRow(ctx,
 		`SELECT terminated_at IS NOT NULL FROM clusters WHERE id=$1`, *cluster.Id).Scan(&clusterTerm); err != nil {
@@ -3590,12 +3608,30 @@ func TestPGSoftDeleteCluster_CascadesToChildren(t *testing.T) {
 		t.Fatalf("cascade missed: cluster=%v ns=%v node=%v wl=%v", clusterTerm, nsTerm, nodeTerm, wlTerm)
 	}
 
-	// Idempotent: a second call on an already-terminated cluster returns nil.
+	// 2. Hard-delete children must be gone.
+	assertGone := func(table, col string, id uuid.UUID) {
+		t.Helper()
+		var exists bool
+		q := fmt.Sprintf(`SELECT EXISTS(SELECT 1 FROM %s WHERE %s=$1)`, table, col)
+		if err := pg.pool.QueryRow(ctx, q, id).Scan(&exists); err != nil {
+			t.Fatalf("scan %s: %v", table, err)
+		}
+		if exists {
+			t.Errorf("%s row %s should have been hard-deleted by cascade", table, id)
+		}
+	}
+	assertGone("pods", "id", *pod.Id)
+	assertGone("services", "id", *svc.Id)
+	assertGone("ingresses", "id", *ing.Id)
+	assertGone("persistent_volume_claims", "id", *pvc.Id)
+	assertGone("persistent_volumes", "id", *pv.Id)
+
+	// 3. Idempotent: a second call on an already-terminated cluster returns nil.
 	if err := pg.SoftDeleteCluster(ctx, *cluster.Id); err != nil {
 		t.Fatalf("second SoftDeleteCluster should be idempotent: %v", err)
 	}
 
-	// Unknown id returns ErrNotFound.
+	// 4. Unknown id returns ErrNotFound.
 	if err := pg.SoftDeleteCluster(ctx, uuid.New()); !errors.Is(err, api.ErrNotFound) {
 		t.Fatalf("expected ErrNotFound for unknown id, got %v", err)
 	}

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -558,6 +558,8 @@ func TestPGUpsertNode_ResurrectsTerminated(t *testing.T) {
 // (Fix 2): when a still-pushing collector calls EnsureCluster on a
 // soft-deleted cluster, the row is restored (terminated_at cleared)
 // and the existing id is preserved. A `restore` history row is captured.
+//
+//nolint:gocyclo // test-fixture sequence; complexity from straight-line setup-then-assertions
 func TestPGEnsureCluster_ResurrectsTerminated(t *testing.T) {
 	pg := newTestPG(t)
 	ctx := context.Background()

--- a/migrations/00042_cleanup_orphan_children.sql
+++ b/migrations/00042_cleanup_orphan_children.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+-- Spec: docs/superpowers/specs/2026-05-18-cluster-cascade-delete-design.md
+--
+-- Before this release, SoftDeleteCluster / SoftDeleteNamespace marked the
+-- parent terminated but never DELETE'd pods, services, ingresses, PVs, or
+-- PVCs. FK ON DELETE CASCADE only fires on hard-delete; soft-delete left
+-- the children attached to a terminated parent, where they remained
+-- queryable. ADR-0021 §IMP-007 keeps these tables out-of-scope for the
+-- history sidecars, so a hard delete is the correct repair.
+--
+-- This migration deletes those orphan rows. It is idempotent and re-runnable.
+
+DELETE FROM pods
+ WHERE namespace_id IN (SELECT id FROM namespaces WHERE terminated_at IS NOT NULL);
+
+DELETE FROM services
+ WHERE namespace_id IN (SELECT id FROM namespaces WHERE terminated_at IS NOT NULL);
+
+DELETE FROM ingresses
+ WHERE namespace_id IN (SELECT id FROM namespaces WHERE terminated_at IS NOT NULL);
+
+DELETE FROM persistent_volume_claims
+ WHERE namespace_id IN (SELECT id FROM namespaces WHERE terminated_at IS NOT NULL);
+
+DELETE FROM persistent_volumes
+ WHERE cluster_id IN (SELECT id FROM clusters WHERE terminated_at IS NOT NULL);
+
+-- +goose Down
+-- Irreversible: the deleted orphan rows cannot be reconstructed without
+-- an external backup. Down is a deliberate no-op.
+SELECT 1;


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                     
                                                                                
  Deleting a cluster used to leave pods / services / ingresses / PVs / PVCs orphaned in the DB (still queryable via the API), and a still-pushing collector that POSTed to `/v1/clusters` after the delete was silently swallowed by `ON CONFLICT
   DO NOTHING`. Both bugs caused stale data to linger indefinitely. Three fixes:
                                                                                                                                                                                                                                                 
  - **`SoftDeleteCluster` / `SoftDeleteNamespace`** now hard-delete the child resources that ADR-0021 §IMP-007 puts out of scope for time-travel history (pods, services, ingresses, PVCs, PVs). Same transaction as the soft-delete UPDATE —
  rollback is safe.
  - **`EnsureCluster`** gains a three-path body (CREATE / NO-OP / RESTORE). A soft-deleted row with the same name is resurrected: `terminated_at` is cleared, a `change_type='restore'` history row is written per ADR-0021 §5, `created=false`.
  Mirrors `UpsertNamespace` / `UpsertNode` / `UpsertWorkload`.
  - **Migration `00042_cleanup_orphan_children.sql`** backfills pre-existing orphans on deployed databases. Idempotent; `Down` is a deliberate no-op (deleted orphans cannot be reconstructed).

  Spec: `docs/superpowers/specs/2026-05-18-cluster-cascade-delete-design.md`
  Plan: `docs/superpowers/plans/2026-05-18-cluster-cascade-delete.md`

  ## Test Plan

  - [x] `make check` (fmt + vet + lint + go test -race + ui test) — green at `-p 2` (CI parallelism)
  - [x] New integration tests cover all three fixes
    - `TestPGSoftDeleteCluster_CascadesToChildren` — pod/svc/ing/PV/PVC orphan assertions
    - `TestPGSoftDeleteNamespace_CascadesToWorkloads` — pod/svc/ing/PVC orphan assertions (PV stays — cluster-scoped)
    - `TestPGEnsureCluster_ResurrectsTerminated` — CREATE + RESTORE + NO-OP paths, restore history row, id preserved
  - [x] **Prod rollout**: pre-flight orphan count on `outscale@10.37.42.180` (see plan Task 6), deploy, verify counts drop to 0, smoke-test resurrection on `zad-sandbox-dmz`