### PR TITLE
feat: mirror image source resolution

### DIFF
--- a/api/openapi/oapi-codegen.yaml
+++ b/api/openapi/oapi-codegen.yaml
@@ -10,6 +10,10 @@ output-options:
     - eolExtract
     - searchExtract
     - searchExtractZip
+    # ADR-0026: getImageRegistryCredentials is hand-written too — it
+    # uses the composite (hostname, path_prefix) key that the strict
+    # server can't easily express alongside the single-key CRUD routes.
+    - getImageRegistryCredentials
 generate:
   models: true
   std-http-server: true

--- a/api/openapi/openapi.yaml
+++ b/api/openapi/openapi.yaml
@@ -4828,7 +4828,7 @@ components:
 
     ImageRegistryUpsert:
       type: object
-      required: [hostname, rate_limit_per_sec]
+      required: [hostname, path_prefix, rate_limit_per_sec, is_mirror]
       properties:
         hostname:
           type: string

--- a/api/openapi/openapi.yaml
+++ b/api/openapi/openapi.yaml
@@ -2310,6 +2310,45 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /v1/admin/image-versions/registries/{hostname}/{path_prefix}/credentials:
+    get:
+      summary: Reveal plaintext robot-account credentials for a mirror registry
+      description: |
+        Returns the decrypted auth_username and auth_token for the mirror row
+        identified by (hostname, path_prefix). Mark `path_prefix` as `_root`
+        when the row has no prefix. Admin-only and audit-logged.
+      tags: [admin, image-versions]
+      operationId: getImageRegistryCredentials
+      x-audit: extract
+      security:
+        - BearerAuth: [admin]
+        - SessionCookie: [admin]
+      parameters:
+        - name: hostname
+          in: path
+          required: true
+          schema: { type: string }
+        - name: path_prefix
+          in: path
+          required: true
+          schema: { type: string }
+          description: "URL-encoded path_prefix; use the literal '_root' for empty"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImageRegistryCredentials'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /v1/eol/extract:
     get:
       tags: [eol]
@@ -4754,11 +4793,14 @@ components:
 
     ImageRegistry:
       type: object
-      required: [hostname, rate_limit_per_sec, enabled, created_at, updated_at]
+      required: [hostname, path_prefix, rate_limit_per_sec, enabled, is_mirror, auth_configured, created_at, updated_at]
       properties:
         hostname:
           type: string
           description: "Exact hostname or '*<suffix>' wildcard"
+        path_prefix:
+          type: string
+          description: "Repo-path prefix (empty for non-mirror rows)"
         rate_limit_per_sec:
           type: number
           format: float
@@ -4768,6 +4810,15 @@ components:
         notes:
           type: string
           nullable: true
+        is_mirror:
+          type: boolean
+          description: "True if this row is a Harbor-style mirror needing resolution"
+        auth_username:
+          type: string
+          nullable: true
+        auth_configured:
+          type: boolean
+          description: "True iff an encrypted auth token is stored (token itself is never returned)"
         created_at:
           type: string
           format: date-time
@@ -4781,6 +4832,8 @@ components:
       properties:
         hostname:
           type: string
+        path_prefix:
+          type: string
         rate_limit_per_sec:
           type: number
           format: float
@@ -4789,6 +4842,14 @@ components:
           type: boolean
         notes:
           type: string
+        is_mirror:
+          type: boolean
+        auth_username:
+          type: string
+        auth_token:
+          type: string
+          writeOnly: true
+          description: "Robot-account token; never echoed in responses"
 
     ImageRegistryPatch:
       type: object
@@ -4802,6 +4863,24 @@ components:
         notes:
           type: string
           nullable: true
+        is_mirror:
+          type: boolean
+        auth_username:
+          type: string
+          nullable: true
+        auth_token:
+          type: string
+          writeOnly: true
+          description: "Empty string clears the stored token; omit to leave unchanged"
+
+    ImageRegistryCredentials:
+      type: object
+      required: [auth_username, auth_token]
+      properties:
+        auth_username:
+          type: string
+        auth_token:
+          type: string
 
     ImageVersionVariant:
       type: object

--- a/cmd/longue-vue/main.go
+++ b/cmd/longue-vue/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sthalbert/longue-vue/internal/eol"
 	"github.com/sthalbert/longue-vue/internal/httputil"
 	"github.com/sthalbert/longue-vue/internal/imageversions"
+	"github.com/sthalbert/longue-vue/internal/imageversions/mirrorresolve"
 	"github.com/sthalbert/longue-vue/internal/imageversions/registry"
 	"github.com/sthalbert/longue-vue/internal/impact"
 	argmcp "github.com/sthalbert/longue-vue/internal/mcp"
@@ -280,6 +281,9 @@ func run() error { //nolint:gocyclo // daemon bootstrap; flat structure is clear
 	encrypter, err := initSecretsEncrypter(rootCtx, pg)
 	if err != nil {
 		return err
+	}
+	if encrypter != nil {
+		pg.SetEncrypter(encrypter)
 	}
 
 	oidcProvider, err := maybeInitOIDC(rootCtx, &cfg.oidcCfg)
@@ -1254,7 +1258,11 @@ func maybeStartImageVersionsEnricher(ctx context.Context, s api.Store) (*imageve
 
 	ivMetrics := imageversions.NewMetrics(metrics.Registry)
 	client := registry.NewClientWithObserver(ivMetrics)
-	enricher := imageversions.NewEnricherWithMetrics(s, client, interval, ivMetrics)
+	resolver := &mirrorresolve.HTTPResolver{
+		Lookup:  imageversions.NewStoreMirrorLookup(s),
+		Metrics: imageversions.NewObserver(ivMetrics),
+	}
+	enricher := imageversions.NewEnricherWithResolver(s, client, resolver, interval, ivMetrics)
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/cmd/longue-vue/main.go
+++ b/cmd/longue-vue/main.go
@@ -548,6 +548,13 @@ func buildHTTPServer(
 	mux.Handle("GET /v1/eol/extract",
 		requireScope(auth.ScopeRead)(extractAuth(auditWrap(api.HandleEolExtract(pg, cfg.extractMaxRows)))))
 
+	// Mirror-registry credentials endpoint (ADR-0026) — composite-key
+	// path, hand-mounted because the strict-server interface can't
+	// express the (hostname, path_prefix) tuple alongside the single-key
+	// CRUD routes. Admin-only and audit-logged (auditWrap).
+	mux.Handle("GET /v1/admin/image-versions/registries/{hostname}/{path_prefix}/credentials",
+		requireScope(auth.ScopeAdmin)(extractAuth(auditWrap(api.HandleGetImageRegistryCredentials(pg)))))
+
 	loginLimiter := api.NewLoginRateLimiter()
 	verifyLimiter := api.NewVerifyRateLimiter()
 	apiServer := api.NewServer(version, pg, cfg.cookiePolicy, oidcProvider, loginLimiter, verifyLimiter)

--- a/cmd/longue-vue/main.go
+++ b/cmd/longue-vue/main.go
@@ -503,6 +503,12 @@ func buildHTTPServer(
 		requireScope(auth.ScopeAdmin)(cloudAuth(auditWrap(api.HandleCreateCloudAccountToken(pg)))),
 	)
 
+	// Image-registry mirror credentials reveal (admin, audit-logged).
+	mux.Handle(
+		"GET /v1/admin/image-versions/registries/{hostname}/{path_prefix}/credentials",
+		requireScope(auth.ScopeAdmin)(cloudAuth(auditWrap(api.HandleGetImageRegistryCredentials(pg)))),
+	)
+
 	// Collector-side cloud-accounts (vm-collector scope).
 	mux.Handle("POST /v1/cloud-accounts", requireScope(auth.ScopeVMCollector)(cloudAuth(auditWrap(api.HandleCollectorRegisterCloudAccount(pg)))))
 	mux.Handle(

--- a/cmd/longue-vue/main.go
+++ b/cmd/longue-vue/main.go
@@ -548,13 +548,6 @@ func buildHTTPServer(
 	mux.Handle("GET /v1/eol/extract",
 		requireScope(auth.ScopeRead)(extractAuth(auditWrap(api.HandleEolExtract(pg, cfg.extractMaxRows)))))
 
-	// Mirror-registry credentials endpoint (ADR-0026) — composite-key
-	// path, hand-mounted because the strict-server interface can't
-	// express the (hostname, path_prefix) tuple alongside the single-key
-	// CRUD routes. Admin-only and audit-logged (auditWrap).
-	mux.Handle("GET /v1/admin/image-versions/registries/{hostname}/{path_prefix}/credentials",
-		requireScope(auth.ScopeAdmin)(extractAuth(auditWrap(api.HandleGetImageRegistryCredentials(pg)))))
-
 	loginLimiter := api.NewLoginRateLimiter()
 	verifyLimiter := api.NewVerifyRateLimiter()
 	apiServer := api.NewServer(version, pg, cfg.cookiePolicy, oidcProvider, loginLimiter, verifyLimiter)

--- a/docs/adr/adr-0026-mirror-image-source-resolution.md
+++ b/docs/adr/adr-0026-mirror-image-source-resolution.md
@@ -1,0 +1,80 @@
+---
+title: "ADR-0026: Mirror image source resolution for image-versions enrichment"
+status: "Accepted"
+date: "2026-05-21"
+authors: "Steve ALBERT"
+tags: ["architecture", "decision", "cmdb", "enrichment", "image-versions", "containers", "mirror", "harbor", "oci"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0026: Mirror image source resolution for image-versions enrichment
+
+## Status
+
+Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-05-21
+- **Supersedes:** none
+- **Superseded by:** none
+
+## Context
+
+ADR-0022 introduced the image-versions enricher: it queries the originating
+public registry of each container image to compute the latest available tag.
+Operators running Harbor with replication (the common SecNumCloud-aligned
+posture) pull images from an internal mirror — pod specs reference
+`ma-registry.io/container/library/nginx:1.25` rather than
+`docker.io/library/nginx`. The enricher cannot find lifecycle data because
+its allowlist contains only public registries, and the mirror does not serve
+upstream release information.
+
+Harbor replication preserves OCI manifest annotations
+(`org.opencontainers.image.base.name`, `org.opencontainers.image.source`)
+and the underlying config-blob labels. That metadata is sufficient to
+reconstruct the public origin in the majority of cases without any
+mirror-vendor-specific API. A vendor-agnostic OCI-native approach also keeps
+the door open if the mirror technology changes.
+
+## Decision
+
+- Extend `image_versions_registries` with a composite primary key
+  `(hostname, path_prefix)`, plus `is_mirror BOOLEAN`, `auth_username TEXT`,
+  and `auth_token_ciphertext BYTEA` (encrypted via `internal/secrets`, AAD
+  bound to the PK — same pattern as `cloud_accounts.secret_key` per
+  ADR-0015 §4).
+- The enricher's public-registry iteration filters on `is_mirror=false`; a
+  new `internal/imageversions/mirrorresolve` resolver filters on
+  `is_mirror=true`. A row never participates in both paths.
+- Per image, the resolver: parses the ref, finds the longest-prefix-matching
+  mirror row, fetches the manifest from the mirror with bearer-token auth
+  when configured, extracts
+  `annotations["org.opencontainers.image.base.name"]` (preferred) or
+  `…source` (when it parses as a registry ref) and falls back to
+  `config.Labels`. The resolved origin replaces the mirror ref on its way
+  into the existing enricher flow.
+- Failures (missing annotation, ambiguous source, fetch error, auth error)
+  skip the image silently and increment
+  `longue_vue_image_versions_mirror_resolve_total{result}`. No DB row is
+  written for skipped images; the next tick retries.
+
+## Consequences
+
+- Operators opt in by adding a mirror row in Admin → Registries. Zero-config
+  deployments are unaffected (the resolver is a no-op when no mirror rows
+  exist).
+- The admin CRUD endpoint paths gain a composite identifier
+  (`/v1/admin/image-versions-registries/{hostname}/{path_prefix}`) — a
+  backwards-incompatible URL change relative to ADR-0022's hostname-only
+  paths. Acceptable because the V1 surface is admin-only and brand-new.
+- A new plaintext-credentials retrieval endpoint follows the
+  `cloud_accounts.credentials` audit-logged pattern (ADR-0015 §4).
+- Coverage limited to mirrors that preserve OCI annotations. Mirrors that
+  strip them are deferred to V2 (admin-maintained mapping table).
+
+## References
+
+- ADR-0012 — Original EOL enricher design
+- ADR-0015 — Encrypted secrets pattern (`internal/secrets`)
+- ADR-0022 — Image-versions enrichment V1
+- OCI Image Spec §6 (Annotations) and Distribution Spec §3 (Pulling manifests)

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -707,9 +707,9 @@ type ImageRegistryUpsert struct {
 	AuthUsername    *string `json:"auth_username,omitempty"`
 	Enabled         *bool   `json:"enabled,omitempty"`
 	Hostname        string  `json:"hostname"`
-	IsMirror        *bool   `json:"is_mirror,omitempty"`
+	IsMirror        bool    `json:"is_mirror"`
 	Notes           *string `json:"notes,omitempty"`
-	PathPrefix      *string `json:"path_prefix,omitempty"`
+	PathPrefix      string  `json:"path_prefix"`
 	RateLimitPerSec float32 `json:"rate_limit_per_sec"`
 }
 
@@ -2676,9 +2676,6 @@ type ServerInterface interface {
 	// Update a registry's rate limit, enabled flag, or notes
 	// (PATCH /v1/admin/image-versions/registries/{hostname})
 	PatchImageRegistry(w http.ResponseWriter, r *http.Request, hostname string)
-	// Reveal plaintext robot-account credentials for a mirror registry
-	// (GET /v1/admin/image-versions/registries/{hostname}/{path_prefix}/credentials)
-	GetImageRegistryCredentials(w http.ResponseWriter, r *http.Request, hostname string, pathPrefix string)
 	// List active human sessions
 	// (GET /v1/admin/sessions)
 	ListSessions(w http.ResponseWriter, r *http.Request, params ListSessionsParams)
@@ -3140,48 +3137,6 @@ func (siw *ServerInterfaceWrapper) PatchImageRegistry(w http.ResponseWriter, r *
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.PatchImageRegistry(w, r, hostname)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
-// GetImageRegistryCredentials operation middleware
-func (siw *ServerInterfaceWrapper) GetImageRegistryCredentials(w http.ResponseWriter, r *http.Request) {
-
-	var err error
-
-	// ------------- Path parameter "hostname" -------------
-	var hostname string
-
-	err = runtime.BindStyledParameterWithOptions("simple", "hostname", r.PathValue("hostname"), &hostname, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "hostname", Err: err})
-		return
-	}
-
-	// ------------- Path parameter "path_prefix" -------------
-	var pathPrefix string
-
-	err = runtime.BindStyledParameterWithOptions("simple", "path_prefix", r.PathValue("path_prefix"), &pathPrefix, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "path_prefix", Err: err})
-		return
-	}
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"admin"})
-
-	ctx = context.WithValue(ctx, SessionCookieScopes, []string{"admin"})
-
-	r = r.WithContext(ctx)
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetImageRegistryCredentials(w, r, hostname, pathPrefix)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -5665,7 +5620,6 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("POST "+options.BaseURL+"/v1/admin/image-versions/registries", wrapper.CreateImageRegistry)
 	m.HandleFunc("DELETE "+options.BaseURL+"/v1/admin/image-versions/registries/{hostname}", wrapper.DeleteImageRegistry)
 	m.HandleFunc("PATCH "+options.BaseURL+"/v1/admin/image-versions/registries/{hostname}", wrapper.PatchImageRegistry)
-	m.HandleFunc("GET "+options.BaseURL+"/v1/admin/image-versions/registries/{hostname}/{path_prefix}/credentials", wrapper.GetImageRegistryCredentials)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/admin/sessions", wrapper.ListSessions)
 	m.HandleFunc("DELETE "+options.BaseURL+"/v1/admin/sessions/{id}", wrapper.RevokeSession)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/admin/tokens", wrapper.ListApiTokens)
@@ -6029,68 +5983,6 @@ type PatchImageRegistry404ApplicationProblemPlusJSONResponse struct {
 }
 
 func (response PatchImageRegistry404ApplicationProblemPlusJSONResponse) VisitPatchImageRegistryResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(404)
-
-	return json.NewEncoder(w).Encode(response)
-}
-
-type GetImageRegistryCredentialsRequestObject struct {
-	Hostname   string `json:"hostname"`
-	PathPrefix string `json:"path_prefix"`
-}
-
-type GetImageRegistryCredentialsResponseObject interface {
-	VisitGetImageRegistryCredentialsResponse(w http.ResponseWriter) error
-}
-
-type GetImageRegistryCredentials200JSONResponse ImageRegistryCredentials
-
-func (response GetImageRegistryCredentials200JSONResponse) VisitGetImageRegistryCredentialsResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
-
-	return json.NewEncoder(w).Encode(response)
-}
-
-type GetImageRegistryCredentials400ApplicationProblemPlusJSONResponse struct {
-	BadRequestApplicationProblemPlusJSONResponse
-}
-
-func (response GetImageRegistryCredentials400ApplicationProblemPlusJSONResponse) VisitGetImageRegistryCredentialsResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(400)
-
-	return json.NewEncoder(w).Encode(response)
-}
-
-type GetImageRegistryCredentials401ApplicationProblemPlusJSONResponse struct {
-	UnauthorizedApplicationProblemPlusJSONResponse
-}
-
-func (response GetImageRegistryCredentials401ApplicationProblemPlusJSONResponse) VisitGetImageRegistryCredentialsResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(401)
-
-	return json.NewEncoder(w).Encode(response)
-}
-
-type GetImageRegistryCredentials403ApplicationProblemPlusJSONResponse struct {
-	ForbiddenApplicationProblemPlusJSONResponse
-}
-
-func (response GetImageRegistryCredentials403ApplicationProblemPlusJSONResponse) VisitGetImageRegistryCredentialsResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/problem+json")
-	w.WriteHeader(403)
-
-	return json.NewEncoder(w).Encode(response)
-}
-
-type GetImageRegistryCredentials404ApplicationProblemPlusJSONResponse struct {
-	NotFoundApplicationProblemPlusJSONResponse
-}
-
-func (response GetImageRegistryCredentials404ApplicationProblemPlusJSONResponse) VisitGetImageRegistryCredentialsResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(404)
 
@@ -10031,9 +9923,6 @@ type StrictServerInterface interface {
 	// Update a registry's rate limit, enabled flag, or notes
 	// (PATCH /v1/admin/image-versions/registries/{hostname})
 	PatchImageRegistry(ctx context.Context, request PatchImageRegistryRequestObject) (PatchImageRegistryResponseObject, error)
-	// Reveal plaintext robot-account credentials for a mirror registry
-	// (GET /v1/admin/image-versions/registries/{hostname}/{path_prefix}/credentials)
-	GetImageRegistryCredentials(ctx context.Context, request GetImageRegistryCredentialsRequestObject) (GetImageRegistryCredentialsResponseObject, error)
 	// List active human sessions
 	// (GET /v1/admin/sessions)
 	ListSessions(ctx context.Context, request ListSessionsRequestObject) (ListSessionsResponseObject, error)
@@ -10468,33 +10357,6 @@ func (sh *strictHandler) PatchImageRegistry(w http.ResponseWriter, r *http.Reque
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(PatchImageRegistryResponseObject); ok {
 		if err := validResponse.VisitPatchImageRegistryResponse(w); err != nil {
-			sh.options.ResponseErrorHandlerFunc(w, r, err)
-		}
-	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
-	}
-}
-
-// GetImageRegistryCredentials operation middleware
-func (sh *strictHandler) GetImageRegistryCredentials(w http.ResponseWriter, r *http.Request, hostname string, pathPrefix string) {
-	var request GetImageRegistryCredentialsRequestObject
-
-	request.Hostname = hostname
-	request.PathPrefix = pathPrefix
-
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.GetImageRegistryCredentials(ctx, request.(GetImageRegistryCredentialsRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "GetImageRegistryCredentials")
-	}
-
-	response, err := handler(r.Context(), w, r, request)
-
-	if err != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(GetImageRegistryCredentialsResponseObject); ok {
-		if err := validResponse.VisitGetImageRegistryCredentialsResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -12680,247 +12542,244 @@ var swaggerSpec = []string{
 	"r3XEcgs9zA/vZaB7BuKFkxqmCi1xRVL4YfewjDuiHPWGtsHN16I42MX91i6wxJHqkbVXLsgu1sSl23es",
 	"Ac1znPSomotYRAGtRhYsX5PNO18c3q5+fesyT52IuG2BS/cE0cNrbnEK3GdleMKAbz1jykcRpcCnUIqO",
 	"K8foQ9YWbNG7k4mNV37hUl7nHt0Iqn/YdiRvMwPE/5qfyZkaKNvxgYLhCIgiQzxWZLsuMyeudAhXp7Ob",
-	"yeSGE9lGyW7thNYQlprPr71h70pBYEm6Rr1FQ6bqt1Bh36vSBdeC+0o9jczW1aW8o5e3RxSXC6wspzL5",
-	"tj0HffA69vYFGG43ul/V1l2d5gyGGsw4BCfW3MBUA0/mPS+11SPv7znk9ZdiaVF+YHvls9vWGc5xdX2F",
-	"NX1nRfEaOp2xPQh3eSsJLYdfK8liUZPcIU6qDJf2aF0rw5cA3sD6nICU5RiwPZlSvOFGJAxfLZbTTJf1",
-	"NYmaG4f8C1+D/7vItZoCOb393rvsHMAXtDp83Njf/d1iOEOtB3Tvnx3/r2/CT/t/q/V2LyQ5NomDvD33",
-	"eCXX8pa85R7wm7zlfsiu3vKt6FyvzVXWFuqHoVq39/z1eYdCmlDp2u+yt+Q7z0BXMld38ZzfLt4se7cx",
-	"SKlabKrL1i31GXmUw9hITnJjmec3DN6jj5wcFYQIXn837PHhY9rn9izyZTf/MrJdy+sfzi7H6DheTS0u",
-	"UapJHEBRpO26gQCBHn8FgQBLV29TIIAsKMAVIwH8+fTilBuzxrUbKIgbQreZilz4SEPNBlgBwKrgiY1a",
-	"ciTk+6jl/mk1h6G4XHWB1iXtfz4+UCzHMuApl3F9OR1HiXjK3LhOGMd4ktB1aHurk5CjSPbJtth1Y3/y",
-	"Q7v+ZP75W7/LXhR+DiZMJPt/iuxv7cJm9rc2y5S25m8f+l12qrI85d4hPRtzi9roME+HIk0hofSYgDQU",
-	"qRinKk+q56mkT1AqyouaNlM6kq/A8vTlT+wAeVDn3ckpO2CcjblOMAMHqUmxWSU7mYZJlx1F0gg5SqHY",
-	"A7PzTMQ8fcYmeWpFh343YPPMhLwhCmxNcp52jOXxJdubPv52+mSfYenNJJcJl5a9Ozk113HVTPh7n5ZX",
-	"cckXpAUDOtfeCKZVjg5ZHLbeORXyp8rzQCdbWUkUc4KROFERM7bnzrbNnN5N/0V7e5sNeHwJsqjVE0m8",
-	"jgd4/vs36bGyac22L16eL8Viu+2JRlt3GzKRdBSJ3JBD0CBjSNg55sQhYbm5HXxYT1d39fouS0LX8voG",
-	"Lt1H2uwdwVxDJEtXMGvqCX4ZxPolivf6/PzEAd6qkebZeM5Q7KSkOeP4AtUOcSR7QWR/FOInInkpZNKx",
-	"qkNvTniWOTwvTs/HQwEj/yAZIsX7MFwlkC4meUCsfFZHuzXIjZCOl7dbFU3C/ZVMhHT6IffW9/pA29UH",
-	"2Xhu8EmdWvlSjYRcG37+1pva2LdFyHmb6toEZr3KNHeLPK8a87bwriURoWJc3hir/Qrq6gchKadgVTtv",
-	"M61SaOMJwnAIMdUUwhTjGqkgqQcUEwkJQQ49/uqW1y5qS1UeFLnoW3WvkEG4OBUlZtEHFzMZp6JIwvBV",
-	"ttpFqqobHkk3on/kq4QgHj1lP2Gtjn6XvT0JQUiY3a0Tx5Xmi5i6kMRYm8ido/XAXcQNGQU+GXgJXF2G",
-	"/ih3zQZKWYfqmc/xwqNxY0wkqSx1kREx427ZhgLKuaQXkHlTBgwbpCq+NFQ6L5KOKwGD9zFklvUPaKmd",
-	"8LW+T+RHhxhG1jjoJAs5IRW7WsjLbEYrz1QthVwDjE1Z/i+WkNSrWG45//5//l9K9g9kSfk6LD6OxJeu",
-	"aTcu7eBPe434u7r4Ar833vVmINhGA4oqU2uLARQVpJofU/HKBmtVWbu1iRHl60juKOB2nfSOmzVb3I71",
-	"aqFy7y3ZrkpbygbrVVm1fEf71c4oXmvvKbsrbLP2hJGOO0TyJm097e2mthKUDYxtZT3Vj2NqW05OW0G1",
-	"a1muSlAE21U1g6XAiia2q7L2/XWNVyWJ/grMVys3b2MmSzH6S8hluVhU6ykSwGewXCVrpWEqSVGvj6eV",
-	"tBK21ySPZB9rf1khY0sRvc9Pji+Y22cHbYJi6KvqtZ1YSvUNpoCHt7h786lkkXxhWRQfIz9CVuScZhkS",
-	"oTZhAtqwa2RIjLlpyupwrCOFKXf0euDLbYTMmyPUHsgGHVoDCTmKWvsLaRNujU4XnEyUoy9YTrfEG5rE",
-	"sAW3lsXIVmiI8DeVAbFQ3fUGciAKwrurPWxVsrqyRazk/TdiD3utkl32oZJ7/Wer/hNMa14BUsl1dB90",
-	"+WzNdi4Eye6XrP2oZLPio5LddZ4dMPqzVncc7EpNx+SDRDk59oa0nRvG0lvWdxwsalUdlTTTclRyAwqO",
-	"o7xfg25TuWGb1Rp3LM00GvZKJYAVe5SMJGfe4tTxicbBfo8ZfOUlKAvTBWnFsD208UeYa2ZNm8VK+kft",
-	"svLum3OG7tT9LjvOsYRhJEPWeMfJkQWf3eujWIl1DEtFxP2JoisqExXpBiuplcoY6hzeMdxDj1B/H1l3",
-	"VvFQRxISgenqB8EMbsda5aPxsrDpyc6ibhXJQrmCSW0JxzRVMcfz6sVZXuMmOX3LHBInOeLHUhY3EQpy",
-	"XKEFXk9pc02yuatzQzaGCWie9oxVmo+WGePWD0xgoig4eZe3MpWYRu98wTo01/FYWEBppv78qyO6bENG",
-	"NZ8kTx63GdcT978si588TqHNzHc/Hr5vpgzEPOOxsPN6ZLxQlqfMLQmpHUkIGNpBji+KEgnf6MZZzvZ+",
-	"zzkSiEYFBorpr4SPxdvNkbF4pSkmliSrthKPzU2FqpHBouhEtXfmhJA2e4XLO9VgTK4dPXwuzGXxJzs9",
-	"eV7+8RrsTOnLt7LIxdyvhttgjS4kxJRsU6ENlG5sHEPmqPXGXLIhtUZxhK3v9tY/8LE9fVYWQ8+4NnB7",
-	"MStFDnXPJ3Cvr2vhK2KGF5KnBwcPu3/pPvyu36Ryxp1Ypz6V0iQ+nstXnqyrsx9Cvk5OCS/9da2EfIkh",
-	"43K+NN/j72umW2Scm6A74Bo6jqymoTIJvlKYQZ5DmrJTNQP9IhlBJM+ePD6MWvtYcyZLYYKyCUn0Kk86",
-	"iNWJ0wKN5dJXWe07wSWSXuUraPMztig3NLTxLHx6dWtYDygk6mLfuW5ZoqUr1EF4v0NLw+OMpK/uOnki",
-	"uu9TrkdYfvnccplwnfSePza96fc16PTw0Q+1S9xw2qdaTLieY9VJf97+jOvPvcl5X7r9pdWLunWNDii9",
-	"TKv38zWv1d4U91YKdj1J+JUGsJEoGjQxDD/YWOZm+jXXuWlmoSUqKEc9Hwe1qg6dsyGfiHS+Cd79VMj8",
-	"vcPtmZCJmpl+I4gr06MGWqtFwx3nfHNOZTYCwMKxvh3k0ubs0aPu4ePud+zlxXldGO+TOzBIk93pbqv1",
-	"qKQXi0Q3KXMTKvLUGleOMb42DKl2CyR6kUHcDU9PnhekjM/M04ODA8g7MzC285AfiM4hH8QPH333+Psn",
-	"f/nhx8MEhjUkrX43aKCprRYzBSkAGwdR1A9LQItp6OCPVBgFq76nbKUA1o3kRVArix/ZHmqqGrhR8iDl",
-	"xl5oLqlA6oWYwL7vEINhhv1SmOszlGC2xSHVYK97tLhoZBsd9/sS7/imH0hAJFeKrlEAdCdLuUTu4QRD",
-	"Un/Bxkn/js39KrmKpb/dIuW/rm0Kark4Jw6pYB/9sBBnPuYYaH4J8zaBqO3jBj/0Q0NelbCUy8Qw7O5A",
-	"5caHTNhIWpU6agc+JI0mpG6o/isOCV4rvyY4eK1evIc4tzckFlfuaCEW57Ki56+CB+GwMKYIsHMoFNvU",
-	"YYhOlOyzYcpH3Vos/UPJrSKNVZlK1Wi+hJru1WVpprz7Nff8SUM/j0p2d/FUDcmfindnuSl48+0sv3nv",
-	"9dnN67MMvxv0AD38ej1Ay1Dd5A1abeXPxeTqFwBf/yozlWsh8Snh81eVvlx7Gjvfg13dpDvehq3uyNN3",
-	"xw29kQuRNVf2R944jn3Vqc7u9OrTnGvxpIlLNSteZFMi7bF79dpe1nou8BW4XTfe2I1+WHe6Vw0sxeZs",
-	"aIFdPKJtKmCph/ywejQDlcukR2hRe/1+/jVoiCsCAiqGbkfCMPwOJvCFtm+RPAWJFexO3x0b7FVMGsfp",
-	"Oyx8N+aGDQCzZFJAt+/em9fs+YuXLy5esPMXF+z125cv9+vvZIPKMJ+HSW97gKGDb31o4VPmAdxmPzno",
-	"t9lLFZpZbTULUP4hJFWH23JFQD+EGfEHsD3USEO5XtMNTfy6/gP7bWw9yK2YFPpi1Pr+7wLbBjdalP/S",
-	"UvL/1hR9j7z1fPGMz1gfl07DXqPOF1Tp03ehgABmnjluX8XlSB77dGGqbIdHDVOQRGjI+6C9eY8wPaC2",
-	"fGAjiehNncQgYXOw9by0gdZcS3F2VaM3Cxo3nkdMPRRuQLO+rkD1NcSgeUzuhlYcHczQS9rMqNAV5obC",
-	"zx5+yuFnq6JOXSzaMoJcSYi6cfHpa5ScmglNq4LHjUhQay8TDUTPtQl8At5nyoRuanLO1DCS6Ij4B9XM",
-	"jNFGf+ZV21dczsPfOIB+WH7lVAU7/s1IcyG+paZJcFHS3g/Z6kXtR62HhwX7PqeyroHFP2OxksEfaxUb",
-	"zDEXwTDu40/c8xi0bBiH5DhRT8NwDRd/jaWYSXwk7uzEIhJJ8N0zGHbdq82K+ixOVyQrr85JCmeTiXFk",
-	"w9mN6GEv0porfXx+Qn1KqQhZKWecvnPQPT4/6WDNlSSswYgujXeHVHRcFrJjNQA7YCmMeDwPxDAIb03E",
-	"kC9LiN4uQx+FiKsgTkfyDFLgxnHRn7FHdVPZmvArU6mI53WCteVCsgP2HBUfdsDOAGvSL2HPwyc3LiOT",
-	"l7vW7RprtxaHXO4o/DTBLV4iG33oF/x5P8jRkSzx9oFZ8Ch7wScvG8okwlyyA2bGXMMKQL+v7x65lY9c",
-	"VxT+9LxL1Iu74W5U8nVaz1Vybyv/SLbyTCUbLeMq2Vlt24TFWxUgt56GOThXKu95b/W+Tau3O701Vm+V",
-	"bGzis6FLT8NbSIXOJ47Cr6k3v7aC/YL4uPrU53+uTyu+CkVYeWfm+1n1Lhd7NdWMaNZJotJuqNjf2kPG",
-	"E2qkQKvk+iqzSr4KLbmkhJsVY5VcVRcuO5ttbXm70N+tGtBfdKjcqCM0+na1EdmK2vCKZ9jDNwz2NluF",
-	"uTpUA74TdFEhh6rLfoU5yVZ8UFa5cmdLYaUYz2bZHCwDqUU8dvqUVLKDqRBIYC0ftVkoD4+jhWQ8TdXM",
-	"4XMbMcJ/ItMqBmOA+nvW1NT/XKKLE2igfkvKJKSeecKEbDWMgm2k/m7X1tyXt6prZ9Qmoc3O8zgGSMAp",
-	"bKSm4em8peZi1QSqRrUVmul4mUrqg/FVwioB+Hsnp9PHbjUnp9Mn+112Uu3e+wwxaMpTgTTfbZbLSJ6c",
-	"slRY0DxdWUptrH5B3OvEiAuVdVKYQlp0PfQEg4JLfQqbA/jec8hSNccutgeRPLfcwjBPnXR9wJ5zmCh5",
-	"DnYfE+IqeY8znl76XKQfTCQxzvosFFNl8Zj7yoBOXC9n8ImdWaXdo1HpFEwkHQQ71GSLnQEK/G4N4afy",
-	"G6Wnkb6DYb5SRbJaOZjK9jIuGa4MK91V2qyxRIGRD6xPUpmD9b6rNvsPNWizY63kf6jB1byQH+op+86q",
-	"akUs/nRqvZ5qNUjr0gbOfj5mf/nh8C+OLLoRPiq+hvXTg/qeQlorbdYwP4/Q/uJg2V8c3vYVOklLHJA9",
-	"pRArFufG7dVOPQFjvD90M/umT5Qv/NagjHHIFVqUS+v7dpe9Bif8PfUp+v7HHytdix4eHhavCWlh5PvS",
-	"C7umg2OZ4DTkeeqm5gOV26eDlMvLrZ3El7bvGy7SbBubKZ5BrGQsUvCuqXP0TK0V5Zsqz5cAGdlvF8TH",
-	"LbU1N7mfKl/cuI/CMrxuJ1db2s4GhM1KWdPdnIFBZPhz5XpiWMbCOoS0Tx63VrFuaSXh1Y3zFm1418DP",
-	"keod4ffpwJ0Wv/0QVL2I/x4SSiNxwnwGOlTE/ovPicBnE55hlwPOhvgCFaF1b/z7v/6bCuvTT9haKFho",
-	"nDh0dHrC+gbiXAs774dyvcKUVL5NZt1Q23gikiQFrKn/LzQtWMudtsyKScxixgvmuizUMcZyCu5vLLCA",
-	"/QnDv6YCZqBrixufU2H55tzSv/BVmkP93j+dYrBflUHUQ3+TUdQP2dUwuhWntxpHfX+G+95Hn6FpNJxd",
-	"vXnU40YTA5z/0LWNcIEmfwWGuKWbt9EYF+7/VQ1yQRKtsSocGSNGTmH2EvTJabU98y/AkxSMYQdFzQc0",
-	"2ITz3m+S8X/f56imzxHq0v5cDRrA5hlEsv+y8kI/9A5KqbnMPDShecaUHYPGdww1QCahDG8Lw/NzU2BT",
-	"ooUqVKyur1Eki7ZGL396ttIQKfD75eZJt1fXBQsB1eT1+muAj2+0B5EjfNRaqs0s1yOwPfoj08qqWKVt",
-	"NE72brz5kAFa0w3ejlNMVkYW7D/eZacqcQTDxmMfZqznlWvCscWoG0stYJpclqDwN6DmF25orcmqOmCT",
-	"jFHQv3kGXXbMjduF96ohajpNYKFyrTWQDiMJE0GYUthpufWKhVti6Ba0aLsd5jbXUBabe+buh0xS0AuG",
-	"ITlUOvbzTx8ykw9MiMIOiklBU1uUnHyqtJMEq3e81W5VKesmTWVX696ybPfpWPjOSfer4UaScWqFMs4n",
-	"XIYGODUsbbuqVVPYKBMazE7v1AmJfvWVWCQPOHRdYOtw9F6M1QwDGKna3zOi0FhBQqB7g+q9pcAvSZ7n",
-	"JE6FJuoL5SGW+hvnZse9U3SelwC2prg4ttrjI6AOxc2GN1XD1raNeQ7SvZwK4zBIad/7Jy7LdmxvIYNz",
-	"huUs6V8LgFvAhnrxzFQbjW8Sfj3Gely9ARnYNGxJflOi6FtT21vN30EHziXNs/RyXOlmbrVmJMJg4/9d",
-	"Onhv/egQHXjY5Ub2YpXXtd8+dhcvzvE8aXzZmsppnZPMGmaEjIGchybHcO5hnmItU9llZ4AFxKxih052",
-	"Xx7ACrzOZariS/cCmbvcXyp33EmDGas0ieTek/3COdV3zxEifSQuRcJPMNkfrgVBxYB/ZeuSsR5wN3ki",
-	"xZZWD+IfwavuGHMuLeO5VR16wavh8D4GwNQopKt4Wh0CcgFDp92x8Jb/UowlQBe6rWHNyXDQXXZMfcKq",
-	"Lch8t7XTo4vjX9jB9OEB/nqATcwO/hTJB6p6yPp0rH91O+53Mc+Q/RWdsbSKJbX/WuBb151tfUWh7f3M",
-	"bsJOdp0+gAUB95Y0XPkuhjSiZqUZbK0pxJtkyBBSUrpVgtasCd5zcnwxB5EiB9D4onwsIhs1VcYyVKaY",
-	"6KqyWDxIyUgOsbYiYnDUYsNUzcjcOuSpofJhBoMRqHUeSgy5VZOK2Wz15Df2b6ya1WqjzXdBmw1HvtF8",
-	"d9T5z8POj91e57dvt6d01bWJ9OtchwpNODgC9Lp8G7no3TLtUiPYJtifg8X2vf2yN6KGMTeO8ziBnnSZ",
-	"SPbrsD1Qs+IjgT/TA6Zhqi7d26RYLspDZZw+NoUsvlEllNSZ0ZCEHBihcTfDt/4OtHuBAVil2ITLuaf9",
-	"kSTiH/h0XZHssPB6MtmcoN7dtUIoreOPDoE87BYEBHei2EXTsP6q2IOm0MNuJF+rUKJMFSD27dWd6lbh",
-	"WuyYSzYAFqvJQEhIiNmhESqShGde5/N+CcOxyg/mcbNOh/E0ZQRZbHqdzhm3auJtW469Kgns7enzo4sX",
-	"9aSsznzwDrQYzi/UJaxveksNUX3TTKvYFN+hUKPnr/7Tp1CzEbcw43O2R97Qh0/2Hb4iRgr0hJqx0rYT",
-	"Cx3nwjIh0RJAnzVsAEOlMXRtzmKtsEc9IEGHGU9Th/XSMoUlay9enlMBOcckSkH6gWFZPkhFjEQJJGgM",
-	"IIpQVkFPG+ufvjm/IOEjt+MD2km/Ds2po+s6K/np0QXb66fTXsZtD8XLmLRWEjX9TyYfFj/1ndjq0736",
-	"XI+U2eHdJlU0lwNAljrSrjly0pPrItPcYSN8fEcvdxvy1Dpp2+ZaYkRhOi9jN31nX0MGnmeRDAd8wHIK",
-	"9mMHjDRG9xsRvOL4R2AZZ48PH5aBYt42QFlJVLtzj/slgQ4yqJBD0Ix6jQ2Exe63M63kaL/uVKmeBlph",
-	"e/629urtE3ih/eKEMXm4sFiUbzrpFKbQvnfjB7T/ft8Xuqy5GljL0pIVzdH0X38wZbCeQYA+i+TS5/0i",
-	"0MIYSppiDUVDhT/Cx2MuI6nBHTN2OAh2utgpR95MpzkZvcccmcqMY1PjK1bxiLFp9JrARt/meQ8bgKuZ",
-	"u5u+EvIlOHLF+jwTPdob4fdWuwe8z9bNhHiFSbOcvZXiPYNMxWNmIFYyKY1qi8gaSUcekEYTXhJJK+GJ",
-	"SiXRCI/9pux5noJx0qcaYpxzaHQPCbu4eEkGvj14n7EOk2q2318C8bpInXU9rt26/EJAJpkSclH7Itxh",
-	"gwqlNl12jD2vizgRE+7MAMI1SioNNIRhZ6fHXjVHOpwoTztzPXXiiPVYPVbZopF2ffvrdQ2b8dgeGN+D",
-	"OYTHmMUTQGdwrKRBrWAMBiLp+USJvKucRQ2mQuXG38uJMN7MveR0uFab52NlJmBFXETPpmrEUiG9LIjR",
-	"M8HVFAoQh20ZkUBtP2iklzVWJB9RQnIeWjkfHR6WRk40mGA3O7cQb3rPDXTrZYAql6AZ2w36Rr8T2uY8",
-	"fcXjsZCwKeenCHxR0vi8nfpYzgUyXDtiuVL/9XKIRP0y6OHGJKL6NCE1A91DEbv2uYaRN9CvFV9vIMGo",
-	"Jr6h9vxCPF9z30d445MM1gpksskGfnVj7yDAK8x3n/S6LcbLk5tbCvUKKRcVP/umsK9wbLvGfW2/HwFJ",
-	"d/seoevKFosMEUySSIR7hm1Kld5cHbJJfaICZE0rU+4VJ9rGBe3fV6i8kYC06s24VlxacaL1gWkBmz56",
-	"8u7arNgrZvXiQfU0pSZVp6zI2JufXpsH1yfobj7Z8kR+rVUAtpA39/HaqI6+e9Iny1IkV8I7mI/uOCrz",
-	"7DA2nu1VE6zalVQvrLtSCHjHxRL2MZhuAGXHY0yZc6iIkSXUOKHoa8Uj6eNHJmJEDZ/YngEIofTf7S9q",
-	"GGViWavdqmS/tdqtIvutVgEJYG1iww6QvbYduxC2voIgzGU2uDEKcynN8T4v+j4v+poRp6v0fulGhU7v",
-	"xMH9QIY6J+WoIuByaUXKyH3oG9eUOFgNENjMTZYdmgatnWsmfVYm7mK5XamYiXnKNUv8i/TC1hWYDOJt",
-	"YZRL7ETIpOwJ6/0Oiy1T47HCinrVGE+sPGes5hZG80guZg23Q0gz6tKU8lIS6v3FXpkGC9ZFkhv2H+dv",
-	"Xv+04LEIp/thA7nZNZJvRVq/mVC+tuewbUe8IlkG9e1eWRVDWSnp69wtmm4ZOV+OcnfN/myRge/nIJOQ",
-	"3W3lpp2eFNZ4NFyr3HbUsDPgEnVTiZy5776ptPgDme9T5r085H0g+yg5H7qRjOQ5ZZGNNJfWp+rTHE8j",
-	"yViH9d316jNGLhmHLI6Yj8CWDR2NH4ndWfs0MkQQyMRfN7YnJo4umPDFwojthIwHhhQfcN/b99+jdEaq",
-	"GqxhoqbAijrIfghGDvgpeZqGYgl8oKbwzLfqXTSf4RsdNKoGg6txcLggYzyGkoe4mfB5sjfi+mNh0zkz",
-	"3AoznGMlA3oYWCq2R+SyBA4C+bSSSthmEzK1Ve3/XkOuRtUEdfbtSSRRgKq4uDC+JpjYF2z/Qv4LQ5UL",
-	"8y/IKZty7W2keGnQbohIUd7MsbVZJbSPDMxremgW3usYRyGHH8yXXXDoVO132S/WZu6+tSN5zidwLiz8",
-	"9dxqEds2+6EzVrlmJhVo8CVjf5dVwYXwe4G+8wKmWCg0s4aBwJ33y7uE3rj+wi76lJdJ5+QjkyfUH44n",
-	"leaxBSZilucexZSQfX2fKR1Juno+7RKfExT328FjY2dOsLNjQ2X2Cm9vJBM1k8Zq4BM07ystDG0Fk0S9",
-	"AdtBmGAa9ImnLfKC9qY59PxqykPjmfgV5q0PHzDFfahqqgK8OL9gjmy41X7zTelS/eabNuNoKiF/Vak/",
-	"gJwKrSR1BOUpJcAED1kkj16fn5+wc4hf5xPqaLd3/vp4n/2e87R0KQ41n4CTuvH4LsbCFF0k9w67D7uH",
-	"+1S0dMZTqnt46e46otQUnNjgqc9LMQUJxnivPU8E/pVpNShogA8k7xfEgR2fvX2OtC0fGPg9x9rBXjJk",
-	"M5GmjCcJ9gpus9eltSMwkjY7VQmS/eDEX4COFXbudakJzzJ0l/pK/QSbmGurRppn4zk55wzhMBZLYEPl",
-	"hDZWlGvY61fM6ge+eMO3/zJKYv3XSGJ/UR824k4yUXHuDocA7aAYCmg6kto/SFRsDshuWXUkVdq7m2fM",
-	"iBESGAzcO8iFv61eTrLKiXIsal3oORPWsZmo5QlIPplwPV9QXDsx+kNiQqdllGGrGFNiR1HJICA6VgfB",
-	"7xydnrTaraJBaQvRxrfQlDwTraet7/AnNDKNkacejIGndvyH+/cIUC0siMZJ0nra+jvYX/wQJ9+RnwVf",
-	"fXR4GPQQH9pdPRd3Hu43Ejq2qRE0Bd3L+iwdgVdrCt0F6aD19J+/VUFcYD/iu4MVHxmntNE2W7+5lw9Q",
-	"/q1ueanrHDkEDauQoAQyJ67J2P2+l3DLB9wA9eXXwONxKOOxAr0zmuxjA49kfqt89IfVfDgUMRrAvj/8",
-	"bsNaqhes+ZpC1ZXNi3IKGC5s86meLZKxdcda8Hl0Oa49XjR0tJkE7BDowyS92UNDrHQCCdINR0KUNF12",
-	"RqKKj8Pp4+e9jNOuyoEDZceFCIR+b186oI8c0hBb9b9RoIfbPclWU2HEQKSOVgbLEAlm9JtVPpMukhSw",
-	"qQrntqN5P2P/dBKNjl4/74TQqi7roxe7zw5YHzW7fugagXtRcZxr7QO9tJPA2d6Yp8OOoxlPWf+f+Hab",
-	"lML90B9jEclfCmOP3KZeTB0OIHlx9MqibWKNMlIOOXgpJsKiz2DLwGMyFbmRy3aVlEL4sOeFE3O8moGe",
-	"J2GKWFwUGH7PQc9LeYE7HY9MziVub7Vcb10Cx1g4x6o5K9TLguGi58KXL/dGUqdAuXVSCEjdSsPbPV/S",
-	"plzuTS9PJFvXsASwHVZQmZCuGBZrD9DAoyLpfj0k6L1rgsCrOk6DKFcU4uW67K1x+jo1COLSzFDKYlFr",
-	"hvY6asYSAkbqQpyiViX+L5LhUmNEX0f7ymMoyhHMT05NRapd2jCNWdhwUa8kE/iSm7s3mrkx1Cj7t1q0",
-	"rf26u+T1+L/R1l//NaQVu3/tt1tkkSV5IhvoKldaSsKioBXEE+SRjw8frpujWPTBW+k1lT8goZe+2/7S",
-	"z0oPRJKAXGaBiwaPf1IZmtZvDupLOmf5bEkYMnZhJxXGSUVulvgm2laDIdatEY2n3sZZKx26KU7cW2fl",
-	"2Gse43WcDdWlzLeW1FpnyF9Fjje/fio44I+tFgf8s1UcQKU6z3wLjfJYS3P4CmZ4f2WBDG7OVqZMDQ5Q",
-	"sMAi6Iu+XT8pap5+I7d4YY63mQHtT6s8VR9PsoSBD29nCXWoQtDwR3+4/eh/4kmINr8rFHNv/Lj9jWMl",
-	"h6nwxuebxMmjJMHuK941400BO+FiM7J18OdYGeu40oeyTtwqAlN3i2UEXpJhkdE5tbnkc+HjrWUE3CSW",
-	"rHK5x3Xd+dmxx9a7RIrH2994rezPTn24caQ4I3N1BS8KM+OuVIrbeLx6yqfu57s85Fumf7ifZuTv8O7I",
-	"3x1yyo+NseR2q2DsA8O0+yV1+mybgcTkMDZM+Si4m8HcCnU7+NMhbY9yZz4cxBowYYSnZq0V5MzHarkL",
-	"lkCs5xlWds7tuBfSIn34th1TbkKRekeFiZhWsyIzRZAetRdW1GaVBe132SuuL1m/8lsf/W49rZTtR7Lw",
-	"7od2q1L50hdddlS6n4pw8k6qRqOQ/rxicVtA0uMKLG7tvq/omm/PXnZAxirBlP9i18/QSoxpiVQ4mz1A",
-	"EDxA2GKhpaD/La6q8o1rcptbogVVMG8gC5+uQPRxed8UeMqylAtp4b1lWg2U7RQlBkrYkpOiuIElI9tG",
-	"U9qt9x1vFm0BBTq2FulM8Nxt1PXOw6Bbt/HdJuZWq7FsNQWUhVg+ZxWwrg7SVntAGIclKRYl6OXonhR9",
-	"fZ6EPyvj8ULS7gC4piABrOmPXvARWMMeHz6MJCd7NHt7wjQkQkNsMdqGqqDUUPkzTJk8L9y720VqeiPp",
-	"fk1ERV0CpbtXM+hrDn3Xy+wXcJK0Pvy2gDDkkNhIQY4yQYEjnzcJCdtoRkO8o+azpiBLMTh7E7A84ZaX",
-	"6ecl/ypqkU3BFPkE+/WYp8wW6RRrnJXftj7Llcc2nTMlYwhxP5VSZxXXuI/Y82mhwhrG9UjJRyJxkubY",
-	"V1ehZO0cyrzQSGpwcvYUfCRul50MWaqMbfuMbZRHJ5h/isHdSkIdrSKLUECYWzKNhc/7zJ07toqF2V8J",
-	"WXsbKDPZgQqSZ5WzpKJ21TPEaMNPWVa84av1qkSfhQu2jTXTLdzKmM+xaIcvMNDjtv+MKktSiI9HRFPh",
-	"zqF4gYYYxBQi+fjwIROTCSSCW0jnXUZnqdWMnM2XkFkfOpMIatcjZC4skYTc+FKySAmLfG3M0ZkKmLGM",
-	"Y43CqfJZsuuZ/cIFuuf2a7j9VizalesizFc5PcYgbGT0b3HEZ83ki4JPWxm8L/n0OfP3smiZ2cio65gb",
-	"Fqu6HcZWqb92x0yNKnCtnrz7PYQfd+/9POvR6jjUxCtRaxtbKysgbuJqx9zEPKGEjFAL7IEp1FqUy96c",
-	"PD/2NXWtANNlRSqALwyGBfNIJPFRfJiblLC9N6/Z8xcvX1y8YGcvzi/OTo4v9n1EPdJYO4ZJJOF9EduO",
-	"IWRtKmrEqTbIJChdwWaKyjDuEcO1zmCYG58DyB4f/lgpx4L1wpkg2RdlVkpVw1Ad/GgkKdwdC8qk3NhO",
-	"CH+fci24tPu4mOKTFKbNZipPExRsEa6e3wvNnAzmbU117JeU++KKb2O9NPxTZr0f+174bvp83Y1or43E",
-	"rT+EwzsheV+PLPV3LMC19nB2E2gc6E6oiEHhmFyfbGVgwqUVsbmtGouYM4tVRZuUWeT2Y9RZ3EQeCUxE",
-	"ygpqy5KyI6h7JZJ/gFZhS1QwHSm46EKXJTBRuJm9vlYpIESkkkREKW+FoEVjFqtT7q8nywV5X6Gg5Cnc",
-	"SUialEjx7e532GcE3rFzeC31oCoCPgj3S/IDfWxOUrigvQTk8LldlJ5us4C7JJxUb+gGQSy34wMiJ51q",
-	"YdJ6Q12RK4GCRq6xvki5AE+vSAJCCxnbC+a3/XYkQ7XROhpGiaShOCZWdiNS5XOM1hSGxVqhRLUIuh2y",
-	"aJAURFH3jw+/860HQw4jGv1oASU4ixredVY9HHtaKRt8C8rP4iTFdWhyrR/XJT742vMh1fZzsrMtX4hl",
-	"XYOOroqFS4dYxfh8IWcEER6LFm6NlriUakDoTFwr4yOH2ZAYsmlhgRm0KKuEz7EFJUY3YNIlqSQLBRK5",
-	"TNpMDJlRbTJ/5tYqSXn/Xcpkk5TGns59RVdsxo2Nd3SoPoolMLGMvzTCXYo1gRGOzhzTRm811rqYpYYZ",
-	"uKcFBCjfd2PuzymVseUrrwWHIUE/00DV+jcfMw1ZS81evC+qCrMiCubbsmkDed8Xk3lDFVjvyiy6eFP5",
-	"ktBbeqCSOUlFJPjkGtieVI5CWyEpC2IAdgYgIxmKxKKK6mjggJedI/ZRGsMKzct5rhhUE7KH2bcr6cPk",
-	"lx1oNUMThu9rJSy1lijMwo6CdpQWI4FVVL2NOFSHxyLLtWlAHvy3QQjx29elf6HTTmG7abfGwBNvyDwH",
-	"21mXxH2+eOIb804+3CVRffTjXWbuXQTRfUlkZxdOgRhxIb2nbOONPrdc28IqVOOVrr22Krfr7201/oCq",
-	"DHaMSErZQKsZ3iMvblB1DzzKSJ7ncYwkxIgUJNpzlC6khUpCsCO5U8EXKstGci9QY/JpqEvYZwYjF5ys",
-	"JQwTCUwy5c5nzaVxO9sJfamfSHeLNFkrRi5xzRc+7iKwzB2OhCqSbQ0tLEoEeFPcvO2FVCoVjwIclgcg",
-	"YY+SEmulQYyjpKK4GCbCsUyLqDDeSLpPdzi2HpR8Kka+9gFmwlNYSTAZovacdLzE56tG1fHMV3CbvPIV",
-	"1OYQkMEugOyqlpdro8c/xorxCTuhs/F5b5KdsERtRg4lkvigWMpaRHklMBORDTWYMeklbXb66/ELFqsE",
-	"eqG+udNG0hTooIT29WWkkjE8K937dgxlRfRvmQxe5b5bTA/DWHEG038Wye8OHxXW44o4dpKcPjCsWHjh",
-	"sKzy+Mc+XDVIc6g4FJ+ow6I3IomPCmAsYdN3h4/qbtAitp4kp0vc6qV3mC6iWpm1qkVNht2HUsNdCs+s",
-	"3QsVaxam0leACWksx+Zp20k8NnF3X+bV8jodd7bYj6YBDjnyMeDUsqIWhY6VNPkkkH60PR0QChW4cOBx",
-	"wVinjGLPxuKEI2nFxFGjQvAjjEigrMZwkpy2w9fo+cnzgvpjWSGHknmCTeXaWCiC21xDm+bdb7Mh1r5Q",
-	"wWvk88jNmCdqRkLeJcwJ3v3iiyYf7Pfb6KEwpdDZZh51I4lVKPpd9jOJk4alWIBDVspT/A1xH7RW+q9U",
-	"zUgDN6pSzqgWWY8D1OsDppfSPR20do2Wrk1C9XaJq0c3N7pLb08aXaXVu7MB34/VJEOb/vVQnsrarxdz",
-	"sLCJ5CkWp89NyG/f3HqE/e//fL+PCLN70xEWeo4wId0X0EGlc2MhYX8oCVh4yBEdU5peiugqrNNDGgcy",
-	"nkhORJKkgOxZ59JgF/cQIEpMuhQcqMmAE6xIhAipBk6CqEoMvt1ByK6eqMT3yXBy6i8XF6eFRboaFfbA",
-	"UOn5SEbym2+w2k4RnCKKzHA08yq52FdlcvHynNIRCOKRDCnj33zD9kLSB5aJefnm9d/fvui9e/uid/L6",
-	"7y/OL3ovT84vXrzuHT1/ftbf7y58OJJ1HVt8iQxfz1ZYEoCw7cuYy8SM+SV4Z2EkjUphQWJVkk3AUTZh",
-	"Jt5AJgwCNDQV074ORyQXaqAxuh+hXH84JKqU+sz3bxZOZIxB20oaSFXqc9popdh/lx3JOVracfl+jDCh",
-	"U0fZTndxdx7HA1gcpPq+IseRTKiFyzEu5hi07TNDvgpfRwkWDlZzCx3Mz6HZKpyNChNMHGwypz9gwn3n",
-	"5DSSgzzBniyODDuyaKzKnGQRc5/M4Tf4oOiQQX1G3NYGcyfAhioDg3w0mrNBLtJaQaHSjuaW9OiaHkd3",
-	"7CSoa7mzNmKwaKFTYMsmGhDsYXdo19zAE2ijbFFfXEv/Q3f0jSFVx2HQXVRY2TLyRMZpnsAFaKy8jvaI",
-	"VXMaj21o/E41X4dYhKPLsOOYAYylJaLPHfE2Fn0EwsJkXekPn5z1cXKe/Ak0CwoLZ/oZx7M6Nbs2Wiwu",
-	"UTEgdPHT+rDuk8IWgnIqVgjFsGqpCjQp5O6RmIIkrMFi8+6yMwkzp+bPqH+UAaxogKWWHh0+ZD75vk8F",
-	"rzw1cN/nK5+PJEorlOdYrWlvyBKP/0YrO01WGNupMeujw0P25td+mbpSJLqohJpbjaRyOhSW9vTGpBmX",
-	"1puKfIlPKoMaSfKXF3OGxZoxOrp9Bbw885OXfWMDzKlp7Pro8+OiDvutuKno67uE6d34lay1oyyeuRN0",
-	"Vo/72cbj3qArLGd8noRaqsvH2F1TWWqtjn6TUYwNwFNvD2+0VQmzdF7UYr3qfj9P2ojFe1fjsL2orjQD",
-	"abB+Liu7INTQyiUBoCb4sS4cr3qhtxmOwzknn3xk3maAe4isi6bbCOX1MXVrIXmnJIq6OprP9mzqBAWK",
-	"o9tyLLsJsh5cVwioexpKjqtQgTyUF0GOzTUs1CD31csdI9/Yy6cu0GtXZnv1WC8/08cJ99qA1SHiq2AI",
-	"X0/yfy1X8HFai/Xzsc5cI94AKj0ISftP//Q/LmX4b63Q9i6MbGTURRvJAh9PqCV96+n3h9iOgpowPDqs",
-	"acOwzsLrW71cwTZcqXSw87vUeElDpq7ytg+pv8qrY27I9l73cqUN5ZoT4OgEBWzDTdbZT6umYhWr1inE",
-	"n0zhvLWKbNE+pmxOgwhjCk1RaN+ihuENLS/quro9KxV70L9ZNesv5zfigOVbunRwj27l4Pzcm0xxR9g6",
-	"IBzKV5C3dKHFaISRV2Xmq8cTDDGP53EKbI+SbpRM5/vrkaK9HF67hBx/ltTpw6Ya7NUza1THaIHqfUIF",
-	"g8IevqjaYeukX7Rlul0/MFUE2uNpyjxjMftNKIocaTBmWyHWYtQnYR/GxRTdIk4Sqr98uxm7ftZm9tkC",
-	"ql+igVZUkKFAr+K3rdVcaeRt1XGlr3+ctN6wtRr08I9uziDmAf7FGMQ+doLMZpMbNnMKeFuH88vU9EBD",
-	"rGQsqFXj5tBSSj3xr4bTLl0U1E53NlbG+xR8NJWQkexfAmTYCc706+tb+FVUCfht3LtiooIqYy+z5K4t",
-	"B8U6zjDIo+4qhiHC93zyATafMaUurJd1cmi9abOAU0nNfQpCtZtuI0xvZlWukv1tVuVALL9sq/I2krLe",
-	"rrwWlod3ycq+WLvy9oPZTQT2ALsjy3LRNJN81zWtMhtbm3cV1a5ubfYzfRxr8wZcD9bmQtq6tzavsTY3",
-	"FJAKDN2sb74uh32yAUlbXiq2UDiW7kJLLWZtpqeWx/ElKqqyikUBKSs/blNVX1dEodsQmksU+Sjqarm9",
-	"GjwpHt6cylpA/l5pvRultVaWX8D/Faq8u95aqqgLmmsRFHc9vXWBEdyq4urJ9L3a+nmorSXKer111du9",
-	"BdOb6a2LPGBrd53iMnzhEVFbKct67XUDRA/vmrd9ubFRDQ5oN7m64m65dT3W3+Wb0WJ3l+KurscWc30c",
-	"TXYj1gddtiKG3Wuz62KnGktOKtmmyuKIz1aLVckdK7Aqaaq7OsB+kWqrx5gC7/DvrcpqmSt943qqQ4KP",
-	"o6K6TdVxcJXcpGKqknud9M50UsLTZeSu0tMrKKEOH66qf7K3lXz3LDdjFqs0hdhiH3w24nrAR9DxP0Yy",
-	"9Ck3VMY0EYZnGRbOKeWaVEyB/ZoPQEtcZkp5O5t1XX/v79XcezW3UHMdTqzXcOsuT0O9NrCL7Q1jky9f",
-	"m62nSRt02FroHd4N3/uCldZ157CjqqqSz09L3UV8u4aCqpKPpZuuQelCLUUh7F4jXauRbpSbfK0ykHaq",
-	"0nwCccrFZLNielq88g5fOaZXPgFNtXZldxzuW7uGZoppeRaMDoPRaXyJuuq6vVYwdQ1qbtNnaw/glqTj",
-	"2rk+jsZbv+06nKsbeHM68ZqDvVeT70hNXgP/JvdqI0vYXbc+fXd8S0HJaznQfYTyvQ5c6sCn7443BSdf",
-	"8R40U5PXc6GtLRFq6fMXrkhfg2qtV7YbnsHhp8KDv1z9/FrHu5taUQvazy+E+npS7NX1/Np5P47i3/g2",
-	"BUvAWtHz3jiwzjhw89LibraDT9RscId+6+XJr2gq+DqMBJvMA7tbBu7KKPBJ2AOaiCG3aAW41/8/lv6/",
-	"5cqsI+NX0fdvJZK7jmXce7rvtfyg5a8yibVu753w/2p6/pVU/K9Ou9/Kxpuq9HepzTfioF+RDr9dFruW",
-	"4v65OeKvLF3enLL+aejpO6no98r5Dsp5Q1amki1KuBvwKejdKqlxzjd6D+u27fTGa5WgB2enl/6h9GWq",
-	"eHJHpgCVNNT+VfJl6vuEmAWOuz+3KvXqtjpdn6rkI6nuKqnFAZXcoIKuknuV/K5UcpWsYnWFWO+uamcq",
-	"uS3XOl3Be0f6vYpdUbFVstGRvorRDZVnT7u36ssq+eJV5DoasUEProPc4V1woC9Ywa0/gh21WJV8hs7m",
-	"HWSoa2irKvlICmo9Nhc6qUrutdANWugG6cUA1/F4tRHE4u/dP0RWfaanYlsdr/Mw6BNQU/1a7jiO3M/a",
-	"TCEMMP0SlUJTokJAwuKnbcqhB+ItCbT+6x9HSQxbq8EN/+jmlEUP73uF8Y4URlOgbQ3GL5HR3ZVH/+Yt",
-	"KZAVyn2vRN4rkaUSGRB2gyK5AcubKZRVer9NqQxU8gtXLDfSkvUK5lpIHt4lB/tylc0tx7Kb0OvB9fkp",
-	"nrvKZ1dXPv1MH0cB3YDpQQktRKx7RXSdItpEKpp5h91m7fIfxajPtbxW2MGV/Kfh5V+FvMJbC67X29SA",
-	"w4TNVODi5L9EHXhWQdiA/OVv27TgAMhbEsnD5z+OHlxsrgZDwrOb04QD0O9V4TtShWcl7tYh/jLZ310b",
-	"Dq9uVof3LoVM2vjzfiRtnqUV7Zjqf3HN0xRSRpqyG2/67IBVFWfGteZzs1F/rvKmW1Wgy4nuVedPXHUu",
-	"0HuD7rzxVjTTnhf4xDb1uaCtX7j+vIUArdeg10Pz8G6Z35erRG89m92E+zLa72716DbrO3bRb19fod5Z",
-	"1Lu6Rh2m+jgq9SbMDzp1KazdK9XrlOpt8tXG2Wq5Gc0Nehpu3eLhHOdag7RMaTESku05gW0yAZm4S6M0",
-	"G2g1M6A7A24gYVHrQs+ZsEzlNmqxqeDsIFGxOdhvtVu5TltPWweovC5O4iT7lCUwhVRlE8Be+TR6bG32",
-	"9OAgdQPGytinPxz+cIjX3W9/5VNOHgRj8G46UiTwr0yrARi2l+PxgyMCDuf2u5Ve+8BTO65ZXaW8q89A",
-	"MEx7kRd7hiHhOH71/KfK18LIzd+jsp977ghBswPsIK9V2slSLoFNeDx2y9/HRvJClklSlYmoQNzmWcoe",
-	"Gps+VJY93/g1jC7793/9N+6aWzURMSsIw7SUflguhTWVCTAWYeOni1c9HFIH6r3nkKVq7tCizc4ttzDM",
-	"03Owbfacw0TJc7D73UgeMSPkKIVQ1NcJoplK5xOls7GImaJjItLNEuGWgBYcpZ8xA8COnp91Dg8PvyNq",
-	"7ddcXq6NCw9etBK+C02Q/McK+9fGbxUtXLvsOOXGiKEosaxfgXSfpXwOmmWgw+IfP4ukGxa1ZmNuHxgm",
-	"pMXvduB9pgwkf4tajOeJsAzJpgOScHfFzBCX3YUd5jbXEEmIlZkbC5MOTaMhRcpvxiIzbdSl3HB6OIHJ",
-	"ALR7tAC+sjPc6pZ93mbHoEOQraRmleWXHbIpCUyrGW42Hufy0tHDAY8vhRxF0lil+QgQRCGPNeaSjR0V",
-	"ULntspe4zL6QQ82N1XnsNtnLxnMjYp722Z7hE4gkN+y1SmD/KX7q9B2b8MwwJa1iYazDnUt2wI7PT0IR",
-	"BuOwcmHjq/keqwAojIHrQEBlZhbh4JYVkLJjRAKR9JIDkmMPiDYbOO7DrGJ8FbJKxgSqALbY4VkkM62m",
-	"wjEH0GzMDTPcCkPYV0KwioAbt+wrT6zu+5d8wiWr0GGHhW5vuQGNjuwDlnFjZkonLFUjIdvMENdiEy75",
-	"CJAWRLIYRJJa1+003IS/LKzNTVazkqNkImRHyXTOQCaZEtKap7iM6kSBDnesugR3X0zOZQztSPLYgaET",
-	"FqdhKmDWZX9HcSYQHO4m6TM8Y7anVQp/xZ/2F1fofmp9+O3D/x8AAP//IcDwkp7QAQA=",
+	"yeSGE9lGyW7thK5OWMqtrb1770oRYUnuRo1GQ6bqN1dh7KtyB9eC+xo+jQza1aW8o5e3xxqXC6wspzL5",
+	"tj0HTfE6lvgFGG43x1/VCl6d5gyGGsw4hC3W3M1UA0/mPS/P1aP17znk9ddlaVF+YHvls9vWGc5xdX2F",
+	"nX1nFfIa2p6xPQi3fCtxLYdfK/1iUcfcIYKqDKT2aF0r3ZcA3sAUneiU5RjKPZlSJOJGJAxfLZbTTMv1",
+	"1Yqam438C1+DZ7zIwpoCucP93rvsHMCXujp83NgT/t1ioEOtb3Tvnx3/r2/CT/t/q/WDL6Q/NomQvD3H",
+	"eSUL85b86B7wm/zofsiufvSt6Fyv51XWFiqLocK39/z1eYeCnVAd2++yt+RVz0BXclp38anfLt4s+70x",
+	"fKlahqrL1i31Gfmaw9hITnJjmec3DN6j95xcGIQIXrM37PHhY9rn9vzy5QCAZWS7VjxAOLsc4+Z4Nem4",
+	"RKkmEQJF+bbrhggEevwVhAgsXb1NIQKyoABXjBHw59OLU27MGqdvoCBuCN1mKn/hYxA1G2BtAKuCjzZq",
+	"yZGQ76OW+6fVHIbictU5WpfO//l4R7FQy4CnXMb1hXYcJeIpc+M6YRzjSULXoe3tUUKOItknq2PXjf3J",
+	"D+36k/nnb/0ue1F4QJgwkez/KbK/tQtr2t/aLFPamr996HfZqcrylHtX9WzMLeqpwzwdijSFhBJnAtJQ",
+	"DGOcqjypnqeSPnWpKDxq2kzpSL4Cy9OXP7ED5EGddyen7IBxNuY6wdwcpCbFZpXsZBomXXYUSSPkKIVi",
+	"D8zOMxHz9Bmb5KkVHfrdgM0zEzKKKOQ1yXnaMZbHl2xv+vjb6ZN9hkU5k1wmXFr27uTUXMeJM+HvfcJe",
+	"xVlfkBYM9Vx7I5hWObpqcdh6t1XIrCrPA91vZY1RzBZG4kTlzdieO9s2cyox/Rct8W024PElyKKKTyTx",
+	"Oh7g+e/fpC/LpjXbvnh5vhSl7bYnGm3dbchE0lEkclAOQYOMIWHnmC2HhOXmdvBhPV3d1R+8LAldyx8c",
+	"uHQfabN3EXMNkSydxKypj/hlEOuXKN7r8/MTB3irRppn4zlDsZPS6YzjC1RVxJHsBZH9UYisiOSlkEnH",
+	"qg69OeFZ5vC8OD0fKQWMPIdkohTvw3CVQLqY/gGx8vke7dYgN0I6Xt5uVTQJ91cyEdLph9zb5etDcFcf",
+	"ZOO5wSd1auVLNRJybWD6W2+EY98WwehtqngTmPUq09wtJr1q5tvCu5ZEhIrZeWMU9yuoqyyEpJzCWO28",
+	"zbRKoY0nCMMhxFRtCJOPa6SCpB5QTCQkBDn0+KtbXruoOlV5UGSpb9W9Qm7h4lSUskUfXMxxnIoiPcPX",
+	"32oXSaxueCTdiP6Rrx+CePSU/YRVPPpd9vYkhCdh3rdOHFeaL2LqQnpjbYp3jtYDdxE35Br4NOElcHUZ",
+	"eqrcNRsoZR2qZz77C4/GjTGRpILVRa7EjLtlGwo155JeQOZNuTFskKr40lBRvUg6rgQM3seQWdY/oKV2",
+	"wtf6PsUfXWUYc+Ogkyxki1TsaiFjsxmtPFO1FHINMDbl/79YQlKvYrnl/Pv/+X+pDEAgS8pXaPERJr6o",
+	"Tbtx0Qd/2mvE39XFF/i98a43A8E2GlDUn1pbJqCoLdX8mIpXNliryqquTYwoX0faRwG36yR+3KzZ4nas",
+	"Vws1fW/JdlXaUjZYr8p65jvar3ZG8Vp7T9l3YZu1J4x03CGSN2nraW83tZWgbGBsKyutfhxT23La2gqq",
+	"XctyVYIi2K6quS0FVjSxXZVV8a9rvCpJ9Fdgvlq5eRtzXIrRX0KWy8WiWk8xAj635Sr5LA2TTIpKfjyt",
+	"JJywvSYZJvtYFcwKGVuK9X1+cnzB3D47aBMUQ19vr+3EUqp8MAU8vMXdm08lv+QLy6/4GJkTsiLnNMud",
+	"CFULE9CGXSN3YsxNU1aHYx0pTLmj1wNfiCPk5Byh9kA26NA0SMhR1NpfSKhwa3S64GSiHH3BQrsl3tAk",
+	"hi24tSzGvEJDhL+p3IiFuq83kB1REN5d7WGrktWVLWIl778Re9hrleyyD5Xc6z9b9Z9gWvMKkEquo/ug",
+	"y2drHnQhSHa/ZO1HJZsVH5XsrvPsgNGftbrjYFdqOiYfJMrJsTek7dwwlt6yvuNgUavqqKSZlqOSG1Bw",
+	"HOX9GnSbyg3brNa4Y2mm0bBXKgGs5aNkJDnzFqeOT0EO9nvM7SsvQVmyLkgrhu2hjT/CLDRr2ixW0j9q",
+	"lzV535wzdKfud9lxjsUNIxnyyTtOjiz47F4fxUqscFgqIu5PFF1RmahIN1hjrVTGUOfwjuEeeoT6+8i6",
+	"s4qHOpKQCExkPwhmcDvWKh+Nl4VNT3YWdatIFsoVTGqLO6apijmeVy/O8ho3yelb5pA4yRE/lvK7iVCQ",
+	"4wot8HpKm2uS512dG7IxTEDztGes0ny0zBi3fmACE0XBybu8lanENHrnC9ahuY7HwgJKM/XnXx3RZRty",
+	"rfkkefK4zbieuP9lWfzkcQptZr778fB9M2Ug5hmPhZ3XI+OFsjxlbklI7UhCwNAOcnxRlEj4RjfOcrb3",
+	"e86RQDQqPVBMfyV8LN5ujozFK00xsSRZtTV6bG4qVI0MFkWPqr0zJ4S02Stc3qkGY3Lt6OFzYS6LP9np",
+	"yfPyj9dgZ0pfvpVFluZ+NdwGq3chIaY0nAptoERk4xgyR6035pINqWmKI2x9t7f+gY/t6bOyTHrGtYHb",
+	"i1kpsqt7PrV7fcULXyszvJA8PTh42P1L9+F3/SY1Ne7EOvWpFC3x8Vy+JmVdBf4Q8nVySnjpr2sl5EsM",
+	"GZfzpfkef18z3SLj3ATdAdfQcWQ1DTVL8JXCDPIc0pSdqhnoF8kIInn25PFh1NrHajRZChOUTUiiV3nS",
+	"QaxOnBZoLJe+/mrfCS6R9CpfQZufsUW5oaGNZ+HTq1vDSkEhhRc70nXL4i1doQ7C+x1aGh5nJH3d18kT",
+	"0X2fcj3CwsznlsuE66T3/LHpTb+vQaeHj36oXeKG0z7VYsL1HOtR+vP2Z1x/7k3O+9LtL61e1K1rdEDp",
+	"ZVq9n695rfamuLdSsOtJwq80gI1E0bqJYfjBxgI406+5Ak4zCy1RQTnq+TioVXXonA35RKTzTfDup0Lm",
+	"7x1uz4RM1Mz0G0FcmR611lotJ+4455tzKsARABaO9e0glzZnjx51Dx93v2MvL87rwnif3IFBmuxOd1vH",
+	"RyW9WCS6SQGcUKun1rhyjPG1YUi1jyDRiwzibnh68rwgZXxmnh4cHEDemYGxnYf8QHQO+SB++Oi7x98/",
+	"+csPPx4mMKwhafW7QQNNbR2ZKUgB2FKIon5YAlpMQ29/pMIoWPU9ZSsFsG4kL4JaWfzI9lBT1cCNkgcp",
+	"N/ZCc0mlUy/EBPZ97xgMM+yXwlyfoQSzLQ6pBnvdo8VFI9vouN+XeMc3/UACIrlSjo0CoDtZyiVyDycY",
+	"kvoLNk76d2zuV8lVLP3tFin/dQ1VUMvFOXFIBfvoh4U48zHHQPNLmLcJRG0fN/ihH1r1qoSlXCaGYd8H",
+	"KkQ+ZMJG0qrUUTvwIWk0IfVJ9V9xSPBa+TXBwWv14j3Eub0hsbhyRwuxOJcVPX8VPAiHhTFFgJ1Dodim",
+	"DkN0omSfDVM+6tZi6R9KbhVprMpUqkbzJdR0ry5LM+Xdr7nnTxr6eVSyu4unakj+VLw7y+3Cm29n+c17",
+	"r89uXp9l+N2gB+jh1+sBWobqJm/QapN/LiZXvwD4+leZqVwLiU8Jn7+q9OXa09j5HuzqJt3xNmx1R56+",
+	"O27ojVyIrLmyP/LGceyrTnV2p1ef5lyLJ01cqlnxIpsSaY/dq9f2stZzga/A7brxxm70w7rTvWpgKbZt",
+	"Qwvs4hFtUwFLPeSH1aMZqFwmPUKL2uv3869BQ1wREFAxdDsShuF3MIEvNISL5ClIrG13+u7YYBdj0jhO",
+	"32FJvDE3bACYJZMCun333rxmz1+8fHHxgp2/uGCv3758uV9/JxtUhvk8THrbAwwdfOtDC58yD+A2+8lB",
+	"v81eqtDmaqtZgPIPIak63JZrBfohzIg/gO2hRhoK+ZpuaO/X9R/Yb2NTQm7FpNAXo9b3fxfYULjRovyX",
+	"lpL/t6boe+St54tnfMb6uHQa9hp1vqBKn74LBQQw88xx+youR/LYpwtTzTs8apiCJEJD3gftzXuE6QG1",
+	"5QMbSURv6jEGCZuDreelDbTmWoqzqxq9WdC48Txi6q5wA5r1dQWqryEGzWNyNzTp6GCGXtJmRoV+MTcU",
+	"fvbwUw4/WxV16mLRlhHkSkLUjYtPX6Pk1ExoWhU8bkSCWnuZaCB6rk3gE/A+Uyb0WZNzpoaRREfEP6ia",
+	"Zow2+jOv2r7ich7+xgH0w/IrpyrY8W9GmgvxLTXtg4ti937IVi9qP2o9PCzY9zkVfA0s/hmLlQz+WKvY",
+	"YI65CIZxH3/insegZcM4JMeJehqGa7j4ayzSTOIjcWcnFpFIgu+ewbDrXm1W1GdxuiJZeXVOUjibTIwj",
+	"G85uRA+7lNZc6ePzE+pgSkXISjnj9J2D7vH5SQdrriRhDUZ0abw7pKIXs5AdqwHYAUthxON5IIZBeGsi",
+	"hnxZQvR2GfooRFwFcTqSZ5ACN46L/ozdq5vK1oRfmUpFPK8TrC0Xkh2w56j4sAN2Blitfgl7Hj65cRmZ",
+	"vNy1btdYu7U45HJH4acJbvES2ehDv+DP+0GOjmSJtw/MgkfZCz552WomEeaSHTAz5hpWAPp9fV/JrXzk",
+	"uqLwp+ddoi7dDXejkq/Teq6Se1v5R7KVZyrZaBlXyc5q2yYs3qoAufU0zMG5UnnPe6v3bVq93emtsXqr",
+	"ZGN7nw39exreQip0PnEUfk0l+rW17RfEx9WnPv9zfVrxVSjCyjsz3+mqd7nYxalmRLMeE5VGRMX+1h4y",
+	"nlAjBVol11eZVfJVaMklJdysGKvkqrpw2fNsazPchc5v1YD+onflRh2h0berLcpW1IZXPMPuvmGwt9kq",
+	"zNWhGvCdoIsKOVRd9ivMSbbig7LKlTtbCivFeDbL5mAZSC3isdOnpJIdTIVAAmv5qM1CeXgcLSTjaapm",
+	"Dp/biBH+E5lWMRgD1Pmzpqb+5xJdnEAD9VtSJiF10xMmZKthFGwj9Xe7tua+vFVdO6M2CW12nscxQAJO",
+	"YSM1DU/nLbUdqyZQNaqt0EzHy1RSH4yvElYJwN87OZ0+dqs5OZ0+2e+yk2pf32eIQVOeCqT5brNcRvLk",
+	"lKXCgubpylJqY/UL4l4nRlyorJPCFNKiH6InGBRc6lPYHMD3nkOWqjn2tz2I5LnlFoZ56qTrA/acw0TJ",
+	"c7D7mBBXyXuc8fTS5yL9YCKJcdZnoZgqi8fcVwZ04no5g0/szCqNII1Kp2Ai6SDYofZb7AxQ4HdrCD+V",
+	"3yg9jfQdDPOVKpLVysFUtpdxyXBlWOmu0oCNJQqMfGB9ksocrPddtdl/qEGbHWsl/0MNruaF/FBP2XdW",
+	"VSti8adT6/VUq0FalzZw9vMx+8sPh39xZNGN8FHxNayfHtR3G9JaabOG+XmE9hcHy/7i8Lav0Ela4oDs",
+	"KYVYsTg3bq926gkY4/2hm9k3faJ84bcGZYxDrtCiXFrf0bvsQjjh76mD0fc//ljpZ/Tw8LB4TUgLI9+x",
+	"Xtg1vR3LBKchz1M3NR+o3D4dpFxebu0xvrR934qRZtvYZvEMYiVjkYJ3TZ2jZ2qtKN9Ueb4EyMh+uyA+",
+	"bqmtucn9VPnixn0UluF1O7na0nY2IGxWypru5gwMIsOfK9cTwzIW1iGkffK4tYp1SysJr26ct2jQuwZ+",
+	"jlTvCL9PB+60+O2HoOpF/PeQUBqJE+Yz0KEi9l98TgQ+m/AMuxxwNsQXqAite+Pf//XfVFiffsLWQsFC",
+	"48Sho9MT1jcQ51rYeT+U6xWmpPJtMuuG2sYTkSQpYE39f6FpwVrutGVWTGIWM14w12WhjjGWU3B/Y4EF",
+	"7FwY/jUVMANdW9z4nArLN+eW/oWv0hzq9/7pFIP9qgyiHvqbjKJ+yK6G0a04vdU46vsz3Pc++gxNo+Hs",
+	"6s2jHjeaGOD8h65thAs0+SswxC3dvI3GuHD/r2qQC5JojVXhyBgxcgqzl6BPTquNm38BnqRgDDsoaj6g",
+	"wSac936TjP/7Pkc1fY5Ql/bnatAANs8gkv2XlRf6oXdQSs1l5qEJzTOm7Bg0vmOoNTIJZXhbGJ6fmwKb",
+	"Ei1UoWJ1fY0iWbQ1evnTs5WGSIHfLzdPur26LlgIqCav118DfHyjPYgc4aPWUm1muR6B7dEfmVZWxSpt",
+	"o3Gyd+PNhwzQmm7wdpxisjKyYP/xLjtViSMYNh77MGM9r1wTji1G3VhqAdPksgSFvwE1v3BDa01W1QGb",
+	"ZIyC/s0z6LJjbtwuvFcNUdNpAguVa62BdBhJmAjClMJOy61XLNwSQ7egRdvtMLe5hrLY3DN3P2SSgl4w",
+	"DMmh0rGff/qQmXxgQhR2UEwKmtqi5ORTpZ0kWL3jrXarSlk3aSq7WveWZbtPx8J3TrpfDTeSjFMrlHE+",
+	"4TI0wKlhadtVrZrCRpnQYHZ6p05I9KuvxCJ5wKHrArt6o/dirGYYwEjV/p4RhcYKEgLdG1TvLQV+SfI8",
+	"J3EqtFdfKA+x1N84NzvunaLzvASwNcXFsdUeHwF1KG42vKkatrZtzHOQ7uVUGIdBSvveP3FZtmN7Cxmc",
+	"MyxnSf9aANwCNtSLZ6baaHyT8Osx1uPqDcjApmFL8psSRd+a2t5q/g46cC5pnqWX40o3c6s1IxHG7SvZ",
+	"pYP31o8O0YGHXW5kL1Z5XfvtY3fx4hzPk8aXramc1jnJrGFGyBjIeWhyDOce5inWMpVddgZYQMwqduhk",
+	"9+UBrMDrXKYqvnQvkLnL/aVyx500mLFKk0juPdkvnFN99xwh0kfiUiT8BJP94VoQVAz4V7YuGesBd5Mn",
+	"Umxp9SD+EbzqjjHn0jKeW9WhF7waDu9jAEyNQrqKp9UhIBcwdNodC2/5L8VYAnSh2xrWnAwH3WXH1Ces",
+	"2oLMd1s7Pbo4/oUdTB8e4K8H2MTs4E+RfKCqh6xPx/pXt+N+F/MM2V/RGUurWFL7rwW+dd3Z1lcU2t7P",
+	"7CbsZNfpA1gQcG9Jw5XvYkgjalaawdaaQrxJhgwhJaVbJWjNmuA9J8cXcxApcgCNL8rHIrJRU2UsQ2WK",
+	"ia4qi8WDlIzkEGsrIgZHLTZM1YzMrUOeGiofZjAYgVrnocSQWzWpmM1WT35j/8aqWa022nwXtNlw5BvN",
+	"d0ed/zzs/NjtdX77dntKV12bSL/OdajQhIMjQK/Lt5GL3i3TLjWCbYL9OVhs39sveyNqGHPjOI8T6EmX",
+	"iWS/DtsDNSs+EvgzPWAapurSvU2K5aI8VMbpY1PI4htVQkmdGQ1JyIERGnczfOvvQLsXGIBVik24nHva",
+	"H0ki/oFP1xXJDguvJ5PNCerdXSuE0jr+6BDIw25BQHAnil00Deuvij1oCj3sRvK1CiXKVAFi317dqW4V",
+	"rsWOuWQDYLGaDISEhJgdGqEiSXjmdT7vlzAcq/xgHjfrdBhPU0aQxabX6ZxxqybetuXYq5LA3p4+P7p4",
+	"UU/K6swH70CL4fxCXcL6prfUENU3zbSKTfEdCjV6/uo/fQo1G3ELMz5ne+QNffhk3+ErYqRAT6gZK207",
+	"sdBxLiwTEi0B9FnDBjBUGkPX5izWCnvUAxJ0mPE0dVgvLVNYsvbi5TkVkHNMohSkHxiW5YNUxEiUQILG",
+	"AKIIZRX0tLH+6ZvzCxI+cjs+oJ3069CcOrqus5KfHl2wvX467WXc9lC8jElrJVHT/2TyYfFT34mtPt2r",
+	"z/VImR3ebVJFczkAZKkj7ZojJz25LjLNHTbCx3f0crchT62Ttm2uJUYUpvMydtN39jVk4HkWyXDAByyn",
+	"YD92wEhjdL8RwSuOfwSWcfb48GEZKOZtA5SVRLU797hfEugggwo5BM2o19hAWOx+O9NKjvbrTpXqaaAV",
+	"tudva6/ePoEX2i9OGJOHC4tF+aaTTmEK7Xs3fkD77/d9ocuaq4G1LC1Z0RxN//UHUwbrGQTos0gufd4v",
+	"Ai2MoaQp1lA0VPgjfDzmMpIa3DFjh4Ngp4udcuTNdJqT0XvMkanMODY1vmIVjxibRq8JbPRtnvewAbia",
+	"ubvpKyFfgiNXrM8z0aO9EX5vtXvA+2zdTIhXmDTL2Vsp3jPIVDxmBmIlk9KotoiskXTkAWk04SWRtBKe",
+	"qFQSjfDYb8qe5ykYJ32qIcY5h0b3kLCLi5dk4NuD9xnrMKlm+/0lEK+L1FnX49qtyy8EZJIpIRe1L8Id",
+	"NqhQatNlx9jzuogTMeHODCBco6TSQEMYdnZ67FVzpMOJ8rQz11MnjliP1WOVLRpp17e/XtewGY/tgfE9",
+	"mEN4jFk8AXQGx0oa1ArGYCCSnk+UyLvKWdRgKlRu/L2cCOPN3EtOh2u1eT5WZgJWxEX0bKpGLBXSy4IY",
+	"PRNcTaEAcdiWEQnU9oNGelljRfIRJSTnoZXz0eFhaeREgwl2s3ML8ab33EC3Xgaocgmasd2gb/Q7oW3O",
+	"01c8HgsJm3J+isAXJY3P26mP5Vwgw7Ujliv1Xy+HSNQvgx5uTCKqTxNSM9A9FLFrn2sYeQP9WvH1BhKM",
+	"auIbas8vxPM1932ENz7JYK1AJpts4Fc39g4CvMJ890mv22K8PLm5pVCvkHJR8bNvCvsKx7Zr3Nf2+xGQ",
+	"dLfvEbqubLHIEMEkiUS4Z9imVOnN1SGb1CcqQNa0MuVecaJtXND+fYXKGwlIq96Ma8WlFSdaH5gWsOmj",
+	"J++uzYq9YlYvHlRPU2pSdcqKjL356bV5cH2C7uaTLU/k11oFYAt5cx+vjerouyd9sixFciW8g/nojqMy",
+	"zw5j49leNcGqXUn1wrorhYB3XCxhH4PpBlB2PMaUOYeKGFlCjROKvlY8kj5+ZCJG1PCJ7RmAEEr/3f6i",
+	"hlEmlrXarUr2W6vdKrLfahWQANYmNuwA2WvbsQth6ysIwlxmgxujMJfSHO/zou/zoq8ZcbpK75duVOj0",
+	"ThzcD2Soc1KOKgIul1akjNyHvnFNiYPVAIHN3GTZoWnQ2rlm0mdl4i6W25WKmZinXLPEv0gvbF2BySDe",
+	"Fka5xE6ETMqesN7vsNgyNR4rrKhXjfHEynPGam5hNI/kYtZwO4Q0oy5NKS8lod5f7JVpsGBdJLlh/3H+",
+	"5vVPCx6LcLofNpCbXSP5VqT1mwnla3sO23bEK5JlUN/ulVUxlJWSvs7doumWkfPlKHfX7M8WGfh+DjIJ",
+	"2d1WbtrpSWGNR8O1ym1HDTsDLlE3lciZ++6bSos/kPk+Zd7LQ94Hso+S86EbyUieUxbZSHNpfao+zfE0",
+	"kox1WN9drz5j5JJxyOKI+Qhs2dDR+JHYnbVPI0MEgUz8dWN7YuLogglfLIzYTsh4YEjxAfe9ff89Smek",
+	"qsEaJmoKrKiD7Idg5ICfkqdpKJbAB2oKz3yr3kXzGb7RQaNqMLgaB4cLMsZjKHmImwmfJ3sjrj8WNp0z",
+	"w60wwzlWMqCHgaVie0QuS+AgkE8rqYRtNiFTW9X+7zXkalRNUGffnkQSBaiKiwvja4KJfcH2L+S/MFS5",
+	"MP+CnLIp195GipcG7YaIFOXNHFubVUL7yMC8podm4b2OcRRy+MF82QWHTtV+l/1ibebuWzuS53wC58LC",
+	"X8+tFrFtsx86Y5VrZlKBBl8y9ndZFVwIvxfoOy9gioVCM2sYCNx5v7xL6I3rL+yiT3mZdE4+MnlC/eF4",
+	"UmkeW2AiZnnuUUwJ2df3mdKRpKvn0y7xOUFxvx08NnbmBDs7NlRmr/D2RjJRM2msBj5B877SwtBWMEnU",
+	"G7AdhAmmQZ942iIvaG+aQ8+vpjw0nolfYd768AFT3IeqpirAi/ML5siGW+0335Qu1W++aTOOphLyV5X6",
+	"A8ip0EpSR1CeUgJM8JBF8uj1+fkJO4f4dT6hjnZ756+P99nvOU9Ll+JQ8wk4qRuP72IsTNFFcu+w+7B7",
+	"uE9FS2c8pbqHl+6uI0pNwYkNnvq8FFOQYIz32vNE4F+ZVoOCBvhA8n5BHNjx2dvnSNvygYHfc6wd7CVD",
+	"NhNpyniSYK/gNntdWjsCI2mzU5Ug2Q9O/AXoWGHnXpea8CxDd6mv1E+wibm2aqR5Np6Tc84QDmOxBDZU",
+	"TmhjRbmGvX7FrH7gizd8+y+jJNZ/jST2F/VhI+4kExXn7nAI0A6KoYCmI6n9g0TF5oDsllVHUqW9u3nG",
+	"jBghgcHAvYNc+Nvq5SSrnCjHotaFnjNhHZuJWp6A5JMJ1/MFxbUToz8kJnRaRhm2ijEldhSVDAKiY3UQ",
+	"/M7R6Umr3SoalLYQbXwLTckz0Xra+g5/QiPTGHnqwRh4asd/uH+PANXCgmicJK2nrb+D/cUPcfId+Vnw",
+	"1UeHh0EP8aHd1XNx5+F+I6FjmxpBU9C9rM/SEXi1ptBdkA5aT//5WxXEBfYjvjtY8ZFxShtts/Wbe/kA",
+	"5d/qlpe6zpFD0LAKCUogc+KajN3vewm3fMANUF9+DTwehzIeK9A7o8k+NvBI5rfKR39YzYdDEaMB7PvD",
+	"7zaspXrBmq8pVF3ZvCingOHCNp/q2SIZW3esBZ9Hl+Pa40VDR5tJwA6BPkzSmz00xEonkCDdcCRESdNl",
+	"ZySq+DicPn7eyzjtqhw4UHZciEDo9/alA/rIIQ2xVf8bBXq43ZNsNRVGDETqaGWwDJFgRr9Z5TPpIkkB",
+	"m6pwbjua9zP2TyfR6Oj1804IreqyPnqx++yA9VGz64euEbgXFce51j7QSzsJnO2NeTrsOJrxlPX/iW+3",
+	"SSncD/0xFpH8pTD2yG3qxdThAJIXR68s2ibWKCPlkIOXYiIs+gy2DDwmU5EbuWxXSSmED3teODHHqxno",
+	"eRKmiMVFgeH3HPS8lBe40/HI5Fzi9lbL9dYlcIyFc6yas0K9LBguei58+XJvJHUKlFsnhYDUrTS83fMl",
+	"bcrl3vTyRLJ1DUsA22EFlQnpimGx9gANPCqS7tdDgt67Jgi8quM0iHJFIV6uy94ap69TgyAuzQylLBa1",
+	"Zmivo2YsIWCkLsQpalXi/yIZLjVG9HW0rzyGohzB/OTUVKTapQ3TmIUNF/VKMoEvubl7o5kbQ42yf6tF",
+	"29qvu0tej/8bbf31X0NasfvXfrtFFlmSJ7KBrnKlpSQsClpBPEEe+fjw4bo5ikUfvJVeU/kDEnrpu+0v",
+	"/az0QCQJyGUWuGjw+CeVoWn95qC+pHOWz5aEIWMXdlJhnFTkZolvom01GGLdGtF46m2ctdKhm+LEvXVW",
+	"jr3mMV7H2VBdynxrSa11hvxV5Hjz66eCA/7YanHAP1vFAVSq88y30CiPtTSHr2CG91cWyODmbGXK1OAA",
+	"BQssgr7o2/WToubpN3KLF+Z4mxnQ/rTKU/XxJEsY+PB2llCHKgQNf/SH24/+J56EaPO7QjH3xo/b3zhW",
+	"cpgKb3y+SZw8ShLsvuJdM94UsBMuNiNbB3+OlbGOK30o68StIjB1t1hG4CUZFhmdU5tLPhc+3lpGwE1i",
+	"ySqXe1zXnZ8de2y9S6R4vP2N18r+7NSHG0eKMzJXV/CiMDPuSqW4jcerp3zqfr7LQ75l+of7aUb+Du+O",
+	"/N0hp/zYGEtutwrGPjBMu19Sp8+2GUhMDmPDlI+CuxnMrVC3gz8d0vYod+bDQawBE0Y4eq0Xvhbs8xsl",
+	"uvMw6NY1+duU+as1F7YK/GW5hc9Z0KurdrJV6g/jMPF8kU8u+/BTtOj7PJZnZdRNSM0bANfkCsTK3ejr",
+	"GoE17PHhQ6dEJ94/xzQkQkNs0adOtQ5qDEtnmBh1XjhxtjNOeiPpfkVs022YklqrebI1h77rZfYLOEla",
+	"H35bQBgyO26kIEeZIPfw501Cwjaa0RBvjv2sKciSp31vApYn3PIyyTRLuZDW3fqi4tAUTBE1vF+Peaou",
+	"5PDMxwsXlYzKb1ufy8Zjm86ZkjEE736loFHFAebjcnzyl7CGcT1S8pFI2Jibsa+hQCmZOZTZX5HU4Ljp",
+	"FHy8XZedDFmqjG37vEw05E8wywxDOJWEOlpFel9AmFtSgMPnfXz+Heu+YfZXQtbeBso/dKCC5FnlLKl0",
+	"VfUMMaboU1aRb/hqvSrRZ+GCbWPNdAu3MuZzTM33acQ9bvvPqH4cOfJD//MKdw4pyhpiEFOI5OPDh0xM",
+	"JpAIbiGddxmdpVYzcildQma9gzwR1JRDyFxYIgm58QUjkRIWWZkYiT8VMGMZx0pkU+Vz4dYz+4ULdM/t",
+	"13D7rVi0K9dFmK9yevQ0bmT0b3HEZ83ki7IuWxm8L+zyOfP3sjSR2cio65gblqS5HcZWqbJ0x0yN6uys",
+	"nrz7PQQZdu+tuevR6jhUvipRaxtbK+ucbeJqx9zEPKGw61Dx54Ep1FqUy96cPD/2lTOtANNlRcCvL/+D",
+	"ZbFIJPGxOpiBkLC9N6/Z8xcvX1y8YGcvzi/OTo4v9n3cLNJYO4ZJJOF9EcGKgSJtKl3CqQLAJChdoSgR",
+	"KsO4RwzKOINhbnymD3t8+GOl6AJWBWaCZF+UWSkhBR3y+NFIUlArlo1IubGdEOQ65VpwafdxMcUnKRiT",
+	"zVSeJijYIlw9vxeaORnMJ5jXsV9S7osrvo310vBPmfV+7Hvhe2bzdTeivTberv4QDu+E5H09stTfsczO",
+	"2sPZTaBxoDuhVOXC/bA+pcLAhEsrYnNbldQwMw5rBzYppsbtx6imtok8EpiIlBXUliVl3z/3SiT/AK3C",
+	"lqgsMlJw0YUuS2CicDN7fa1SQIhIJYmIUnQ6QYvGLNag219PlgvyvkJByR+wk5A0KZHi293vsM/7uWMX",
+	"0FrqQbnCPtTuExeYPitOUjiavATk8LldFJhts4C7JJxUb+gGQSy34wMiJ51q+cF6Q10REY2CRq6xikC5",
+	"AE+vSAJCCxnbC+a3/XYkQ03BOhpG6WKhBB7WbyJS5TMJ1pR/xIqARLUIuh2yaJAURLG1jw+/8w3GQqYS",
+	"Gv1oASU4i0q9dVY9HHtaKQ56C8rP4iTFdWhyrR/XhTf7CtMhoe5zsrMtX4hlXYOOroqFS4dYxfh8ITIc",
+	"ER5Lk62NDA/26EupBoTOxLUyPnKYDYkhmxaWkUCLskr4HBvNRXI2BkytIpVkoQwal0mbiSEzqk3mz9xa",
+	"JSm7t0v5KpKSVdO5r9uILXexvYYONQax0B0W65ZGuEtRh7B/B+vozDFt9FYjKotZapiBe1pAgLL6Nkb4",
+	"n1KxSr7yWnAYEvQzDVSTe/Mx05C11OzF+6J2KAslgNm3ZWl2tHMupeyFWo/elVn06qUiBaGD7EAlc5KK",
+	"SPDJNbA9qRyFtkJSrPMA7AxARjKUgkQV1dHAAS/rw++jNIZ1WJez2fqMmyJHkH27kiRIftmBVjM0Yfju",
+	"NcJSAfnCLOwoaEdpMRJYK9HbiEMNaCylWhvs78F/G4QQv31d+hf6aRS2m3ZrDDzxhsxzsJ11qZrniye+",
+	"Mbr8w10S1Uc/3mV+zkUQ3ZdEdnbhFIgRF9J7yjbe6HPLtS2sQjVe6dprq3K7/t5W4w+olljHiKSUDbSa",
+	"4T3y4gbl8ONRRtL3XjfMiBQk2nOULqSFStqfI7lTwRfqR0ZyL1Bj8mmoS9hnBiMXnKwlDBMJTDLlzmfN",
+	"pXE72wl9qWtAd4s0WStGLnHNFz7uIrDMHY6E6g5tZJYLicDeFDdveyGVCkKjAIdJwCTsUepRrTSI0VJU",
+	"+hLDRHjou14w3ki6T3c4NhiTfCpGPsMZ810prCSYDFF7Tjpe4vO1Yep45iu4TV75CmojhclgF0B2VcvL",
+	"tdHjH2PF+ISd0Nn47BbJTliiNiOHEkl8UCxlLaK8EphvxIYazJj0kjY7/fX4BYtVAr1QxdhpI2kKdFBC",
+	"+yoSUskYnpXufTuGsu7xt0wGr3LfLabnFkNlKE3/WSS/O3xUWI8r4thJcvrAsGLhhcOyyuMfo0AnC2kO",
+	"FYfiE3VY9EYk8VEBjCVs+u7wUd0NWsTWk+R0iVu99A7TRVTb0v38Q6nhLsVm1u6FSrIKU6kezkL39yYk",
+	"Hls1uy/zahGNjjtb7DrRAIcc+RhwKkxfi0LHSpp8Ekg/2p4OCIUKXDjwuGCsU0axM1txwpG0YuKoUSH4",
+	"EUYkUOZcnySn7fA1en7yvKD+WDzEoWSeYOuoNqaDc5traNO8+202xAx3FbxGPlvUjHmiZiTkXcKc4N0v",
+	"vmjywX6/jR4KUwqdbeZRN5KYa97vsp9JnDQsxTR7WUlC/xviPmit9F+pZokGblSlaEktsh4HqNeHQS8l",
+	"dTlo7RQDvS7VzNslrh4x3+guvT1pdJVW784GfD9Wkwxt+tdDeSpevV7MwfIFkqdYgjo3IYt1c4MB9r//",
+	"8/0+IszurQVY6CzAhHRfQAeVzo2FhP2hJGB5EUd0TGl6KaKrqGU7ahzIeCJZacGuc2mwV3MIECUmXQoO",
+	"VErcCVYkQoRS906CqEoMvqh5yKGcqMRXw3dy6i8XF6eFRboaFfbAUIHpSEbym2+wpkYRnCKK/E808yq5",
+	"2D1hcvHynPKyCeKRDImh33zD9kJoNxaDePnm9d/fvui9e/uid/L67y/OL3ovT84vXrzuHT1/ftbf7y58",
+	"OJJ1fRl8IryvWiksCUDY3GHMZWLG/BK8szCSRqWwILEqySbgKJswE28gEwYBGloHaZ9tH8mFSkeM7kco",
+	"yh0OieohPvNdWoUTGWPQtmhDUBgCSYDhplrSu8uO5Bwt7bh8P0aYUI+/bJq5uDuP4wEsDlJ9n3d/JBNq",
+	"1HCMizkGbfvMkK/CV0uBhYPV3EIHo/Bptgpno/TjiYNN5vQHTKvtnJxGcpAn2HnBkWFHFo1VmZMsYm6g",
+	"usEHRR186ibgtjaYOwE25BIP8tFozga5SGsFhUrTiVvSo2s6mdyxk6CuscbaiMGiUUaBLZtoQLCH3aFd",
+	"cwNPoI2yRX1xLf0PPZA3hlQdh0F3UUdhy8gTGad5Ahegsb4y2iNWzWk8tqG9M1V2HGKqfZdhXyEDGEtL",
+	"RJ874m0s+giEhcm6BH+fcrVLHt3NYa8/gWZBYeFMP+N4Vqdm10aLxSUqBoQuflof1n1S2EJQTsU6gBhW",
+	"LVWBJoXcPRJTkIQ1WFLaXXYmYebU/Bl1iTGAectYUOXR4UPmU2z7VNbGUwP3fb7y+UiitIKfX6hcbcgS",
+	"j/9GKztNVhjbqf3io8ND9ubXfpm6UiS6qIRa2IykcjoUFvDzxqQZl9abinwhPyp2GEnylxdzhsWaMTq6",
+	"fZ2rPPOTl90hA8ypNeT66PPjotryrbip6Ou7hOnd+JWstaMsnrkTdFaP+9nG496gKyw5uc9OQsXE5WPs",
+	"rqkfs1ZHv8koxgbgqbeHN9qqhFk6LyouXnW/nydtxBKdq3HYXlRXmoE0WCWTlbXOa2jlkgBQE/xYF45X",
+	"vdDbDMfhnJNPPjJvM8A9RNZF022E8vqYurWQvFMSRb3bzGd7NnWCAsXRbTmW3QRZD64rBNQ9DYWFVagz",
+	"HIoIIMfmGhYqDfsaxY6Rb+zYURfotSuzvXqsl5/p44R7bcDqEPFVMIQvKejrClzBx2ktVsnGalKNeAOo",
+	"9ACoB0mZtb9UG2BrHaZ3YWQjoy7aSBb4eEKNp1tPvz/EovNUav3RYU2x9XUWXt/Q4Qq2YV0W5tj5XWqv",
+	"oiFTV3nbh9Rf5dUxN2R7r3u50mxuzQlwdIICNtsl6+ynVTmtilXrFOJPpjzWWkW2aBJRtqBAhDGFpii0",
+	"b0TB8IaWF3VddY6Vuhzo36ya9ZfzG3HA8i1dOrhHt3Jwfu5NprgjLBAeDuUryFu60GI0wsirMvPV4wmG",
+	"mMfzOAW2R0k3Sqbz/fVI0V4Or11Cjj9L6vRhU6Xl6pk1qk60QPWuU4TqdgjGl1UhaJ30i7ZMt+sHpopA",
+	"ezxNmWcsZr8JRZEjDcZsK7dYjPok7MO4mKIm/ElCVVZvN2PXz9rMPltA9Us00IoKMhToVfy2tWYjjbyt",
+	"ao309Y+T1hu2VoMe/tHNGcQ8wL8Yg9jHTpDZbHLDli0Bb+twfpmaHmiIlYwFNWTbHFpKqSf+1XDapYuC",
+	"mmbOxsp4n4KPphIykv1LgAz7PZl+fX0Lv4oqAb+Ne1dMVFBl7FiU3LXloFjHGQZ51F3FMET4zi4+wOYz",
+	"ptSF9bJODq03bRZwKqm5T0Go9sxshOnNrMpVsr/NqhyI5ZdtVd5GUtbbldfC8vAuWdkXa1fefjC7icAe",
+	"YHdkWS5a45HvuqYhXmNr866i2tWtzX6mj2Nt3oDrwdpcSFv31uY11uaGAlKBoZv1zdflsE82IGnLS8UW",
+	"CsfSXWipxazN9NTyOL5ERVVWsSggZeXHbarq64oodBtCc4kiH0VdLbdXgyfFw5tTWSsd8O+V1rtQWmtl",
+	"+QX8X6HKu+utpYq6oLkWQXHX01sXGMGtKq6eTN+rrZ+H2lqirNdbV73dWzC9md66yAO29tAoLsMXHhG1",
+	"lbKs1143QPTwrnnblxsb1eCAdpOrK+6WW9dj/V2+GS12dynu6npsMdfH0WQ3Yn3QZSti2L02uy52qrHk",
+	"pJJtqiyO+Gy1WJXcsQKrkqa6qwPsF6m2eowp8A7/3qqslrnSN66nOiT4OCqq21QdB1fJTSqmKrnXSe9M",
+	"JyU8XUbuKj29ghLq8OGq+id7W8l3z3IzZrFKU4gtdrtmI64HfAQd/2MkQzdiQ2VME2F4lmHhnFKuScUU",
+	"WNl7H4kWZQ5v0HX9vb9Xc+/V3ELNdTixXsOtuzwN9drALra3hUy+fG22niZt0GFroXd4N3zvC1Za153D",
+	"jqqqSj4/LXUX8e0aCqpKPpZuugalC7UUhbB7jXStRrpRbvK1ykDaqUrzCcQpF5PNiulp8co7fOWYXvkE",
+	"NNXald1xuG/tGpoppuVZMDoMRqfxJeqq6/ZawdQ1qLlNn609gFuSjmvn+jgab/2263CubuDN6cRrDvZe",
+	"Tb4jNXkN/Jvcq40sYXfd+vTd8S0FJa/lQPcRyvc6cKkDn7473hScfMV70ExNXs+FtrZEqKXPX7gifQ2q",
+	"tV7ZbngGh58KD/5y9fNrHe9uakUtaD+/EOrrSbFX1/Nr5/04in/j2xQsAWtFz3vjwDrjwM1Li7vZDj5R",
+	"s8Ed+q2XJ7+iqeDrMBJsMg/sbhm4K6PAJ2EPaCKG3KIV4F7//1j6/5Yrs46MX0Xfv5VI7jqWce/pvtfy",
+	"g5a/yiTWur13wv+r6flXUvG/Ou1+KxtvqtLfpTbfiIN+RTr8dlnsWor75+aIv7J0eXPK+qehp++kot8r",
+	"5zso5w1ZmUq2KOFuwKegd6ukxjnf6D2s27bTG69Vgh6cnV76h9KXqeLJHZkCVNJQ+1fJl6nvE2IWOO7+",
+	"3KrUq9vqdH2qko+kuqukFgdUcoMKukruVfK7UslVsorVFWK9u6qdqeS2XOt0Be8d6fcqdkXFVslGR/oq",
+	"RjdUnj3t3qovq+SLV5HraMQGPbgOcod3wYG+YAW3/gh21GJV8hk6m3eQoa6hrarkIymo9dhc6KQquddC",
+	"N2ihG6QXA1zH49VGEIu/d/8QWfWZnoptdbzOw6BPQE31a7njOHI/azOFMMD0S1QKTYkKAQmLn7Yphx6I",
+	"tyTQ+q9/HCUxbK0GN/yjm1MWPbzvFcY7UhhNgbY1GL9ERndXHv2bt6RAVij3vRJ5r0SWSmRA2A2K5AYs",
+	"b6ZQVun9NqUyUMkvXLHcSEvWK5hrIXl4lxzsy1U2txzLbkKvB9fnp3juKp9dXfn0M30cBXQDpgcltBCx",
+	"7hXRdYpoE6lo5h12m7XLfxSjPtfyWmEHV/Kfhpd/FfIKby24Xm9TAw4TNlOBi5P/EnXgWQVhA/KXv23T",
+	"ggMgb0kkD5//OHpwsbkaDAnPbk4TDkC/V4XvSBWelbhbh/jLZH93bTi8ulkd3rsUMmnjz/uRtHmWVrRj",
+	"qv/FNU9TSBlpym686bMDVlWcGdeaz81G/bnKm25VgS4nuledP3HVuUDvDbrzxlvRTHte4BPb1OeCtn7h",
+	"+vMWArReg14PzcO7ZX5frhK99Wx2E+7LaL+71aPbrO/YRb99fYV6Z1Hv6hp1mOrjqNSbMD/o1KWwdq9U",
+	"r1Oqt8lXG2er5WY0N+hpuHWLh3Ocaw3SMqXFSEi25wS2yQRk4i6N0myg1cyA7gy4gYRFrQs9Z8Iylduo",
+	"xaaCs4NExeZgv9Vu5TptPW0doPK6OImT7FOWwBRSlU0Ae+XT6LG12dODg9QNGCtjn/5w+MMhXne//ZVP",
+	"OXkQjMG76UiRwL8yrQZg2F6Oxw+OCDic2+9Weu0DT+24ZnWV8q4+A8Ew7UVe7BmGhOP41fOfKl8LIzd/",
+	"j8p+7rkjBM0OsIO8VmknS7kENuHx2C1/HxvJC1kmSVUmogJxm2cpe2hs+lBZ9nzj1zC67N//9d+4a27V",
+	"RMSsIAzTUvphuRTWVCbAWISNny5e9XBIHaj3nkOWqrlDizY7t9zCME/PwbbZcw4TJc/B7ncjecSMkKMU",
+	"QlFfJ4hmKp1PlM7GImaKjolIN0uEWwJacJR+xgwAO3p+1jk8PPyOqLVfc3m5Ni48eNFK+C40QfIfK+xf",
+	"G79VtHDtsuOUGyOGosSyfgXSfZbyOWiWgQ6Lf/wskm5Y1JqNuX1gmJAWv9uB95kykPwtajGeJ8IyJJsO",
+	"SMLdFTNDXHYXdpjbXEMkIVZmbixMOjSNhhQpvxmLzLRRl3LD6eEEJgPQ7tEC+MrOcKtb9nmbHYMOQbaS",
+	"mlWWX3bIpiQwrWa42Xicy0tHDwc8vhRyFEljleYjQBCFPNaYSzZ2VEDltste4jL7Qg41N1bnsdtkLxvP",
+	"jYh52md7hk8gktyw1yqB/af4qdN3bMIzw5S0ioWxDncu2QE7Pj8JRRiMw8qFja/me6wCoDAGrgMBlZlZ",
+	"hINbVkDKjhEJRNJLDkiOPSDabOC4D7OK8VXIKhkTqALYYodnkcy0mgrHHECzMTfMcCsMYV8JwSoCbtyy",
+	"rzyxuu9f8gmXrEKHHRa6veUGNDqyD1jGjZkpnbBUjYRsM0Nci0245CNAWhDJYhBJal2303AT/rKwNjdZ",
+	"zUqOkomQHSXTOQOZZEpIa57iMqoTBTrcseoS3H0xOZcxtCPJYweGTlichqmAWZf9HcWZQHC4m6TP8IzZ",
+	"nlYp/BV/2l9cofup9eG3D/9/AAAA///xElXfnswBAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -669,8 +669,12 @@ type ImageRegistry struct {
 
 	// Hostname Exact hostname or '*<suffix>' wildcard
 	Hostname        string    `json:"hostname"`
+	PathPrefix      string    `json:"path_prefix"`
 	Notes           *string   `json:"notes,omitempty"`
 	RateLimitPerSec float32   `json:"rate_limit_per_sec"`
+	IsMirror        bool      `json:"is_mirror"`
+	AuthUsername    *string   `json:"auth_username,omitempty"`
+	AuthConfigured  bool      `json:"auth_configured"`
 	UpdatedAt       time.Time `json:"updated_at"`
 }
 
@@ -679,14 +683,21 @@ type ImageRegistryPatch struct {
 	Enabled         *bool    `json:"enabled,omitempty"`
 	Notes           *string  `json:"notes,omitempty"`
 	RateLimitPerSec *float32 `json:"rate_limit_per_sec,omitempty"`
+	IsMirror        *bool    `json:"is_mirror,omitempty"`
+	AuthUsername    *string  `json:"auth_username,omitempty"`
+	AuthToken       *string  `json:"auth_token,omitempty"`
 }
 
 // ImageRegistryUpsert defines model for ImageRegistryUpsert.
 type ImageRegistryUpsert struct {
 	Enabled         *bool   `json:"enabled,omitempty"`
 	Hostname        string  `json:"hostname"`
+	PathPrefix      string  `json:"path_prefix"`
 	Notes           *string `json:"notes,omitempty"`
 	RateLimitPerSec float32 `json:"rate_limit_per_sec"`
+	IsMirror        bool    `json:"is_mirror,omitempty"`
+	AuthUsername    *string `json:"auth_username,omitempty"`
+	AuthToken       *string `json:"auth_token,omitempty"`
 }
 
 // ImageVersion defines model for ImageVersion.

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -664,40 +664,53 @@ type HealthStatus string
 
 // ImageRegistry defines model for ImageRegistry.
 type ImageRegistry struct {
-	CreatedAt time.Time `json:"created_at"`
-	Enabled   bool      `json:"enabled"`
+	// AuthConfigured True iff an encrypted auth token is stored (token itself is never returned)
+	AuthConfigured bool      `json:"auth_configured"`
+	AuthUsername   *string   `json:"auth_username,omitempty"`
+	CreatedAt      time.Time `json:"created_at"`
+	Enabled        bool      `json:"enabled"`
 
 	// Hostname Exact hostname or '*<suffix>' wildcard
-	Hostname        string    `json:"hostname"`
+	Hostname string `json:"hostname"`
+
+	// IsMirror True if this row is a Harbor-style mirror needing resolution
+	IsMirror bool    `json:"is_mirror"`
+	Notes    *string `json:"notes,omitempty"`
+
+	// PathPrefix Repo-path prefix (empty for non-mirror rows)
 	PathPrefix      string    `json:"path_prefix"`
-	Notes           *string   `json:"notes,omitempty"`
 	RateLimitPerSec float32   `json:"rate_limit_per_sec"`
-	IsMirror        bool      `json:"is_mirror"`
-	AuthUsername    *string   `json:"auth_username,omitempty"`
-	AuthConfigured  bool      `json:"auth_configured"`
 	UpdatedAt       time.Time `json:"updated_at"`
+}
+
+// ImageRegistryCredentials defines model for ImageRegistryCredentials.
+type ImageRegistryCredentials struct {
+	AuthToken    string `json:"auth_token"`
+	AuthUsername string `json:"auth_username"`
 }
 
 // ImageRegistryPatch defines model for ImageRegistryPatch.
 type ImageRegistryPatch struct {
+	// AuthToken Empty string clears the stored token; omit to leave unchanged
+	AuthToken       *string  `json:"auth_token,omitempty"`
+	AuthUsername    *string  `json:"auth_username,omitempty"`
 	Enabled         *bool    `json:"enabled,omitempty"`
+	IsMirror        *bool    `json:"is_mirror,omitempty"`
 	Notes           *string  `json:"notes,omitempty"`
 	RateLimitPerSec *float32 `json:"rate_limit_per_sec,omitempty"`
-	IsMirror        *bool    `json:"is_mirror,omitempty"`
-	AuthUsername    *string  `json:"auth_username,omitempty"`
-	AuthToken       *string  `json:"auth_token,omitempty"`
 }
 
 // ImageRegistryUpsert defines model for ImageRegistryUpsert.
 type ImageRegistryUpsert struct {
+	// AuthToken Robot-account token; never echoed in responses
+	AuthToken       *string `json:"auth_token,omitempty"`
+	AuthUsername    *string `json:"auth_username,omitempty"`
 	Enabled         *bool   `json:"enabled,omitempty"`
 	Hostname        string  `json:"hostname"`
-	PathPrefix      string  `json:"path_prefix"`
+	IsMirror        *bool   `json:"is_mirror,omitempty"`
 	Notes           *string `json:"notes,omitempty"`
+	PathPrefix      *string `json:"path_prefix,omitempty"`
 	RateLimitPerSec float32 `json:"rate_limit_per_sec"`
-	IsMirror        bool    `json:"is_mirror,omitempty"`
-	AuthUsername    *string `json:"auth_username,omitempty"`
-	AuthToken       *string `json:"auth_token,omitempty"`
 }
 
 // ImageVersion defines model for ImageVersion.
@@ -2663,6 +2676,9 @@ type ServerInterface interface {
 	// Update a registry's rate limit, enabled flag, or notes
 	// (PATCH /v1/admin/image-versions/registries/{hostname})
 	PatchImageRegistry(w http.ResponseWriter, r *http.Request, hostname string)
+	// Reveal plaintext robot-account credentials for a mirror registry
+	// (GET /v1/admin/image-versions/registries/{hostname}/{path_prefix}/credentials)
+	GetImageRegistryCredentials(w http.ResponseWriter, r *http.Request, hostname string, pathPrefix string)
 	// List active human sessions
 	// (GET /v1/admin/sessions)
 	ListSessions(w http.ResponseWriter, r *http.Request, params ListSessionsParams)
@@ -3124,6 +3140,48 @@ func (siw *ServerInterfaceWrapper) PatchImageRegistry(w http.ResponseWriter, r *
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.PatchImageRegistry(w, r, hostname)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetImageRegistryCredentials operation middleware
+func (siw *ServerInterfaceWrapper) GetImageRegistryCredentials(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "hostname" -------------
+	var hostname string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "hostname", r.PathValue("hostname"), &hostname, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "hostname", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "path_prefix" -------------
+	var pathPrefix string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "path_prefix", r.PathValue("path_prefix"), &pathPrefix, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "path_prefix", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{"admin"})
+
+	ctx = context.WithValue(ctx, SessionCookieScopes, []string{"admin"})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetImageRegistryCredentials(w, r, hostname, pathPrefix)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -5607,6 +5665,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("POST "+options.BaseURL+"/v1/admin/image-versions/registries", wrapper.CreateImageRegistry)
 	m.HandleFunc("DELETE "+options.BaseURL+"/v1/admin/image-versions/registries/{hostname}", wrapper.DeleteImageRegistry)
 	m.HandleFunc("PATCH "+options.BaseURL+"/v1/admin/image-versions/registries/{hostname}", wrapper.PatchImageRegistry)
+	m.HandleFunc("GET "+options.BaseURL+"/v1/admin/image-versions/registries/{hostname}/{path_prefix}/credentials", wrapper.GetImageRegistryCredentials)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/admin/sessions", wrapper.ListSessions)
 	m.HandleFunc("DELETE "+options.BaseURL+"/v1/admin/sessions/{id}", wrapper.RevokeSession)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/admin/tokens", wrapper.ListApiTokens)
@@ -5970,6 +6029,68 @@ type PatchImageRegistry404ApplicationProblemPlusJSONResponse struct {
 }
 
 func (response PatchImageRegistry404ApplicationProblemPlusJSONResponse) VisitPatchImageRegistryResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetImageRegistryCredentialsRequestObject struct {
+	Hostname   string `json:"hostname"`
+	PathPrefix string `json:"path_prefix"`
+}
+
+type GetImageRegistryCredentialsResponseObject interface {
+	VisitGetImageRegistryCredentialsResponse(w http.ResponseWriter) error
+}
+
+type GetImageRegistryCredentials200JSONResponse ImageRegistryCredentials
+
+func (response GetImageRegistryCredentials200JSONResponse) VisitGetImageRegistryCredentialsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetImageRegistryCredentials400ApplicationProblemPlusJSONResponse struct {
+	BadRequestApplicationProblemPlusJSONResponse
+}
+
+func (response GetImageRegistryCredentials400ApplicationProblemPlusJSONResponse) VisitGetImageRegistryCredentialsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetImageRegistryCredentials401ApplicationProblemPlusJSONResponse struct {
+	UnauthorizedApplicationProblemPlusJSONResponse
+}
+
+func (response GetImageRegistryCredentials401ApplicationProblemPlusJSONResponse) VisitGetImageRegistryCredentialsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetImageRegistryCredentials403ApplicationProblemPlusJSONResponse struct {
+	ForbiddenApplicationProblemPlusJSONResponse
+}
+
+func (response GetImageRegistryCredentials403ApplicationProblemPlusJSONResponse) VisitGetImageRegistryCredentialsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetImageRegistryCredentials404ApplicationProblemPlusJSONResponse struct {
+	NotFoundApplicationProblemPlusJSONResponse
+}
+
+func (response GetImageRegistryCredentials404ApplicationProblemPlusJSONResponse) VisitGetImageRegistryCredentialsResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(404)
 
@@ -9910,6 +10031,9 @@ type StrictServerInterface interface {
 	// Update a registry's rate limit, enabled flag, or notes
 	// (PATCH /v1/admin/image-versions/registries/{hostname})
 	PatchImageRegistry(ctx context.Context, request PatchImageRegistryRequestObject) (PatchImageRegistryResponseObject, error)
+	// Reveal plaintext robot-account credentials for a mirror registry
+	// (GET /v1/admin/image-versions/registries/{hostname}/{path_prefix}/credentials)
+	GetImageRegistryCredentials(ctx context.Context, request GetImageRegistryCredentialsRequestObject) (GetImageRegistryCredentialsResponseObject, error)
 	// List active human sessions
 	// (GET /v1/admin/sessions)
 	ListSessions(ctx context.Context, request ListSessionsRequestObject) (ListSessionsResponseObject, error)
@@ -10344,6 +10468,33 @@ func (sh *strictHandler) PatchImageRegistry(w http.ResponseWriter, r *http.Reque
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(PatchImageRegistryResponseObject); ok {
 		if err := validResponse.VisitPatchImageRegistryResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetImageRegistryCredentials operation middleware
+func (sh *strictHandler) GetImageRegistryCredentials(w http.ResponseWriter, r *http.Request, hostname string, pathPrefix string) {
+	var request GetImageRegistryCredentialsRequestObject
+
+	request.Hostname = hostname
+	request.PathPrefix = pathPrefix
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetImageRegistryCredentials(ctx, request.(GetImageRegistryCredentialsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetImageRegistryCredentials")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetImageRegistryCredentialsResponseObject); ok {
+		if err := validResponse.VisitGetImageRegistryCredentialsResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -12448,321 +12599,328 @@ func (sh *strictHandler) UpdateWorkload(w http.ResponseWriter, r *http.Request, 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+y965LbNrYw+iqrdL4qdyeSuu04nsSuqSmn7Ux6x5cud9tTtYc5LYiEJEyTAAOAkpWU",
-	"q/av8wCn9jOc/R77UeZJTmEtgKQkSqL65lv/SdwiSAALC+t++bMTqyxXkktrOo//7ORMs4xbrvGvo7Qw",
-	"luvjxP2RcBNrkVuhZOdx55TrKdc9ZowYS55ATENBJFxaMRJc9zvdjnBDc2YnnW5Hsox3HndE0ul2NP+9",
-	"EJonncdWF7zbMfGEZ8zNMlI6Y7bzuFMUONLOc/eWsVrIcefDh27nqNBG6dUVvc7Z7wWHGB+D5rbQbmEj",
-	"rTJgkGs+FaowkApjQXOTK2l4ucbfC67n1SLpI536wjL2/gWXYzvpPP7+/oOmhR3LOC0SfsZ1JiSzvAFq",
-	"/5hwCbhlEDQatJoZmE2U4TCw5avnzA5AGDDcwp5RI9tLeMotT2A4j6SdcIhVmvLY4lZjJWORcsiZMft9",
-	"eMZHrEitAatgxFLDH4OS6RxSMeXgjscKbiLJNC/B1Ienz970Dg8f3If//Z/v4QD+938e9SO5Bjx+7efV",
-	"ehdAldD8ncc4eQmqoVIpZ9LDaqy5MW0wS9DQW8Asv6hXLOMmZzE/Tn4WqeUNuPYGwUZQ9evjBoY8VXIs",
-	"5NgB3k6EARk+tQ7RygHnYhGG21f7QmTCri7tJXsvsiIDWWRDrkGNQFieIS7QYfeBIAxxyrIcH/zzfhce",
-	"HB7+tm6VKU7VeMTfH3bd1XBTdh4/OHR/CUl/3S9XLaTlY65x2SV0S+LSBsglnJqg7GnP2stMj3eHcA0R",
-	"tqNpucJbQNRXKtkRfCq5XcippB3QVHIb8Drh2ghjubTvVFpk/ChlImuzvrx8Eab4prs0IvtYS96RMq1Z",
-	"/W0TqtWt7IC5K3u4TTReXvnlUOYWkEUlrZamkltaTMbGfN3pHjHDe0IaLo2wTiIxxZBeh4zZeAJszIQ0",
-	"FpicQ6ykZUJyfc/AQLjPDiI5Ejx1cgE4OShXyT1TjTPwH6evX8GekMLWf/UiS7Lfj+QvTCZzGCkNTJoZ",
-	"x6mjzmwi4on7nAFdSBikavzwX48f9O9/3z8c/C3qwL//67+dIMm0FSyNZCoueH3UAGYiTf0eFt/uLvx9",
-	"f9AFbuMN4pXb5zrh88H3362B+q7Uwe30limBShxncAtdt8Ln71lslxChOuaBYxjnbgWDPrzgTsSdcHDf",
-	"hIRbJtJITgWf+XNdPFQn7k6UcTK0kn6vKuHuZGfCTlRhI5mzsZNnHTz4lOs5XRlCtEBk1h5bubbdj+4f",
-	"Sl+kiiXrT45+94c2dwsSGvFbqzR16535T/SBDtnUThnVi0gOwphzkQzg518JzJyAOBZTLuHt2+Nn63dY",
-	"e3/Hk3ekSLQTpAwNvQVK5Re1473x67vtu3PKjRFKNkMQH9UgBnukIqoLwWHK0oLvXw6INex99LBpWWfq",
-	"gss2x/r05BisG3wLB/vWtDNaFOZWLBbV7d6+pHDFbnNZt8itw/Z2ZdkvhdZKE6VaFDDAKBgqO4ELIR2V",
-	"J8rvxhmW8UgGHsCMcfzCsXaSGYPdC6ZOYlPSMYLfC27cxq+XNwdA/ypkKwoTgGSc9o6LdXtbR1Pcs4UF",
-	"/R/NR53Hnf/roDLtHdBTc1BfysLadiSC1RJvkwp+cAhPlju0T/7Ekjccz8z95VCHS/wny/NUxMwt/CDX",
-	"apjy7Nt/GbeLP1sC6oTeokmXLSypWyhPQNPk/c6HbudIyVEq4ltdSZgTBRiIC60dPhvLLIc93h/3u5AU",
-	"ND/HY9nHpf6s9FAkCZe3udYzov3GsSORwLCwkLL4gq60iVXOIRAzL+CAyrnG1eCqXyn7sypkcpuLfsON",
-	"KnTMQSoLIzc7LuWtZIWdKC3+4Le6nJfCGHfTlAYhPRw5047eOej28Ub777hpnuYCwd5gJeSWJcwy0oIg",
-	"Y/FESO4/A2dO4E6ZkJa/t+7MpJOGiYYLE8lwCVElEvaelzVLm7uSMXeHOIg1Z5aHZQyIrObaHawVdIdp",
-	"SHLO7AIFSJjlPStQmNacJa9lOg9MboksdMtvDOfnjqU7stJATbZ+hr/PheZm01JkkaZsmPK137jk1Ckz",
-	"1q092WXyrV8lert89r8UGZO92OkEElI25GkgFoOoE4ue5il3XD8XOU+F5FFngNLjAqN71DBdrvlIvG/S",
-	"XbSx8APEE6ZZbB1vR8ZWRzKPec+EyVM25wkwx1aMSDi5O0h0dBtyDJ8ogxMIYlYKlHMgTm8DpRHSSXiR",
-	"9OodaD7lDJUl98VRkaYkGxNaboWm5lN1cc0nhIQP7wFa6d0/Vsb4H5jWbN4hHhiEvn+SFOiVTg//8quN",
-	"F6Nbv3G/lV9Xw3/x2Lrpwm09wmGrp3nC5iigWgWZkBYYSD5boiArt3zxai077tw/WAo4aN6H4xGwoeHS",
-	"dqE6+pJzFNKKFPxhuJkud1HD3diK1dURLUnu+LsDw1gzafvwNMmE9KwsZtKxjCGnhxzBhRsxjmhGkrnB",
-	"PSSbXCa5EtKSicKQMkePkDrHsSqkZUORCjv3kmlAFi6LzKGBQ7ROtzPTwrrdk7OwdrzVdjIhj+nt+1tQ",
-	"qzRl4P43ocoLYWwToox5Qv5Wd91x86uYUW6l/Mcm5lhytJV70e1I/t6ex6V3eAsGLN8jnH3TJl8Kz+HT",
-	"9PWo8/ifrRf659KObTNLPlmkhV0gvIZBOj3PmT2PisPD7+IfHBE1+G/uf9JMJiqjnxyLPdHcXR6eAH/P",
-	"YpvOkR/34dQqzR1RZGB4rJ02lDHJxlw/gURFiLCxyjLhVgBe8PEmJkK7zSCkfa2C8LcGqYrEh1JgaJIV",
-	"UAoZ4EcHQEpkzLRG13VJvysG4kSRWOVzEBakmnXd/2dK3rPA8pwz7RTU2YRrDjw1SPLd2RaJsM+nXnZb",
-	"IkuSo2tdJ956wWKUReEfWljLZZBSmfsGZCJJUj5zN5iNLNe0xpl2kycwYTJJuUal091M88SLVEXuiBaq",
-	"x3nqVKYGCYnmXV3gM2V7hudM4xemXA/BFKjpwsBR+z5BdNCFQbBd0nSDbiQHToLtp2osZN8UccyNcQNr",
-	"v46YSAvNB41H33WrUkHSWlzXK3cwjnIVKCY73hzjEr26ZEjcADeBIxBuNrO/QMm92LSViNMiUAOuEUO3",
-	"ebdkxMduh0kl55kqHEM0c2N51kgY6VtapbwF9QjD3VSBk2x9hUzUdKZJIojrndTOmt5bhOZTPP2eyXks",
-	"RiKGnNhvH56mMzY3wCTQRYPZhEvI6fL310OvomwTa/PzjNuJShoFD3yORqe1T52uWdTFltLVv04UXvmO",
-	"ilFx3ShXNchiRJ8aEfAUh4mRcBcrCbKmZXrMiU5kbA6ePTM0eROjTVMyIvXboF65AnqyvIZfhVyeGSNv",
-	"5h75w5V0l84hEV6+XJwTvdtvtQRaQFOUkRODU/RCco0GayeATHhpsMC5MMDISdkF700Lfs9AXgxTEUey",
-	"fHVv4nQF0wUUV0wXrHarTnp/KFkLQTL7fRgIOebGno9ng0gKUuuzsxenvRAkw42t1jTSStpK03/28j9h",
-	"zCyfsXkk9ygU6f4j91W6sLhUd0Zm7uiqFTFwR7UN8MwRY/xQtZVICmt4OuriKScaXRvDubsrv5ydnZRg",
-	"QMoWqAbLBdqr/C42E4uAfXmri4+yNxt7NrOjYOIuTf2OLFC9buAOi7e5fncXb2qjhFNywTaCHPE7An/X",
-	"yf7uYEdOxbuycFdx41sU7wo7OVJyJMYNG9e8h+wJHCNzstBIjAuySYHkPKkw+O1xH47RCoRUPZ1H0snk",
-	"boXBvUgfMQrH02dzNkZdATSXiTdbvz5+dhTJYWGtkjDkIye0ud/RWTFhBsU31BGahAUlkhgDORfVL+kW",
-	"UqfyZTBet4MmgNXN/0QrIAOBkkur7gKSsahzKsbSiS9uk5F8fWFZ1OnDkfdMetnuxetXf3/7/Pzd2+fn",
-	"bnvnL57+9PzFoI1QGVa+enRLA3HjTQd8NGFyzE+YMTOl6/biJVuqt57mfiB8i3pt+HMVt7259TyMWFIm",
-	"7x8+eNikdvLZwhvLBj6MnYP7D+rGkpxreHV8egY/HB72Hn33E4wLkTCU6V8pUHbixE28TwaFCtBFyo2P",
-	"V3BUEXeRTzQz3BFSFsc8t4iaTCaRzDUfcUdeQDmZ1EyUtl5UfQ+0dENntbK/TMjyhwfbznIFYkvgaDw9",
-	"YpPtFS//wssCN9igfl2HwfHSVr75Llt5gcNX9Scv+Q2EHGlmrC5iW2h+7i5nzNIBMkoPhj6cchtoFAoC",
-	"6E5cXGmzNeTR4vE+6HZyZi3XbgX/9z9Z74/D3o+/+f/3fvvzsPvowYfw8/9pktm8rnMFwG+wfRFoF4xb",
-	"CzO2UEufwq/FkGvp9LMynl3zsZNZNC9dmEcvn/3Ur6FmZSe7JgRtttqe0oU1aTHuYehR5SDuQiHF7wUH",
-	"FmtlTLXKSB5nWeFvutNKAcFTso6bO+0mU1KLI6jZFgPgvX2xDPGrAN9GWPGvXdnuFMjQdrlkU1KCVUiJ",
-	"UUP/G/321wFG6XMbT/Dc3NeQwfYj+RSNoKA0OGGH9DupIHMSgRtiQPOMCX+Y1yUQLeFngzWfp4lxEgEL",
-	"VAbshFmIU4EiudOuDLeOt0DKbGnlWD0DNJIiPm5Qittw1aUVas57jr7AxcEUqWEW3F1OH5gpbScgrAE1",
-	"k06JKTLZh3csLUJWROB5cFQmWaBlNTjCrCrwuJxS4qBR3qb6umvxMhVwnYoX7L0NSmNFf56eHHt6DW/f",
-	"vIA9IYlgIniWjCVadBqdYsI6fiDsvOEQSxBZwTUJeW67WaYkOUXMYxiETzjldCLGEzQcZTwRRUYxjbOB",
-	"E0GcaltkPe6WGPNk1UFjUmVBSLSJCY1gt+y9kiqbw97J4cHJ/YN//9f/t79ClL570HTW5CI63+TcGmnB",
-	"ZZLOaWNdGIXttvJjcTkVWsms0SxYQa42DCwblx53Pu2CsWws5LgLuVbJsvfsURMKX5Rnf+4DUhpkVH/d",
-	"asjhx4LmudJeEa6h0Z6X0u/3H/zY/z7qLC+lEcIItLY3shmES5xVD4XVTM9RiemZIs9T4RCFAoku+PwA",
-	"cY6Oy/RbXiapbJNj5oWSYzqhXCvD+/BUziFj+iJxiCeMV7Ywac1RrJ4RCV+Cyw/3f2yCjJrJxuDMEifI",
-	"0Is0By0/nGVwAEr2YpamRCbVTBrvR49LIa3QIxaHyNQQzErqoVEgZIzc3uetJVybSF5INYPZRDn+MWMX",
-	"HIp85QKt89OqqUiaNvLWfTudu0OpIVEi3LvDAnULpTGK1g0J3+lH8nXOZc+BNXmCPoQaFRlfOGXxwnSB",
-	"uf+onEszESPbBe2eOLxnSdYF5fQQ93+nzzTKJw02uLG/J1tHFnKo1MV5oRs03RdCXlD0Enengw5izrJ7",
-	"GC3mXvPnuZhpsER/tzGpD+tZ7Vtkj5eXIFfEqJdcj3kvx/i8oUrmfXBCNQRREHmWeQIDDKRGT3kQE91R",
-	"eosajUKfZMpHFgoZoyadeN/JUYjUa5bDjqpAPmaMigW6ADBQiSyRZELrw89Kw4lK6E6A5iPHcVGIjSRm",
-	"LOpCOvUA9txyu4AReP5/58IneJZhg6do5uKmC0IKG8lRysb7T/AA/1HGrGHIio8qB8uz3Ikp9wwkPE4Z",
-	"EoZy8ZFcmlYKu98HL9cJCdP7j4GzeAJcWj2/Z8BMWE5qNhLPKe9G0igSYoM40ePvLWr3JZgTdFV5CQ0Y",
-	"mJzHMCyyfMnhu8lxsIJfy6JqeSbviGscy5FaNRYJcz7kE+9TaTIXGXseT3h8saPN3gHZ2HPLxg3+hCXx",
-	"tDa2W1vQ6uxNEuxzlT4n+L5Rs9X9La59VW6qLA6rz+YxicQNMoMVdu7dEeueBpFl3fPgSggm6bCULuYW",
-	"dLqdabM1mqv0PJCQNWDf8OicTZlIg7DfxC2SIm7+QOX+CUvmKu04MTfXCiNCxuf0i+P5KKA4tRx5l2w2",
-	"rNO47RhSB1kd/IvArpYfDq9cdBPm/MJZSu6uRZRZ3ae6aFz+WtHtp0KkSSmteceQLiRym8pz0d+qSm9Y",
-	"PUZFv0G9Wc8b8H674asBMTcYjp0c0CyFUxZPeO5khnvfULCCKUYj8Z6CFe7BTKRJzHSjX7CU7ra74pjl",
-	"55ijfJ5zfW54vLDBUarQGlQmJh/2D6vYF8qTbmmf2nw0JTwal1QBcxcr1dKpnjievqN9/5YB+WHbHt7m",
-	"htMN32ETdVxbjyo3tqP2x7z2CN9VpGGJ36Ik4xS45i3ULvQqvWFaMF+7o5Uhq76Ud/Ty9hjDaoG15dQm",
-	"37bnICFexQK3AMPtZrjLWr/q07zhI83NJIQrre6ApZqzZH7u6Xgz5v5e8KIZq5cW5Qd2Vz67bZ3hHFfX",
-	"V9rXdhYdryDlGXvOtW7lpa0Pv1LY9aJsuUPkRBVA6dG6katXAF7ic1lu58GM4XSMvMAQzmxKEUgbkTB8",
-	"tVxOO+nWVylpry76F74Gj1iZfTHl5Abze+/DKee+xM3hw9YesO8WHZyNPpG9f/b8v74JP+3/rdH/tZD2",
-	"1CYy6uYcZrXsqxvyn3nAb/Kf+SG7+s+2onOzSFpbW6gohLLp3rNXpz0KcjB2nvL9Prwlb1rOdS2XbRdf",
-	"2s3izbK/C8MW6uVn+rBuqU/IxxTGRjIrjAXPb4C/R68ZmS4JEXyIroGHhw9pn9vzSpcdf8vIdiU/YDi7",
-	"AuNlWD3ZsEKpNp7BsmzTVV2DgR5/Ba7Bpau3yTUoSwpwSd+gP5/zOGXGrHH2BArihtBtprR3H3ukYYg5",
-	"wVYF30zUkWMh30cd90+rGR+Ji1WnSFMa7+fjFcECDUOWMhk3F9hwlIil4Mb1wjhgSULXoQsZ5loLOY7k",
-	"gKwNfTf2Jz+070/mn78N+vC8tHyCMJEc/Cnyv3VLxf9vXciVtuZvHwZ9OFF5kTLvoppNmEVX6qhIRyJN",
-	"eUIB8wFpKHYpTlWR1M9TSZ+yUBYcNF1QOpIvuWXpi5/gAHlQ793xCRwAgwnTCcbkIzUpN6tkL9c868PT",
-	"SBohxykv9wB2nouYpU8gK1IrevS74bbITcgkoFC3pGBpz1gWX8De9OG300f7gMX4kkImTFp4d3xirmK8",
-	"zdh7n6hTc9KVpAVDvNbeCNCqQBcNDltvrg4ZFdV5oNm9qi2IWYJInKisEey5s+1CzuyE/osWuC4MWXzB",
-	"ZVm9I5J4HQ/w/Pev04Zt04Ztn704XYrOdNsTrbbuNmQi6SgSOSZGXHMZ8wROMUsGCcv17eDDerq6qx9o",
-	"WRK6kh8ocOkB0mbvGmKaR7JyDkFb39CLINYvUbxXp6fHDvBWjTXLJ3NAsZPSaIzjC1RNwJHsBZH9QfCo",
-	"RvJCyKRnVY/ezFieOzwvT89HSHAgjwHFvYn3YbhKeLoY9s1j5eO8u51hYYR0vLzbqWkS7q8kE9Lph8wH",
-	"WzeH3q0+yCdzg0+a1MoXaizk2oDUtz61BL4tg1C7VOkiMOtVprlbLGo9eWUL71oSEco3u52N0ZsveVNF",
-	"ESTlFL5m513QKuVdPEE+GvGYqoxg0mGDVJA0AwpEQkKQQ4+/uuV1y2oztQdldupW3SvkFC1ORaka9MHF",
-	"3KapKMOyfd2dbpm85oZH0o0YPPV1AxCPHsNPmL0/6MPb4xCWgPmeOnFcab6IqQtpTY2pnQVaD9xF3BBj",
-	"7NMDl8DVhzNdUODCUCnrUD33WR94NG6MiSQVqi1jpGfMLdtQiCmT9AIyb4qJh2Gq4gtDxbQi6bgSB/4+",
-	"5rmFwQEttRe+NvCpvegHRl+7g06yECVes6uFTK12tPKNaqSQa4CxKe/3+RKSehXLLeff/8//S+m/gSwp",
-	"X5nBe5Z9MYtu62Rvf9prxN/VxZf4vfGutwPBNhpQ1p1Zmx5c1pRpf0zlKxusVVU1xzZGlK8j3LuE21UC",
-	"vq/XbHEz1quFWp43ZLuqbCkbrFdVHeMd7Vc7o3ijvaeqt77N2hNGOu4Qyeu09XS3m9oqULYwtlUVFj+O",
-	"qW05XWUF1a5kuapAEWxX9Zj2Eiva2K6qathXNV5VJPorMF+t3LyNse3l6C8huv1sUa2nMHYf036ZOPaW",
-	"weVlBS+W1gLNYa9NZPk+VgOyQsaWYvyeHR+dgdtnD22CYuTrbHWdWEoZz1OOh7e4e/OpxJV/YXHVHyNi",
-	"WtbknHYx06FaWcK1gSvETE+YacvqcKwjhSlz9HroE/BDLP5T1B7IBh2ahQg5jjr7C4HUbo1OF8wy5egL",
-	"Ftis8IYmMbDg1rIY68ZbIvx1xUQv1Hu8hqjokvDuag9blawubRGreP+12MNeqWSXfajkTv/Zqv8E05pX",
-	"gFRyFd0HXT5b8x9LQbL/JWs/Ktms+Khkd51nB4z+rNUdB7tK0zHFMFFOjr0mbeeasfSG9R0Hi0ZVRyXt",
-	"tByVXIOC4yjv16Db1G7YZrXGHUs7jQZeqoRjDQ8lI8nAW5x6PvUw2O8xp6e6BFWpqiCtGNhDG3+E2SfW",
-	"dCFW0j/qVrU4X58CulP3+3BUYFGzSIY80p6TI0s+uzdAsRIrm1WKiPsTRVdUJmrSDdZWqpQx1Dm8Y/gc",
-	"PUKDfWTdec1DHUmeCExgPQhmcDvRqhhPloVNT3YWdatIlsoVzxqLuqWpihme13mcFw1ukpO34JA4KRA/",
-	"lvI6iVCQ4wot8HpKm2uT31mfm+cTnnHN0nNjlWbjZca49QMZzxQFJ+/yVq4S0+qdL1iHZjqeCMtRmmk+",
-	"//qIPmzIsWRZ8uhhF5jO3P/yPH70MOVdMN/9ePi+nTIQs5zFws6bkfFMWZaCWxJSO5IQMLSDHF8UJRK+",
-	"0Y/zAvZ+LxgSiFYpx+X0l8LH8u32yFi+0hYTK5LVWJvDFqZG1chgUfam2XvjhJAuvMTlnWhuTKEdPXwm",
-	"zEX5J5wcP6v+eMXtTOmLt7LMztqvh9tg1R4kxJTJWKMNlIBoHENmqPXGTMKImiU4wjZwexsc+NieAVTl",
-	"kXOmDb+5mJUyq/Lcp3Suz3T3NfLCC8njg4P7/b/07383aJNLfyvWqU+lWIGP5/K16Joqb4eQr+MTwkt/",
-	"XWshX2IETM6X5nv4fcN0i4xzE3SHTPOeI6tpqFWAr5RmkGc8TeFEzbh+nox5JN88engYdfaxCkWe8gxl",
-	"E5LoVZH0EKsTpwUay6SvuzhwgkskvcpX0uYnsCg3tLTxLHx6dWtYISSk7mEnqn5VtKEv1EF4v0dLw+OM",
-	"pK/3mD0S/fcp02MsyHpqmUyYTs6fPTTn0+8b0On+gx8al7jhtE+0yJieYx06f97+jJvPvc15X7j9pfWL",
-	"unWNDijnuVbv52tea7wp7q2U2/Uk4VcaAGNRtmwBDD/YWPhi+jVXvmhnoSUqKMfnPg5qVR06hRHLRDrf",
-	"BO9BKmTx3uH2TMhEzcygFcSVOaeWOqtlhB3nfH1KifcBYOFY3w4LaQt48KB/+LD/Hbw4O20K4310CwZp",
-	"sjvdbv0OlZzHItFtCl+EGh2NxpUjjK8NQ+r9w4he5Dzuh6fHz0pSxmbm8cHBAS96M25s7z47EL1DNozv",
-	"P/ju4feP/vLDj4cJHzWQtObdoIGmsX7ElEvBsZUIRf1AwrWYhp7eSIVRsBp4ylYJYP1IngW1svwR9lBT",
-	"1ZwZJQ9SZuyZZpJKJp6JjO/7nhEYZjiohLkBoASzLQ6pAXvdo8VFI9voud+XeMc3g0ACIrlShokCoHt5",
-	"yiRyDycYkvrLbZwMbtncr5LLWPq7HVL+mxopoJaLc+KQGvbRDwtx5hOGgeYXfN4lEHV93OCHQWjRqRJI",
-	"mUwMYL13KkA8AmEjaVXqqB33IWk0oW+/Tl9xSPBK+TXxg1fq+XseF/aaxOLaHS3F4kLW9PxV8CAcFsaU",
-	"AXYOhWKbOgzRiZIDGKVs3G/E0j+U3CrSWJWrVI3nS6jpXl2WZqq733DPH7X086hkdxdP3ZD8qXh3ltsE",
-	"t9/O8pt3Xp/dvD7L8LtGD9D9r9cDtAzVTd6gxj7ll78A+PpXmancCIlPCZ+/qvTlxtPY+R7s6ibd8TZs",
-	"dUeevDtq6Y1ciKy5tD/y2nHsq051dqfXnObciCdtXKp5+SJMibTH7tUre1mbucBX4HbdeGM3+mHd6V42",
-	"sBTbNaEFdvGItqmAlR7yw+rRDFUhk3NCi8br9/OvQUNcERBQMXQ7EgbwO5jAFxpBRfKEy8Tpdyfvjgx2",
-	"LyWN4+QdaDXDphZDjlkyKUe3797rV/Ds+YvnZ8/h9PkZvHr74sV+851sURnm8zDpbQ8wdPBtDi18DB7A",
-	"XfjJQb8LL1Rob7PVLED5hzypO9yW+7X5IWDEHxz2UCMNBTxNP7T16vsP7HexGRmzIiv1xajz/d8FNhJt",
-	"tSj/paXk/60p+h55m/niGzaDAS6dhr1CnS+o0ifvQgEBzDxz3L6Oy5E88unCKInRUfMpl0RoyPugvXmP",
-	"MD2gtrxnI4noTb2FeAJzbpt5aQutuZHi7KpGbxY0rj2PmKqqX4NmfVWB6muIQfOY3A/F+XuYoZd0wajQ",
-	"J+Kaws/uf8rhZ6uiTlMs2jKCXEqIunbx6WuUnNoJTauCx7VIUGsvEw1Ez7UJfIK/z5UJ/ZXkHNQokuiI",
-	"+IcWlr+WMdro33jV9iWT8/A3DqAfll85UcGOfz3SXIhvaWgbWha59kO2elEHUef+Ycm+sY1sUrL4JxAr",
-	"GfyxVsFwjrkIBpiPP3HPY65lyzgkx4nONR+t4eKvsJ4siY/EnZ1YRCIJvvuGj/ru1XZFfRanK5OVV+ck",
-	"hbPNxDiy5exGnGN3woYrfXR6TJ0LqQhZJWecvHPQPTo97mHNlSSswYg+jXeHVPZgFbJnNedwACkfs3ge",
-	"iGEQ3tqIIV+WEL1dhn4aIq6COB3JN9QTP+nCz9i1tq1sTfiVq1TE8ybB2jIh4QCeoeIDB/CGY5XqJey5",
-	"/+jaZWTycje6XWPt1uKQyx2Fnya4xStkow/9gj/vBzk6khXe3jMLHmUv+BRVi4lEmAs4ADNhmq8A9Pvm",
-	"fnJb+chVReFPz7tE3Xlb7kYlX6f1XCV3tvKPZCvPVbLRMq6SndW2TVi8VQFy62mZg3Op8p53Vu+btHq7",
-	"01tj9VbJxrYeG/p2tLyFVOg8cxR+TT359SXo6+JjQ4H6ZE1zjSCwXIYirLwz8x1uyo7460es2UizTl4n",
-	"JesPGU+olQKtkqurzCr5KrTkihJuVoxVcllduOp1tLUJ5kLHp3pAf9mzbqOO0Orb9dZEK2rDS5ZjV88w",
-	"2NtsFebqUA34XtBFhRypPvzK5yRbsWFV5cqdLYWVYjybhTm259cinjh9SirZw1QIJLCWjbsQysPjaCGB",
-	"pamaOXzuIkb4T+RaxdwYTh3/Gmrqfy7RxQlvoX5LyiSkLlrChGw1jIJtpf5u19bcl7eqa2+oTUIXTos4",
-	"xqbs3UiSmoan85baDdUTqFrVVmin4+UqaQ7GVwnUAvD3jk+mD91qjk+mj/b7cFzv5/kEMWjKUoE0322W",
-	"yUgen0AqLNcsXVlKY6x+SdybxIgzlfdSPuVp2QfNEwwKLvUpbA7ge894nqo59rU8iOSpZZaPitRJ1wfw",
-	"jPFMyVNu9zEhrpb3OGPphc9F+sFEEuOs34RiqhBPmK8M6MT1agaf2JnXGsAZlU65iaSDYI86BcEbjgK/",
-	"W0P4qfpG5Wmk72CYr1SRrFcOprK9wCTgyrDSXa3xEiSKG3nP+iSVObfed9WF/1DDLhxpJf9DDS/nhfzQ",
-	"TNl3VlVrYvGnU+v1RKth2pQ28ObnI/jLD4d/cWTRjfBR8Q2snx40d0bTWmmzhvl5hPYXB8v+4vCur9BJ",
-	"WuKQ7CmlWLE4N26vceqMG+P9oZvZN32ieuG3FmWMQ67Qolza3Mm36j6WsffUp+j7H3+sdS26f3hYviak",
-	"5WPfqVrYNT3dqgSnEStSNzUbqsI+HqZMXmztLby0fd+CjWbb2F7tDY+VjEXKvWvqFD1Ta0X5tsrzBec5",
-	"2W8XxMcttTU3uZ9qX9y4j9IyvG4nl1vazgaEzUpZ29284QaR4c+V64lhGQvrENI+ethZxbqllYRXN85b",
-	"NuZcAz9HqneE36cDd1r89kNQzSL+e55QGokT5nOuQ0Xsv/icCHyWsRy7HDAY4QtUhNa98e//+m8qrE8/",
-	"YWuhYKFx4tDTk2MYGB4XWtj5IJTrFaai8l0y64baxplIkpRjTf1/oWnBWua0ZSgnMYsZL5jrslDHGMsp",
-	"uL+xwEKn22FF+NdU8BnXjcWNT6mwfHtu6V/4Ks2hfu+fTjHYr8og6qG/ySjqh+xqGN2K01uNo74/w13v",
-	"o8/QNBrOrtk86nGjjQHOf+jKRrhAk78CQ9zSzdtojAv3/7IGuSCJNlgVnhojxk5h9hL08QnscWxC6Mj+",
-	"L5wlKTcGDsqaD2iwCee93ybj/67PUUOfI9Sl/bkaNIDNcx7JwYvaC4PQOyil5jLz0ITmCSg74RrfMZBy",
-	"NuUklOFtATw/NwU2JVqoQgVNfY0iWbY1evHTk5WGSIHfLzdPurm6LlgIqCGv118DfHytPYioI7/7bhcs",
-	"02Nuz+mPXCurYpV20Th5fu3NhwynNV3j7TjBZGVkwf7jfThRiSMYFhuo+0zl6powbDHqxlILmDaXJSj8",
-	"Laj5mRvaaLKqD9gkY5T0b57zPhwx43bhvWqImk4TWKhcaw1PR5HkmSBMKe20zHrFwi0xdAtatN2OClto",
-	"XhWbe+Luh0xSrhcMQ3KkdOznn94HUwxNiMIOiklJUzuUnHyitJME63e80+3UKesmTWVX696ybPfpWPhO",
-	"Sfdr4EYSGLVCmRQZk6EBTgNLu0zr+fe50Nzs9E6TkOhXX4tF8oBD14XmI/EevRcTNcMARqr294QoNFaQ",
-	"EOjeoHpvKWcXJM8zEqe07w69UB5iqb9xYXbcO0XneQlga4qLY6vnbMypQ3G74W3VsLVtY55x6V5OhXEY",
-	"pLTv/RNXZTu2t5DBOcNylvSvBcAtYEOzeGbqjcY3Cb8eYz2uXoMMbFq2JL8uUfStaeyt5u+gA+eS5ll5",
-	"OS51M7daMxJhsHP/Lh28t350hA487HIjz2NVNLXfPnIXLy7wPGl81ZrKaZ1Zbg0YIWNOzkNTYDj3qEix",
-	"lqnswxuOBcSsgkMnuy8PgBKvC5mq+MK9QOYu95cqHHfS3ExUmkRy79F+6ZwauOcIkQESlzLhJ5jsD9eC",
-	"oGbAv7R1yVgPuOs8kXJLqwfxj+BVd4y5kBZYYVWPXvBqOH8fc46pUUhX8bR6BOQShk67g/CW/1KMJUAX",
-	"uq1hzclw0H04oj5h9RZkvtvaydOzo1/gYHr/AH89wCZmB3+K5ANVPYQBHetf3Y4HfcwzhL+iM5ZWsaT2",
-	"Xwl867qzra8otL2f2XXYya7SB7Ak4N6ShivfxZBG1Kwyg601hXiTDBlCKkq3StDaNcF7Ro4vcBApcwCN",
-	"L8oHEdmoqTKWoTLFRFeVxeJBSkZyhLUVEYOjDoxSNSNz64ilhsqHGQxGoNZ5KDEUVmU1s9nqyW/s31g3",
-	"qzVGm++CNhuOfKP57mnvPw97P/bPe799uz2lq6lNpF/nOlRow8ERoFfl28hFb5dpVxrBNsH+lFts3zuo",
-	"eiNqPmHGcR4n0JMuE8lBE7YHalZ+JPBnegCaT9WFe5sUy0V5qIrTx6aQ5TfqhJI6MxqSkAMjNO5m+Nbf",
-	"gXYvMACrFGRMzj3tjyQR/8Cnm4pkh4U3k8n2BPX2rhVCaR1/dAjkYbcgILgTxS6aBgarYg+aQg/7kXyl",
-	"QokyVYLYt1d3qluNa8ERkzDkEKtsKCRPiNmhESqShGde5/N+CcOwyg/mcUOvByxNgSCLTa/TOTCrMm/b",
-	"cuxVSQ5vT549PXveTMqazAfvuBaj+Zm64Oub3lJDVN800yqY4jsUavTs5X/6FGoYM8tnbA575A29/2jf",
-	"4StipEBPqJkobXux0HEhLAiJlgD6rIEhHymNoWtziLXCHvUcCTqfsTR1WC8tKCxZe/bilArIOSZRCdL3",
-	"DOTFMBUxEiUuucYAoghlFfS0weDk9ekZCR+FnRzQTgZNaE4dXddZyU+ensHeIJ2e58yeo3gZk9ZKoqb/",
-	"yRSj8qeBE1t9uteA6bEyO7zbpormcgDIUkfaNUdOenJTZJo7bISP7+jlbkORWidt20JLjChM51Xspu/s",
-	"a8jA8ySS4YAPoKBgPzgA0hjdb0TwyuMfcwsMHh7erwLFvG2AspKoduce80viOsigQo64Buo1NhQWu9/O",
-	"tJLj/aZTpXoaaIU997f1vNk+gRfaL04YU4QLi0X5plmvNIUOvBs/oP33+77QZcPVwFqWlqxojqb/+oOp",
-	"gvUMAvRJJJc+7xeBFsZQ0hRrKBoq/BE+HjMZSc3dMWOHg2Cni51y5M10mpHRe8KQqcwYNjW+ZBWPGJtG",
-	"rwls9G2e97ABuJq5u+krIV9wR65gwHJxTnsj/N5q9+Dv83UzIV5h0iyDt1K8B56reAKGx0omlVFtEVkj",
-	"6cgD0mjCSyJpFTxRqSQa4bHfVD3PU26c9KlGGOccGt3zBM7OXpCBb4+/z6EHUs32B0sgXheps67HtVuX",
-	"XwiXSa6EXNS+CHdgWKPUpg9H2PO6jBMx4c4MebhGSa2BhjDw5uTIq+ZIhxPlaWehp04csR6rJypfNNKu",
-	"b3+9rmEzHts943swh/AYs3gC6AyOlTSoFUy44ZH0fKJC3lXOooZToQrj72UmjDdzLzkdrtTm+UiZjFsR",
-	"l9GzqRpDKqSXBTF6JriaQgHisC0jEt7YDxrpZYMVyUeUkJyHVs4Hh4eVkRMNJtjNzi3Em94Lw/vNMkCd",
-	"S9CM3RZ9o98JbQuWvmTxREi+KeenDHxR0vi8neZYzgUy3DhiuVL/1XKIRPMy6OHGJKLmNCE14/ocRezG",
-	"55qPvYF+rfh6DQlGDfENjecX4vna+z7CG59ksFYgk2028KsbewsBXmG+u6TXbTFentzcUKhXSLmo+dk3",
-	"hX2FY9s17mv7/QhIutv3CF1XtlhmiGCSRCLcM2xTqvTm6pBt6hOVIGtbmXKvPNEuLmj/rkLltQSk1W/G",
-	"leLSyhNtDkwL2PTRk3fXZsVeMqsXD+pcU2pSfcqajL356ZV5cHOC7uaTrU7k10YFYAt5cx9vjOoYuCcD",
-	"sixFciW8A3x0x9Mqzw5j42GvnmDVraV6Yd2VUsA7Kpewj8F0Q151PMaUOYeKGFlCjRPKvlYskj5+JBNj",
-	"avgEe4bzEEr/3f6ihlEllnW6nVr2W6fbKbPfGhWQANY2NuwA2SvbsUth6ysIwlxmgxujMJfSHO/you/y",
-	"oq8YcbpK75duVOj0ThzcDwTUOSlHFQFXSCtSIPehb1xT4WA9QGAzN1l2aBq0dq6Z9EmVuIvldqUCE7OU",
-	"aUj8i/TC1hWYnMfbwiiX2ImQSdUT1vsdFlumxhOFFfXqMZ5Yec5YzSwfzyO5mDXcDSHNqEtTyktFqPcX",
-	"e2UaLFgXSWbgP05fv/ppwWMRTvfDBnKzayTfirR+PaF8Xc9hu454RbIK6tu9siqGslLS16lbNN0ycr48",
-	"Ldw1+7NDBr6fg0xCdreVm3ZyXFrj0XCtCttTo96QSdRNJXLmgfum0uIPZL6PwXt5yPtA9lFyPvQjGclT",
-	"yiIbayatT9WnOR5HEqAHA3e9BgDkknHI4oj5mNuqoaPxI7E764BGhggCmfjrBnsic3TBhC+WRmwnZNwz",
-	"pPhw9719/z1KZ6SqwZpnasqhrIPsh2DkgJ+SpWkolsCGasqf+Fa9i+YzfKOHRtVgcDUODmdkjMdQ8hA3",
-	"Ez5P9kZcfyxsOgfDrDCjOVYyoIeBpWJ7RCYr4CCQT2qphF3IyNRWt/97DbkeVRPU2bfHkUQBqubiwvia",
-	"YGJfsP0L+S8MVS7Nv1xOYcq0t5HipUG7ISJFdTMn1ua10D4yMK/poVl6r2MchRx+OF92waFTddCHX6zN",
-	"3X3rRvKUZfxUWP7XU6tFbLvwQ2+iCg0mFWjwJWN/H+rgQvg9R995CVMsFJpbA1zgzgfVXUJv3GBhFwPK",
-	"y6Rz8pHJGfWHY0mteWyJiZjluUcxJWRf3welI0lXz6dd4nOC4n43eGzszAl2dmKozF7p7Y1kombSWM1Z",
-	"huZ9pYWhrWCSqDdgOwgTTIM+8bhDXtDzacHP/WqqQ2O5+JXPOx8+YIr7SDVUBXh+egaObLjVfvNN5VL9",
-	"5psuMDSVkL+q0h+4nAqtJHUEZSklwAQPWSSfvjo9PYZTHr8qMupot3f66mgffi9YWrkUR5pl3EndeHxn",
-	"E2HKLpJ7h/37/cN9Klo6YynVPbxwdx1Rasqd2OCpzwsx5ZIb4732LBH4V67VsKQBPpB8UBIHOHrz9hnS",
-	"tmJo+O8F1g72kiHMRJoCSxLsFdyFV5W1IzCSLpyoBMl+cOIvQMcKO/e6VMbyHN2lvlI/wSZm2qqxZvlk",
-	"Ts45QziMxRJgpJzQBmW5hr1Bzax+4Is3fPsvoyTWf40k9hf1YSPuJBMVF+5wCNAOiqGApiOpg4NExeaA",
-	"7JZ1R1Ktvbt5AkaMkcBg4N5BIfxt9XKSVU6Ug6hzpucgrGMzUccTkCLLmJ4vKK69GP0hMaHTMsrAKsZU",
-	"2FFWMgiIjtVB8DtPT4473U7ZoLSDaONbaEqWi87jznf4ExqZJshTDyacpXbyh/v3mKNaWBKN46TzuPN3",
-	"bn/xQ5x8R34WfPXB4WHQQ3xod/1c3Hm430jo2KZG0BR0L5uzdARerSnvL0gHncf//K0O4hL7Ed8drNjY",
-	"OKWNttn5zb18gPJvfctLXefIIWigRoISnjtxTcbu972EWTZkhlNffs1ZPAllPFag94Ym+9jAI5nfKh/9",
-	"YTUbjUSMBrDvD7/bsJb6BWu/plB1ZfOinAKGC9t8qm8Wydi6Yy35PLoc1x4vGjq6IDl2CPRhkt7soXms",
-	"dMITpBuOhChp+vCGRBUfhzPAz3sZp1uXA4fKTkoRCP3evnTAADmkIbbqf6NAD7d7kq2mwoihSB2tDJYh",
-	"EszoN6t8Jl0kKWBTlc5tR/N+xv7pJBo9ffWsF0Kr+jBAL/YADmCAmt0gdI3Avag4LrT2gV7aSeCwN2Hp",
-	"qOdoxmMY/BPf7pJSuB/6Yywi+Qth7FO3qedThwNIXhy9smibWKOMVEMOXohMWPQZbBl4RKYiN3LZrpJS",
-	"CB/2vHBijlcz0PMkTBmLiwLD7wXX80peYE7HI5NzhdtbLddbl8AwFs6xagalelkyXPRc+PLl3kjqFCi3",
-	"TgoBaVppePvcl7SplnvdyxPJ1jUsAWyHFdQmpCuGxdoDNPCoSLpfDwl674og8KqO0yCqFYV4uT68NU5f",
-	"pwZBTJoZSlkQdWZor6NmLCFgpCnEKerU4v8iGS41RvT1tK88hqIcwfz4xNSk2qUN05iFDZf1SnKBL7m5",
-	"z8czN4YaZf/WiLaNX3eXvBn/N9r6m7+GtGL3r/12gyyyIk9kA13lSktJWBS0gniCPPLh4f11c5SLPngr",
-	"vabyB0/ope+2v/Sz0kORJFwus8BFg8c/qQxN5zcH9SWds3q2JAwZu7CTGuOkIjdLfBNtq8EQ69aIxlNv",
-	"42yUDt0Ux+6tN9XYKx7jVZwN9aXMt5bUWmfIX0WO179+Kjjgj60RB/yzVRxApbrIfQuN6lgrc/gKZnh/",
-	"ZYkMbs5OrkwDDlCwwCLoy75dPylqnn4tt3hhjre54dqfVnWqPp5kCQPv38wSmlCFoOGP/nD70f/EkhBt",
-	"flso5t74cfsbR0qOUuGNz9eJk0+TBLuveNeMNwXshIvtyNbBnxNlrONKH6o6casITN0tlhF4SYZFRufU",
-	"5orPhY93lhFwk1iyyuUeNnXnhyOPrbeJFA+3v/FK2Z+d+nDtSPGGzNU1vCjNjLtSKWbjyeopn7ifb/OQ",
-	"b5j+4X7akb/D2yN/t8gpPzbGktuthrH3DGj3S+r02S5wiclhMErZOLibudmZugWL+kYZ7DQMunHd+yal",
-	"9HqVhK0ielUg4XMWzZrqk2yV08M4TBVf5GzLXvcUbfA+8+RJFScTkumGnGly3mGtbfROjbk18PDwvlN7",
-	"E+9RA80ToXls0QtO1QkaTEFvMJXptHS7bGd19EbS/4oYndswpaHWM1sbDn3Xy+wXcJx0Pvy2gDBkKNxI",
-	"QZ7mghy6nzcJCdtoR0O8AfWzpiBLvvG9jFuWMMuqtNA8ZUJad+vLGkFTbso43/1mzFNNQYJvfIRvWXuo",
-	"+rb12WcstukclIx58MfXShDVXFY+ksanawlrgOmxkg9EAhNmJr7qASVRFrzK14qk5k66n3IfIdeH4xGk",
-	"ytiuz6RE03uGeWEYdKkkb6JVpKkFhLkhlTV83kfU37K2GmZ/KWTjbaCMQQcqnjypnSUVm6qfIUYBfcpK",
-	"7TVfrZcV+ixcsG2smW7hVsZ8isn0PvH3nNnBE6r4Rq730LG8xp1DUrHmMRdTHsmHh/dBZBlPBLM8nfeB",
-	"zlKrGTmBLnhuvUs7EdRGQ8hCWCIJhfElHpESlnmUGDs/FXwGOcPaYVPls9fWM/uFC3TH7ddw+61YtCvX",
-	"RZivcnr0DW5k9G9xxGfN5MtCLFsZvC/F8jnz96qYkNnIqJuYGxaRuRnGVquLdMtMjSrjrJ68+z2EBfbv",
-	"7K/r0eoo1KqqUGsbW6sqk23iakfMxCyhQOlQo+eeKdValMteHz878rUureCmD2WIri/Yg4WsSCTx0TWY",
-	"M5DA3utX8Oz5i+dnz+HN89OzN8dHZ/s+0hVprJ3wLJL8fRlziqEdXSo2wihnPwtKVygjhMow7hHDKN7w",
-	"UWF8bg48PPyxViYB6/iCINkXZVZKIUEXOn40khSGioUeUmZsL4SlTpkWTNp9XEz5SQqfhJkq0gQFW4Sr",
-	"5/dCg5PBfEp4E/sl5b684ttYLw3/lFnvx74Xvss1W3cjumsj5JoP4fBWSN7XI0v9HQvjrD2c3QQaB7pj",
-	"Si4uHQbrkyAMz5i0IjY3VfsMc9mw2l+b8mfMfoz6Z5vII4GJSFlJbSGpOvW5VyL5B9cqbIkKGSMFF33e",
-	"h4RnCjezN9Aq5QgRqSQRUYonJ2jRmMWqcfvryXJJ3lcoKFnwdxKSsgopvt39DvtMnVt22qylHpTd64Pj",
-	"PnGB6bPiJKVryEtADp+7ZUnYLgTcJeGkfkM3CGKFnRwQOenVCwY2G+rKGGYUNAqNef/VAjy9IgkILWSw",
-	"F8xv+91IhiqATTSMErxC0TqsuESkysf+rynYiDX8iGoRdHtk0SApiKJhHx5+51uChdwiNPrRAipwlrV1",
-	"m6x6OPakVs7zBpSfxUnK69DmWj9sCkj2NaFDCtznZGdbvhDLugYdXR0Llw6xjvHFQiw3IjwWE1sbyx3s",
-	"0RdSDQmdiWvlbOwwmyeGbFpY+AEtyiphc2wNF8nZhGMyFKkkC4XLmEy6IEZgVJfMn4W1SlI+bp8yTCSl",
-	"l6ZzX2kRm+RiQwwdqgJiaTosry2NcJeiCWH/zq2jM0e00RuNgSxnaWAG7mkJAcrD2xiTf0LlJdnKa8Fh",
-	"SNDPNacq2puPmYaspWbP35fVPiEU7YVvq2LqaOdcSrIL1Rm9K7PsrktlBULP16FK5iQVkeBTaA57UjkK",
-	"bYWk6OQhtzPOZSRD8UZUUR0NHLKqovs+SmNYOXU5/2wAzJRZffDtSlof+WWHWs3QhOH7zQhLJd9Ls7Cj",
-	"oD2lxVhgdUNvIw5Vm7H4aWN4vgf/TRBC/PZV6V/ogFHabrqdCWeJN2Secttbl1x5unjiG+PBP9wmUX3w",
-	"421m1JwF0X1JZIczp0CMmZDeU7bxRp9apm1pFWrwSjdeW1XY9fe2Hn9A1b96RiSVbKDVDO+RFzco6x6P",
-	"MpK+W7oBI1Iu0Z6jdCkt1BL1HMmdCrZQ8TGSe4Eak09DXfB9MBi54GQtYUAkPMuVO581l8btbCf0pTr/",
-	"/S3SZKMYucQ1n/u4i8AydzgSqhS0kVkupO56U9y864VUKuGMAhym7ZKwR8lCjdIgxjdRsUoME2GhU3rJ",
-	"eCPpPt1j2BJMsqkY+5xkzFClsJJgMkTtOel5ic9Xc2nimS/5TfLKl7wxtpcMdgFkl7W8XBk9/jFRwDI4",
-	"prPx+SgSjiFRm5FDiSQ+KJeyFlFeCswQgpHmZkJ6SRdOfj16DrFK+HmoO+y0kTTldFBC+7oPUsmYP6nc",
-	"+3bCq0rF34IMXuWBW8y5WwwVjjSDJ5H87vBBaT2uiWPHyck9A+XCS4dlncc/RIFOltIcKg7lJ5qw6LVI",
-	"4qclMJaw6bvDB003aBFbj5OTJW71wjtMF1FtS7/yD5WGuxRN2bgXKqIqTK3eN4R+7W1IPDZXdl9m9bIX",
-	"PXe22CeiBQ458jFkVEq+EYWOlDRFFkg/2p4OCIVKXDjwuGCsU0axl1p5wpG0InPUqBT8CCMSXmVJHycn",
-	"3fA1en78rKT+WO7DoWSRYLOnLiZwM1to3qV597swwpx0FbxGPr/TTFiiZiTkXfA5wXtQftEUw/1BFz0U",
-	"phI6u+BRN5KYHT7ow88kThpIMTFe1tLG/4a4z7VW+q9UZURzZlStzEgjsh4FqDcHLi+lYTlo7RS1vC45",
-	"zNslLh/j3uouvT1udZVW784GfD9SWY42/auhPJWbXi/mYMEByVIsGl2YkHe6uSUA/O//fL+PCLN7MwAI",
-	"vQBASPcFdFDpwliewB9KciwI4oiOqUwvZXQVNVlHjQMZTyRrTdN1IQ12Vw4BosSkK8GBin87wYpEiFCc",
-	"3kkQdYnBlyEPWY+ZSnz9eien/nJ2dlJapOtRYfcMlYSOZCS/+QarYJTBKaLM2EQzr5KL/Q6ysxenlElN",
-	"EI9kSOX85hvYC8HYWL7hxetXf3/7/Pzd2+fnx6/+/vz07PzF8enZ81fnT589ezPY7y98OJJNnRR86rqv",
-	"MyksCUDYjmHCZGIm7IJ7Z2EkjUr5gsSqJGTcUTZhMm8gEwYBGpr9aJ8fH8mF2kRA9yOU0Q6HRBUMn/i+",
-	"qsKJjDHXtmwcUBoCSYBhpl6Euw9P5Rwt7bh8P0aYUEG/anO5uDuP4wEsDlIDnyn/VCbUWuEIF3PEtR2A",
-	"IV+Fr2/CFw5WM8t7GDdPs9U4GyUMZw42udMfMBG2d3wSyWGRYK8ER4YdWTRW5U6yiJnh9Q3eKyvXU/1/",
-	"t7Xh3AmwIft3WIzHcxgWIm0UFGptIm5Ij27oPXLLToKmVhhrIwbL1hYltmyiAcEedot2zQ08gTYKi/ri",
-	"WvofuhZvDKk6CoNuo/LBlpHHMk6LhJ9xjRWR0R6xak5jsQ0NmakW4wiT4/uAnYAMx1haIvrMEW9j0Ucg",
-	"LM/WpeT7JKldMt+uD3v9CbQLCgtn+hnHszo1uzFaLK5QMSB0+dP6sO7j0haCcipW7sOwaqlKNCnl7rGY",
-	"cklYg0Wg3WUHyWdOzZ9RXxfDMdMYS6A8OLwPPil2QIVoPDVw32crn48kSiv4+YVa04Ys8fhvtLLTZKWx",
-	"nRomPjg8hNe/DqrUlTLRRSXUdGYsldOhsOSeNybNmLTeVORL71F5wkiSv7ycMyzWTNDR7StTFbmfvOrn",
-	"GGBOzRzXR58flfWRb8RNRV/fJUzv2q9kox1l8cydoLN63E82HvcGXWHJyf3mONQ4XD7G/pqKL2t19OuM",
-	"YmwBnmZ7eKutSj5L52WNxMvu9/OkjVhUczUO24vqSgOXButaQlWdvIFWLgkADcGPTeF49Qu9zXAczjn5",
-	"5CPzNgPcQ2RdNN1GKK+PqVsLyVslUdRtzXy2Z9MkKFAc3ZZj2U2Q9eC6REDd41AKWIXKwCHtHzk203yh",
-	"NrCvKuwY+cYeG02BXrsy28vHevmZPk641wasDhFfJUP4koK+LsEVfJzWYl1rrP/UijdwlR5w6hrSefyn",
-	"/3Epm39r5aR3YWQroy7aSBb4eEKtojuPvz/EMvFUHP3BYUN59HUWXt+C4RK2YV2V0tj5XWqIonmuLvO2",
-	"D6m/zKsTZsj23vRyrT3cmhNg6ATl2B6XrLOfVq2zOlatU4g/mYJWaxXZsq1D1TQCEcaUmqLQvnUE4A2t",
-	"Luq6ehordYLQv1k36y/nN+KA5Vu6dHAPbuTg/NybTHFPsaR3OJSvIG/pTIvxGCOvqsxXjycYYh7P45TD",
-	"HiXdKJnO99cjRXc5vHYJOf6sqNOHTbWR62fWqp7QAtW7StmomyEYX1ZNn3XSL9oy3a7vmToC7bE0Bc9Y",
-	"zH4biiLHmhuzrUBiOeqTsA/jYsoq7scJ1UW92YxdP2s7+2wJ1S/RQCtqyFCiV/nb1iqLNPKm6ivS1z9O",
-	"Wm/YWgN6+EfXZxDzAP9iDGIfO0Fms8kNm6wEvG3C+WVqeqB5rGQsqIXa5tBSSj3xr4bTrlwU1OZyNlHG",
-	"+xR8NJWQkRxccJ5jhyYzaK5v4VdRJ+A3ce/KiUqqjD2Gktu2HJTreINBHk1XMQwRvheLD7D5jCl1ab1s",
-	"kkObTZslnCpq7lMQ6l0uW2F6O6tynexvsyoHYvllW5W3kZT1duW1sDy8TVb2xdqVtx/MbiKwB9gtWZbL",
-	"Znbku25oYdfa2ryrqHZ5a7Of6eNYmzfgerA2l9LWnbV5jbW5pYBUYuhmffNVNeyTDUja8lK5hdKxdBta",
-	"ajlrOz21Oo4vUVGVdSwKSFn7cZuq+qomCt2E0FyhyEdRV6vtNeBJ+fD6VNZaz/o7pfU2lNZGWX4B/1eo",
-	"8u56a6WiLmiuZVDc1fTWBUZwo4qrJ9N3auvnobZWKOv11lVv9xZMb6e3LvKArV0vysvwhUdEbaUs67XX",
-	"DRA9vG3e9uXGRrU4oN3k6pq75cb1WH+Xr0eL3V2Ku7weW871cTTZjVgfdNmaGHanza6LnWotOalkmyqL",
-	"Iz5bLVYlt6zAqqSt7uoA+0WqrR5jSrzDv7cqq1Wu9LXrqQ4JPo6K6jbVxMFVcp2KqUrudNJb00kJT5eR",
-	"u05PL6GEOny4rP4Jb2v57nlhJhCrNOWxxf7UMGZ6yMa853+MZOgfbKiMaSIMy3MsnFPJNamYcqi65SPR",
-	"oszhDbquv/d3au6dmluquQ4n1mu4TZenpV4b2MX2Ro7Jl6/NNtOkDTpsI/QOb4fvfcFK67pz2FFVVcnn",
-	"p6XuIr5dQUFVycfSTdegdKmWohB2p5Gu1Ug3yk2+VhmXdqrSIuNxykS2WTE9KV95h68c0SufgKbauLJb",
-	"DvdtXEM7xbQ6C6DDADqNL1FXXbfXGqauQc1t+mzjAdyQdNw418fReJu33YRzTQOvTydec7B3avItqclr",
-	"4N/mXm1kCbvr1ifvjm4oKHktB7qLUL7TgSsd+OTd0abg5Eveg3Zq8noutLUlQiN9/sIV6StQrfXKdssz",
-	"OPxUePCXq59f6Xh3UysaQfv5hVBfTYq9vJ7fOO/HUfxb36ZgCVgret4ZB9YZB65fWtzNdvCJmg1u0W+9",
-	"PPklTQVfh5Fgk3lgd8vAbRkFPgl7QBsx5AatAHf6/8fS/7dcmXVk/DL6/o1EcjexjDtP952WH7T8VSax",
-	"1u29E/5fTs+/lIr/1Wn3W9l4W5X+NrX5Vhz0K9Lht8tiV1LcPzdH/KWly+tT1j8NPX0nFf1OOd9BOW/J",
-	"ylSyRQl3Az4FvVslDc75Vu9h3bad3nilEvTg7PTSP5S+SBVLbskUoJKW2r9Kvkx9nxCzxHH351alXt1U",
-	"p+sTlXwk1V0ljTigkmtU0FVyp5LflkquklWsrhHr3VXtXCU35VqnK3jnSL9TsWsqtko2OtJXMbql8uxp",
-	"91Z9WSVfvIrcRCM26MFNkDu8DQ70BSu4zUewoxarks/Q2byDDHUFbVUlH0lBbcbmUidVyZ0WukEL3SC9",
-	"GM50PFltBLH4e/8Pkdef6anYVsfrNAz6BNRUv5ZbjiP3s7ZTCANMv0Sl0FSoEJCw/GmbcuiBeEMCrf/6",
-	"x1ESw9YacMM/uj5l0cP7TmG8JYXRlGjbgPFLZHR35dG/eUMKZI1y3ymRd0pkpUQGhN2gSG7A8nYKZZ3e",
-	"b1MqA5X8whXLjbRkvYK5FpKHt8nBvlxlc8ux7Cb0enB9fornrvLZ5ZVPP9PHUUA3YHpQQksR604RXaeI",
-	"tpGKZt5ht1m7/Ec56nMtrxV2cCn/aXj5VyEv8daC6/UmNeAwYTsVuDz5L1EHntUQNiB/9ds2LTgA8oZE",
-	"8vD5j6MHl5trwJDw7Po04QD0O1X4llThWYW7TYi/TPZ314bDq5vV4b0LIZMu/rwfSVvkaU07pvpfTLM0",
-	"5SmQpuzGmwEcQF1xBqY1m5uN+nOdN92oAl1NdKc6f+Kqc4neG3Tnjbeinfa8wCe2qc8lbf3C9ectBGi9",
-	"Br0emoe3y/y+XCV669nsJtxX0X63q0d3YeDYxaB7dYV6Z1Hv8hp1mOrjqNSbMD/o1JWwdqdUr1Oqt8lX",
-	"G2dr5GY0N9fTcOsWD+eo0JpLC0qLsZCw5wS2LOMycZdGaRhqNTNc94bM8ASizpmeg7CgCht1YCoYHCQq",
-	"Ngf7nW6n0GnncecAldfFSZxkn0LCpzxVecaxVz6NnlibPz44SN2AiTL28Q+HPxzidffbX/mUkwe5MXg3",
-	"HSkS+Feu1ZAb2Cvw+LkjAg7n9vu1XvucpXbSsLpaeVefgWBAe5EXe4Yh4Th6+eyn2tfCyM3fo7Kfe+4I",
-	"uYYD7CCvVdrLUyY5ZCyeuOXvYyN5IaskqdpEVCBu8yxVD41NH6rKnm/8GkaX/fu//ht3zazKRAwlYZhW",
-	"0g8UUlhTmwBjETZ+unzVwyF1oN57xvNUzR1adOHUMstHRXrKbReeMZ4pecrtfj+ST8EIOU55KOrrBNFc",
-	"pfNM6XwiYlB0TES6IRFuCWjBUfoJGM7h6bM3vcPDw++IWvs1V5dr48KDF62C70ITJP+x0v618VtlC9c+",
-	"HKXMGDESFZYNapAeQMrmXEPOdVj8wyeRdMOizmzC7D0DQlr8bo+/z5Xhyd+iDrAiERaQbDogCXdXzAxx",
-	"2V3YUWELzSPJY2XmxvKsR9NoniLlNxORmy7qUm44Pcx4NuTaPVoAX9UZbnXLPm+zZ9AhCCupWVX5ZYds",
-	"SnLQaoabjSeFvHD0cMjiCyHHkTRWaTbmCKKQxxozCRNHBVRh+/AClzkQcqSZsbqI3SbP88nciJilA9gz",
-	"LOORZAZeqYTvP8ZPnbyDjOUGlLQKwliHOxdwAEenx6EIg3FYubDx1XyPVQCUxsB1IKAyM4twcMsKSNkz",
-	"IuGR9JIDkmMPiC4MHfcBq4CtQlbJmEAVwBY7PItkrtVUOObANUyYAcOsMIR9FQTrCLhxy77yxOq+fyky",
-	"JqFGhx0Wur0Vhmt0ZB9AzoyZKZ1AqsZCdsEQ14KMSTbmSAsiWQ4iSa3vdhpuwl8W1uYma1jJ0yQTsqdk",
-	"Ogcuk1wJac1jXEZ9okCHe1ZdcHdfTMFkzLuRZLEDQy8sTvOp4LM+/B3FmUBwmJtkAHjGsKdVyv+KP+0v",
-	"rtD91Pnw24f/PwAA//+I6V9GSMgBAA==",
+	"H4sIAAAAAAAC/+y963IbN7Yw+ioonq/KUkJSsuN4ErumphTZmWjHF5Uke6r2dA4Jdi+SGDWBDoAmzaRc",
+	"tX+dBzi1n+Hs99iPMk9yCmsB3U2ySTZ1801/EouNbgALC+t++bMVq0mmJEhrWk//bGVc8wlY0PjXcZob",
+	"C/okcX8kYGItMiuUbD1tnYOegu5wY8RIQsJiGspEAtKKoQDdbbVbwg3NuB232i3JJ9B62hJJq93S8Hsu",
+	"NCStp1bn0G6ZeAwT7mYZKj3htvW0lec40s4z95axWshR68OHdus410bp1RW9yfjvObAYHzMNNtduYUOt",
+	"JoyzTMNUqNywVBjLNJhMSQPFGn/PQc/LRdJHWtWFTfj7lyBHdtx6+v3DR3ULO5FxmidwAXoiJLdQA7V/",
+	"jEEy3DITNJppNTNsNlYGWN8Wr/a47TNhmAHL9owa2k4CKVhI2GAeSTsGFqs0hdjiVmMlY5ECy7gx+132",
+	"HIY8T61hVrEhTw08ZUqmc5aKKTB3PFaAiSTXUICpy46en3UODx89ZP/7P9+zA/a///OkG8k14PFr75Xr",
+	"XQBVQvO3nuLkBagGSqXApYfVSIMxTTBL0NA7wCy/qNd8AibjMZwkP4vUQg2unSHYCKp+fWDYAFIlR0KO",
+	"HODtWBgmw6fWIVoxoCcWYbh9tS/FRNjVpb3i78UknzCZTwagmRoyYWGCuECH3WUEYRanfJLhg38+bLNH",
+	"h4e/rVtlilPVHvH3h213NdyUraePDt1fQtJfD4tVC2lhBBqXXUC3IC5NgFzAqQ7Knvasvcz0eHcIVxBh",
+	"O5oWK7wDRH2tkh3Bp5K7hZxKmgFNJXcBr1PQRhgL0r5TaT6B45SLSZP1ZcWLbIpvuksjJh9ryTtSpjWr",
+	"v2tCtbqVHTB3ZQ93icbLK78aytwBsqik0dJUckeLmfARrDvdY26gI6QBaYR1EonJB/Q6m3AbjxkfcSGN",
+	"ZVzOWayk5UKCfmBYX7jP9iM5FJA6uYA5OShTyQNTjjPsP87fvGZ7Qgpb/dWLLMl+N5K/cJnM2VBpxqWZ",
+	"AU4dtWZjEY/d5wzTuWT9VI0e/+vpo+7D77uH/b9FLfbv//pvJ0hybQVPI5mKS6iO6rOZSFO/h8W32wt/",
+	"P+y3Gdh4g3jl9rlO+Hz0/XdroL4rdXA7vWNKoBLHGdxC163wxXse2yVEKI+57xhGz62g32UvwYm4Y2Du",
+	"mywBy0UayamAmT/XxUN14u5YGSdDK+n3qhJwJzsTdqxyG8mMj5w86+ABU9BzujKEaIHIrD22Ym27H90/",
+	"lL5MFU/Wnxz97g9t7hYkNOK3Vmnq1jvzn+gyOmRTOWVULyLZD2N6Iumzn38lMAMBcSSmINnbtyfP1++w",
+	"8v6OJ+9IkWgmSBkaegeUyi9qx3vj13fXd+ccjBFK1kMQH1UgxvZIRVSXAtiUpznsXw2IFex98rhuWRfq",
+	"EmSTYz06PWHWDb6Dg31rmhktcnMnFovydm9fUrhid7msO+TWYXu7suxXQmuliVItChjMKDZQdswuhXRU",
+	"nii/G2f4BCIZeAA3xvELx9pJZgx2LzZ1EpuSjhH8noNxG79Z3hwA/auQjShMAJJx2jsu1u1tHU1xzxYW",
+	"9H80DFtPW//XQWnaO6Cn5qC6lIW17UgEyyXeJRX84BCeLHdon/yJJ2eAZ+b+cqgDEv/JsywVMXcLP8i0",
+	"GqQw+fZfxu3iz4aAOqW3aNJlC0vqFgoJ0zR5t/Wh3TpWcpiK+E5XEuZEAYbFudYOn43lFtgedEfdNkty",
+	"mh/wWPZxqT8rPRBJAvIu13pBtN84diQSNsgtS3l8SVfaxCoDFoiZF3CYykDjanDVr5X9WeUyuctFn4FR",
+	"uY6BSWXZ0M2OS3kreW7HSos/4E6X80oY426a0kxID0fg2tE7B90u3mj/HTfNUSYQ7DVWQrA84ZaTFsQm",
+	"PB4LCf4z7MIJ3CkX0sJ7685MOmmYaLgwkQyXEFUiYR94WbOwuSsZgzvEfqyBWwjL6BNZzbQ7WCvoDtOQ",
+	"pMftAgVIuIWOFShMa+DJG5nOA5NbIgvt4huDec+xdEdWaqjJ1s/A+0xoMJuWIvM05YMU1n7jilOn3Fi3",
+	"9mSXybd+lejt8tn/kk+47MROJ5As5QNIA7HoR61YdDSk4Lh+JjJIhYSo1UfpcYHRPamZLtMwFO/rdBdt",
+	"LPuBxWOueWwdb0fGVkUyj3nPhclSPoeEccdWjEiA3B0kOroNOYZPlMEJBDEvBMo5I05vA6UR0kl4kfTq",
+	"HdMwBY7KkvviME9Tko0JLbdCU8NUXd7wCSHhw3uAVnr3j5Ux/geuNZ+3iAcGoe+fJAV6pdPDv/hq7cVo",
+	"V2/cb8XX1eBfEFs3Xbitxzhs9TRP+RwFVKvYREjLOJMwW6IgK7d88WotO+7cP3jKcNC8y06GjA8MSNtm",
+	"5dEXnCOXVqTMH4ab6WoXNdyNrVhdHtGS5I6/OzCMNJe2y46SiZCelcVcOpYxAHoICC7ciHFEM5LcDe4g",
+	"2QSZZEpISyYKQ8ocPULqHMcql5YPRCrs3EumAVlA5hOHBg7RWu3WTAvrdk/OwsrxltuZCHlCbz/cglqF",
+	"KQP3vwlVXgpj6xBlBAn5W911x82vYkaxleIfm5hjwdFW7kW7JeG97cWFd3gLBizfI5x90yZfCc/h0/TN",
+	"sPX0n40X+ufSjm09Sz5dpIVtRnjN+um0l3Hbi/LDw+/iHxwRNfhv8D9pLhM1oZ8ciz3V4C4PJAze89im",
+	"c+THXXZulQZHFDkzEGunDU245CPQz1iiIkTYWE0mwq2AecHHm5gI7TaDkPa1CsLfaqQqEh8KgaFOVkAp",
+	"pI8f7TNSImOuNbquC/pdMhAnisQqmzNhmVSztvv/TMkHlvEsA66dgjobgwYGqUGS7842T4R9MfWy2xJZ",
+	"koCudZ146wWPURZl/9DCWpBBSuXuG2wikiSFmbvBfGhB0xpn2k2esDGXSQoalU53M80zL1LlmSNaqB5n",
+	"qVOZaiQkmnd1gc+V7RjIuMYvTEEPmMlR02V9R+27BNF+m/WD7ZKm67cj2XcSbDdVIyG7Jo9jMMYNrPw6",
+	"5CLNNfRrj77tVqWCpLW4rtfuYBzlylFMdrw5xiV6dcmQuMHcBI5AuNnM/gIl92LTViJOi0ANuEIM3ebd",
+	"khEf2y0ulZxPVO4YopkbC5Nawkjf0iqFBtQjDHdTBU6y9RUyUdOZJokgrndaOWt6bxGaR3j6HZNBLIYi",
+	"Zhmx3y47Smd8bhiXjC4am41Bsowuf3c99ErKNrY2603AjlVSK3jgczQ6rX3qdM28KrYUrv51ovDKd1SM",
+	"iutGuapGFiP6VIuA5zhMDIW7WEmQNS3XIyA6MeFz5tkzR5M3Mdo0JSNStwnqFSugJ8tr+FXI5Zkx8mbu",
+	"kT9cSXfpHBLh5ctEj+jdfqMl0ALqooycGJyiFxI0GqydADKGwmCBc2GAkZOyc+hMc3hgWJYPUhFHsnh1",
+	"b+x0BdNmKK6YNrParTrp/KFkJQTJ7HdZX8gRGNsbzfqRFKTWTy5enndCkAwYW65pqJW0pab//NV/shG3",
+	"MOPzSO5RKNLDJ+6rdGFxqe6MzNzRVStiBo5qGwYTR4zxQ+VWIimsgXTYxlNONLo2BnN3V365uDgtwICU",
+	"LVANngm0V/ldbCYWAfuyRhcfZW8+8mxmR8HEXZrqHVmgeu3AHRZvc/XuLt7UWgmn4IJNBDnidwT+tpP9",
+	"3cEOnYp3beGu5MZ3KN7ldnys5FCMajauoYPsiTlG5mShoRjlZJNiEiApMfjtSZedoBUIqXo6j6STyd0K",
+	"g3uRPmIUjqfPZnyEugLTIBNvtn5z8vw4koPcWiXZAIZOaHO/o7NizA2Kb6gj1AkLSiQxBnIuql/SLaRK",
+	"5YtgvHYLTQCrm/+JVkAGAiWXVt1mSMai1rkYSSe+uE1G8s2l5VGry469Z9LLdi/fvP772xe9d29f9Nz2",
+	"ei+Pfnrxst9EqAwrXz26pYG48boDPh5zOYJTbsxM6aq9eMmW6q2nmR/IvkW9Nvy5itve3NoLI5aUyYeH",
+	"jx7XqZ0wW3hj2cCHsXPs4aOqsSQDzV6fnF+wHw4PO0+++4mNcpFwlOlfK6bs2ImbeJ8MChVM5ykYH6/g",
+	"qCLuIhtrbsARUh7HkFlETS6TSGYahuDIC1NOJjVjpa0XVd8zWrqhs1rZ30TI4odH285yBWJL4Kg9PWKT",
+	"zRUv/8KrHDdYo37dhMHxyla++S5beYnDV/UnL/n1hRxqbqzOY5tr6LnLGfO0j4zSg6HLzsEGGoWCALoT",
+	"F1dabw15sni8j9qtjFsL2q3g//4n7/xx2PnxN///zm9/HrafPPoQfv4/dTKb13WuAfgNti8C7YJxa2HG",
+	"BmrpEfs1H4CWTj8r4tk1jJzMoqFwYR6/ev5Tt4KapZ3shhC03mp7ThfWpPmog6FHpYO4zXIpfs+B8Vgr",
+	"Y8pVRvJkMsn9TXdaKUPwFKzj9k67zpTU4AgqtsUAeG9fLEL8SsA3EVb8a9e2OwUytF0u2ZSUYBVSYtTQ",
+	"/0a//bWPUfpg4zGem/saMthuJI/QCMqUZk7YIf1OKjZxEoEbYpiGCRf+MG9KIFrCzxprPqSJcRIBD1SG",
+	"2TG3LE4FiuROuzJgHW9hKbeFlWP1DNBIivi4QSluwlWXVqgBOo6+sMuDKVLDSXB3OX1gprQdM2ENUzPp",
+	"lJh8IrvsHU/zkBUReB47LpIs0LIaHGFW5XhcTilx0ChuU3XdlXiZErhOxQv23hqlsaQ/R6cnnl6zt2cv",
+	"2Z6QRDARPEvGEi1atU4xYR0/EHZec4gFiKwATUKe2+5koiQ5RcxT1g+fcMrpWIzGaDiaQCLyCcU0zvpO",
+	"BHGqbT7pgFtiDMmqg8akyjIh0SYmNILd8vdKqsmc7Z0eHpw+PPj3f/1/+ytE6btHdWdNLqLeJufWUAuQ",
+	"STqnjbXZMGy3kR8L5FRoJSe1ZsEScpVhzPJR4XGHaZsZy0dCjtos0ypZ9p49qUPhy+Lsez4gpUZG9det",
+	"ghx+LNOQKe0V4Qoa7Xkp/WH30Y/d76PW8lJqIYxAa3oj60G4xFn1QFjN9RyVmI7JsywVDlEokOgS5geI",
+	"c3RcptvwMkll6xwzL5Uc0QllWhnosiM5ZxOuLxOHeMJ4ZQuT1hzF6hiRwBJcfnj4Yx1k1EzWBmcWOEGG",
+	"XqQ5aPkBPmEHTMlOzNOUyKSaSeP96HEhpOV6yOMQmRqCWUk9NIoJGSO393lrCWgTyUupZmw2Vo5/zPgl",
+	"sDxbuUDr/LRqKpK6jbx1307n7lAqSJQI9+4gR91CaYyidUPCd7qRfJOB7DiwJs/Qh1ChIqNLpyxemjbj",
+	"7j8qA2nGYmjbTLsnDu95Mmkz5fQQ93+nz9TKJzU2uJG/J1tH5nKg1GUv1zWa7kshLyl6CdzpoIMY+OQB",
+	"Rou51/x5LmYaLNHfbUzqw3pW+xbZ49UlyBUx6hXoEXQyjM8bqGTeZU6oZkEURJ5lnrE+BlKjpzyIie4o",
+	"vUWNRqFPMoWhZbmMUZNOvO/kOETq1cthx2UgHzdGxQJdABioRJZIMqF12c9Ks1OV0J1gGoaO46IQG0nM",
+	"WNS5dOoB23PLbTOMwPP/6wmf4FmEDZ6jmQtMmwkpbCSHKR/tP8MD/EcRs4YhKz6qnFmYZE5MeWBYAnHK",
+	"kTAUi4/k0rRS2P0u83KdkGz68CkDHo8ZSKvnDwwzY56Rmo3EcwrtSBpFQmwQJzrw3qJ2X4A5QVeVl9AY",
+	"ZyaDmA3ySbbk8N3kOFjBr2VRtTiTd8Q1TuRQrRqLhOkNYOx9KnXmImN78Rjiyx1t9g7IxvYsH9X4E5bE",
+	"08rYdmVBq7PXSbAvVPqC4HumZqv7W1z7qtxUWhxWn81jEolrZAYr7Ny7I9Y9DSLLuufBlRBM0mEpbcwt",
+	"aLVb03prNKi0F0jIGrBveNTjUy7SIOzXcYskj+s/ULp/wpJBpS0n5mZaYUTIqEe/OJ6PAopTy5F3yXrD",
+	"Oo3bjiFVkFXBvwjscvnh8IpF12HOL8BTcnctoszqPtVl7fLXim4/5SJNCmnNO4Z0LpHblJ6L7lZVesPq",
+	"MSr6DPVmPV/dBM/tuBds2HXZ6RfakbThkHHJQMZ6njkChVbrIgbHWOUI5J7/Ad0sZYRgcOjvt9o1lAMX",
+	"sJPHtIGtruYubbB1O9GlXnGgxKPw3Ik5D76h+AqTD4fiPcVXPGAzkSYx17WuTGF6EwxUXwtbz+TUDBkE",
+	"+4XrgdIdY+cpMHoV/QoOKRyHTHPv3FndSSH8bgVixu24ty427wwy5SSFMaMRbA8mmaXII6lkxy9Kq5nZ",
+	"r3XEcgs9zA/vZaB7BuKFkxqmCi1xRVL4YfewjDuiHPWGtsHN16I42MX91i6wxJHqkbVXLsgu1sSl23es",
+	"Ac1znPSomotYRAGtRhYsX5PNO18c3q5+fesyT52IuG2BS/cE0cNrbnEK3GdleMKAbz1jykcRpcCnUIqO",
+	"K8foQ9YWbNG7k4mNV37hUl7nHt0Iqn/YdiRvMwPE/5qfyZkaKNvxgYLhCIgiQzxWZLsuMyeudAhXp7Ob",
+	"yeSGE9lGyW7thNYQlprPr71h70pBYEm6Rr1FQ6bqt1Bh36vSBdeC+0o9jczW1aW8o5e3RxSXC6wspzL5",
+	"tj0HffA69vYFGG43ul/V1l2d5gyGGsw4BCfW3MBUA0/mPS+11SPv7znk9ZdiaVF+YHvls9vWGc5xdX2F",
+	"NX1nRfEaOp2xPQh3eSsJLYdfK8liUZPcIU6qDJf2aF0rw5cA3sD6nICU5RiwPZlSvOFGJAxfLZbTTJf1",
+	"NYmaG4f8C1+D/7vItZoCOb393rvsHMAXtDp83Njf/d1iOEOtB3Tvnx3/r2/CT/t/q/V2LyQ5NomDvD33",
+	"eCXX8pa85R7wm7zlfsiu3vKt6FyvzVXWFuqHoVq39/z1eYdCmlDp2u+yt+Q7z0BXMld38ZzfLt4se7cx",
+	"SKlabKrL1i31GXmUw9hITnJjmec3DN6jj5wcFYQIXn837PHhY9rn9izyZTf/MrJdy+sfzi7H6DheTS0u",
+	"UapJHEBRpO26gQCBHn8FgQBLV29TIIAsKMAVIwH8+fTilBuzxrUbKIgbQreZilz4SEPNBlgBwKrgiY1a",
+	"ciTk+6jl/mk1h6G4XHWB1iXtfz4+UCzHMuApl3F9OR1HiXjK3LhOGMd4ktB1aHurk5CjSPbJtth1Y3/y",
+	"Q7v+ZP75W7/LXhR+DiZMJPt/iuxv7cJm9rc2y5S25m8f+l12qrI85d4hPRtzi9roME+HIk0hofSYgDQU",
+	"qRinKk+q56mkT1AqyouaNlM6kq/A8vTlT+wAeVDn3ckpO2CcjblOMAMHqUmxWSU7mYZJlx1F0gg5SqHY",
+	"A7PzTMQ8fcYmeWpFh343YPPMhLwhCmxNcp52jOXxJdubPv52+mSfYenNJJcJl5a9Ozk113HVTPh7n5ZX",
+	"cckXpAUDOtfeCKZVjg5ZHLbeORXyp8rzQCdbWUkUc4KROFERM7bnzrbNnN5N/0V7e5sNeHwJsqjVE0m8",
+	"jgd4/vs36bGyac22L16eL8Viu+2JRlt3GzKRdBSJ3JBD0CBjSNg55sQhYbm5HXxYT1d39fouS0LX8voG",
+	"Lt1H2uwdwVxDJEtXMGvqCX4ZxPolivf6/PzEAd6qkebZeM5Q7KSkOeP4AtUOcSR7QWR/FOInInkpZNKx",
+	"qkNvTniWOTwvTs/HQwEj/yAZIsX7MFwlkC4meUCsfFZHuzXIjZCOl7dbFU3C/ZVMhHT6IffW9/pA29UH",
+	"2Xhu8EmdWvlSjYRcG37+1pva2LdFyHmb6toEZr3KNHeLPK8a87bwriURoWJc3hir/Qrq6gchKadgVTtv",
+	"M61SaOMJwnAIMdUUwhTjGqkgqQcUEwkJQQ49/uqW1y5qS1UeFLnoW3WvkEG4OBUlZtEHFzMZp6JIwvBV",
+	"ttpFqqobHkk3on/kq4QgHj1lP2Gtjn6XvT0JQUiY3a0Tx5Xmi5i6kMRYm8ido/XAXcQNGQU+GXgJXF2G",
+	"/ih3zQZKWYfqmc/xwqNxY0wkqSx1kREx427ZhgLKuaQXkHlTBgwbpCq+NFQ6L5KOKwGD9zFklvUPaKmd",
+	"8LW+T+RHhxhG1jjoJAs5IRW7WsjLbEYrz1QthVwDjE1Z/i+WkNSrWG45//5//l9K9g9kSfk6LD6OxJeu",
+	"aTcu7eBPe434u7r4Ar833vVmINhGA4oqU2uLARQVpJofU/HKBmtVWbu1iRHl60juKOB2nfSOmzVb3I71",
+	"aqFy7y3ZrkpbygbrVVm1fEf71c4oXmvvKbsrbLP2hJGOO0TyJm097e2mthKUDYxtZT3Vj2NqW05OW0G1",
+	"a1muSlAE21U1g6XAiia2q7L2/XWNVyWJ/grMVys3b2MmSzH6S8hluVhU6ykSwGewXCVrpWEqSVGvj6eV",
+	"tBK21ySPZB9rf1khY0sRvc9Pji+Y22cHbYJi6KvqtZ1YSvUNpoCHt7h786lkkXxhWRQfIz9CVuScZhkS",
+	"oTZhAtqwa2RIjLlpyupwrCOFKXf0euDLbYTMmyPUHsgGHVoDCTmKWvsLaRNujU4XnEyUoy9YTrfEG5rE",
+	"sAW3lsXIVmiI8DeVAbFQ3fUGciAKwrurPWxVsrqyRazk/TdiD3utkl32oZJ7/Wer/hNMa14BUsl1dB90",
+	"+WzNdi4Eye6XrP2oZLPio5LddZ4dMPqzVncc7EpNx+SDRDk59oa0nRvG0lvWdxwsalUdlTTTclRyAwqO",
+	"o7xfg25TuWGb1Rp3LM00GvZKJYAVe5SMJGfe4tTxicbBfo8ZfOUlKAvTBWnFsD208UeYa2ZNm8VK+kft",
+	"svLum3OG7tT9LjvOsYRhJEPWeMfJkQWf3eujWIl1DEtFxP2JoisqExXpBiuplcoY6hzeMdxDj1B/H1l3",
+	"VvFQRxISgenqB8EMbsda5aPxsrDpyc6ibhXJQrmCSW0JxzRVMcfz6sVZXuMmOX3LHBInOeLHUhY3EQpy",
+	"XKEFXk9pc02yuatzQzaGCWie9oxVmo+WGePWD0xgoig4eZe3MpWYRu98wTo01/FYWEBppv78qyO6bENG",
+	"NZ8kTx63GdcT978si588TqHNzHc/Hr5vpgzEPOOxsPN6ZLxQlqfMLQmpHUkIGNpBji+KEgnf6MZZzvZ+",
+	"zzkSiEYFBorpr4SPxdvNkbF4pSkmliSrthKPzU2FqpHBouhEtXfmhJA2e4XLO9VgTK4dPXwuzGXxJzs9",
+	"eV7+8RrsTOnLt7LIxdyvhttgjS4kxJRsU6ENlG5sHEPmqPXGXLIhtUZxhK3v9tY/8LE9fVYWQ8+4NnB7",
+	"MStFDnXPJ3Cvr2vhK2KGF5KnBwcPu3/pPvyu36Ryxp1Ypz6V0iQ+nstXnqyrsx9Cvk5OCS/9da2EfIkh",
+	"43K+NN/j72umW2Scm6A74Bo6jqymoTIJvlKYQZ5DmrJTNQP9IhlBJM+ePD6MWvtYcyZLYYKyCUn0Kk86",
+	"iNWJ0wKN5dJXWe07wSWSXuUraPMztig3NLTxLHx6dWtYDygk6mLfuW5ZoqUr1EF4v0NLw+OMpK/uOnki",
+	"uu9TrkdYfvnccplwnfSePza96fc16PTw0Q+1S9xw2qdaTLieY9VJf97+jOvPvcl5X7r9pdWLunWNDii9",
+	"TKv38zWv1d4U91YKdj1J+JUGsJEoGjQxDD/YWOZm+jXXuWlmoSUqKEc9Hwe1qg6dsyGfiHS+Cd79VMj8",
+	"vcPtmZCJmpl+I4gr06MGWqtFwx3nfHNOZTYCwMKxvh3k0ubs0aPu4ePud+zlxXldGO+TOzBIk93pbqv1",
+	"qKQXi0Q3KXMTKvLUGleOMb42DKl2CyR6kUHcDU9PnhekjM/M04ODA8g7MzC285AfiM4hH8QPH333+Psn",
+	"f/nhx8MEhjUkrX43aKCprRYzBSkAGwdR1A9LQItp6OCPVBgFq76nbKUA1o3kRVArix/ZHmqqGrhR8iDl",
+	"xl5oLqlA6oWYwL7vEINhhv1SmOszlGC2xSHVYK97tLhoZBsd9/sS7/imH0hAJFeKrlEAdCdLuUTu4QRD",
+	"Un/Bxkn/js39KrmKpb/dIuW/rm0Kark4Jw6pYB/9sBBnPuYYaH4J8zaBqO3jBj/0Q0NelbCUy8Qw7O5A",
+	"5caHTNhIWpU6agc+JI0mpG6o/isOCV4rvyY4eK1evIc4tzckFlfuaCEW57Ki56+CB+GwMKYIsHMoFNvU",
+	"YYhOlOyzYcpH3Vos/UPJrSKNVZlK1Wi+hJru1WVpprz7Nff8SUM/j0p2d/FUDcmfindnuSl48+0sv3nv",
+	"9dnN67MMvxv0AD38ej1Ay1Dd5A1abeXPxeTqFwBf/yozlWsh8Snh81eVvlx7Gjvfg13dpDvehq3uyNN3",
+	"xw29kQuRNVf2R944jn3Vqc7u9OrTnGvxpIlLNSteZFMi7bF79dpe1nou8BW4XTfe2I1+WHe6Vw0sxeZs",
+	"aIFdPKJtKmCph/ywejQDlcukR2hRe/1+/jVoiCsCAiqGbkfCMPwOJvCFtm+RPAWJFexO3x0b7FVMGsfp",
+	"Oyx8N+aGDQCzZFJAt+/em9fs+YuXLy5esPMXF+z125cv9+vvZIPKMJ+HSW97gKGDb31o4VPmAdxmPzno",
+	"t9lLFZpZbTULUP4hJFWH23JFQD+EGfEHsD3USEO5XtMNTfy6/gP7bWw9yK2YFPpi1Pr+7wLbBjdalP/S",
+	"UvL/1hR9j7z1fPGMz1gfl07DXqPOF1Tp03ehgABmnjluX8XlSB77dGGqbIdHDVOQRGjI+6C9eY8wPaC2",
+	"fGAjiehNncQgYXOw9by0gdZcS3F2VaM3Cxo3nkdMPRRuQLO+rkD1NcSgeUzuhlYcHczQS9rMqNAV5obC",
+	"zx5+yuFnq6JOXSzaMoJcSYi6cfHpa5ScmglNq4LHjUhQay8TDUTPtQl8At5nyoRuanLO1DCS6Ij4B9XM",
+	"jNFGf+ZV21dczsPfOIB+WH7lVAU7/s1IcyG+paZJcFHS3g/Z6kXtR62HhwX7PqeyroHFP2OxksEfaxUb",
+	"zDEXwTDu40/c8xi0bBiH5DhRT8NwDRd/jaWYSXwk7uzEIhJJ8N0zGHbdq82K+ixOVyQrr85JCmeTiXFk",
+	"w9mN6GEv0porfXx+Qn1KqQhZKWecvnPQPT4/6WDNlSSswYgujXeHVHRcFrJjNQA7YCmMeDwPxDAIb03E",
+	"kC9LiN4uQx+FiKsgTkfyDFLgxnHRn7FHdVPZmvArU6mI53WCteVCsgP2HBUfdsDOAGvSL2HPwyc3LiOT",
+	"l7vW7RprtxaHXO4o/DTBLV4iG33oF/x5P8jRkSzx9oFZ8Ch7wScvG8okwlyyA2bGXMMKQL+v7x65lY9c",
+	"VxT+9LxL1Iu74W5U8nVaz1Vybyv/SLbyTCUbLeMq2Vlt24TFWxUgt56GOThXKu95b/W+Tau3O701Vm+V",
+	"bGzis6FLT8NbSIXOJ47Cr6k3v7aC/YL4uPrU53+uTyu+CkVYeWfm+1n1Lhd7NdWMaNZJotJuqNjf2kPG",
+	"E2qkQKvk+iqzSr4KLbmkhJsVY5VcVRcuO5ttbXm70N+tGtBfdKjcqCM0+na1EdmK2vCKZ9jDNwz2NluF",
+	"uTpUA74TdFEhh6rLfoU5yVZ8UFa5cmdLYaUYz2bZHCwDqUU8dvqUVLKDqRBIYC0ftVkoD4+jhWQ8TdXM",
+	"4XMbMcJ/ItMqBmOA+nvW1NT/XKKLE2igfkvKJKSeecKEbDWMgm2k/m7X1tyXt6prZ9Qmoc3O8zgGSMAp",
+	"bKSm4em8peZi1QSqRrUVmul4mUrqg/FVwioB+Hsnp9PHbjUnp9Mn+112Uu3e+wwxaMpTgTTfbZbLSJ6c",
+	"slRY0DxdWUptrH5B3OvEiAuVdVKYQlp0PfQEg4JLfQqbA/jec8hSNccutgeRPLfcwjBPnXR9wJ5zmCh5",
+	"DnYfE+IqeY8znl76XKQfTCQxzvosFFNl8Zj7yoBOXC9n8ImdWaXdo1HpFEwkHQQ71GSLnQEK/G4N4afy",
+	"G6Wnkb6DYb5SRbJaOZjK9jIuGa4MK91V2qyxRIGRD6xPUpmD9b6rNvsPNWizY63kf6jB1byQH+op+86q",
+	"akUs/nRqvZ5qNUjr0gbOfj5mf/nh8C+OLLoRPiq+hvXTg/qeQlorbdYwP4/Q/uJg2V8c3vYVOklLHJA9",
+	"pRArFufG7dVOPQFjvD90M/umT5Qv/NagjHHIFVqUS+v7dpe9Bif8PfUp+v7HHytdix4eHhavCWlh5PvS",
+	"C7umg2OZ4DTkeeqm5gOV26eDlMvLrZ3El7bvGy7SbBubKZ5BrGQsUvCuqXP0TK0V5Zsqz5cAGdlvF8TH",
+	"LbU1N7mfKl/cuI/CMrxuJ1db2s4GhM1KWdPdnIFBZPhz5XpiWMbCOoS0Tx63VrFuaSXh1Y3zFm1418DP",
+	"keod4ffpwJ0Wv/0QVL2I/x4SSiNxwnwGOlTE/ovPicBnE55hlwPOhvgCFaF1b/z7v/6bCuvTT9haKFho",
+	"nDh0dHrC+gbiXAs774dyvcKUVL5NZt1Q23gikiQFrKn/LzQtWMudtsyKScxixgvmuizUMcZyCu5vLLCA",
+	"/QnDv6YCZqBrixufU2H55tzSv/BVmkP93j+dYrBflUHUQ3+TUdQP2dUwuhWntxpHfX+G+95Hn6FpNJxd",
+	"vXnU40YTA5z/0LWNcIEmfwWGuKWbt9EYF+7/VQ1yQRKtsSocGSNGTmH2EvTJabU98y/AkxSMYQdFzQc0",
+	"2ITz3m+S8X/f56imzxHq0v5cDRrA5hlEsv+y8kI/9A5KqbnMPDShecaUHYPGdww1QCahDG8Lw/NzU2BT",
+	"ooUqVKyur1Eki7ZGL396ttIQKfD75eZJt1fXBQsB1eT1+muAj2+0B5EjfNRaqs0s1yOwPfoj08qqWKVt",
+	"NE72brz5kAFa0w3ejlNMVkYW7D/eZacqcQTDxmMfZqznlWvCscWoG0stYJpclqDwN6DmF25orcmqOmCT",
+	"jFHQv3kGXXbMjduF96ohajpNYKFyrTWQDiMJE0GYUthpufWKhVti6Ba0aLsd5jbXUBabe+buh0xS0AuG",
+	"ITlUOvbzTx8ykw9MiMIOiklBU1uUnHyqtJMEq3e81W5VKesmTWVX696ybPfpWPjOSfer4UaScWqFMs4n",
+	"XIYGODUsbbuqVVPYKBMazE7v1AmJfvWVWCQPOHRdYOtw9F6M1QwDGKna3zOi0FhBQqB7g+q9pcAvSZ7n",
+	"JE6FJuoL5SGW+hvnZse9U3SelwC2prg4ttrjI6AOxc2GN1XD1raNeQ7SvZwK4zBIad/7Jy7LdmxvIYNz",
+	"huUs6V8LgFvAhnrxzFQbjW8Sfj3Gely9ARnYNGxJflOi6FtT21vN30EHziXNs/RyXOlmbrVmJMJg4/9d",
+	"Onhv/egQHXjY5Ub2YpXXtd8+dhcvzvE8aXzZmsppnZPMGmaEjIGchybHcO5hnmItU9llZ4AFxKxih052",
+	"Xx7ACrzOZariS/cCmbvcXyp33EmDGas0ieTek/3COdV3zxEifSQuRcJPMNkfrgVBxYB/ZeuSsR5wN3ki",
+	"xZZWD+IfwavuGHMuLeO5VR16wavh8D4GwNQopKt4Wh0CcgFDp92x8Jb/UowlQBe6rWHNyXDQXXZMfcKq",
+	"Lch8t7XTo4vjX9jB9OEB/nqATcwO/hTJB6p6yPp0rH91O+53Mc+Q/RWdsbSKJbX/WuBb151tfUWh7f3M",
+	"bsJOdp0+gAUB95Y0XPkuhjSiZqUZbK0pxJtkyBBSUrpVgtasCd5zcnwxB5EiB9D4onwsIhs1VcYyVKaY",
+	"6KqyWDxIyUgOsbYiYnDUYsNUzcjcOuSpofJhBoMRqHUeSgy5VZOK2Wz15Df2b6ya1WqjzXdBmw1HvtF8",
+	"d9T5z8POj91e57dvt6d01bWJ9OtchwpNODgC9Lp8G7no3TLtUiPYJtifg8X2vf2yN6KGMTeO8ziBnnSZ",
+	"SPbrsD1Qs+IjgT/TA6Zhqi7d26RYLspDZZw+NoUsvlEllNSZ0ZCEHBihcTfDt/4OtHuBAVil2ITLuaf9",
+	"kSTiH/h0XZHssPB6MtmcoN7dtUIoreOPDoE87BYEBHei2EXTsP6q2IOm0MNuJF+rUKJMFSD27dWd6lbh",
+	"WuyYSzYAFqvJQEhIiNmhESqShGde5/N+CcOxyg/mcbNOh/E0ZQRZbHqdzhm3auJtW469Kgns7enzo4sX",
+	"9aSsznzwDrQYzi/UJaxveksNUX3TTKvYFN+hUKPnr/7Tp1CzEbcw43O2R97Qh0/2Hb4iRgr0hJqx0rYT",
+	"Cx3nwjIh0RJAnzVsAEOlMXRtzmKtsEc9IEGHGU9Th/XSMoUlay9enlMBOcckSkH6gWFZPkhFjEQJJGgM",
+	"IIpQVkFPG+ufvjm/IOEjt+MD2km/Ds2po+s6K/np0QXb66fTXsZtD8XLmLRWEjX9TyYfFj/1ndjq0736",
+	"XI+U2eHdJlU0lwNAljrSrjly0pPrItPcYSN8fEcvdxvy1Dpp2+ZaYkRhOi9jN31nX0MGnmeRDAd8wHIK",
+	"9mMHjDRG9xsRvOL4R2AZZ48PH5aBYt42QFlJVLtzj/slgQ4yqJBD0Ix6jQ2Exe63M63kaL/uVKmeBlph",
+	"e/629urtE3ih/eKEMXm4sFiUbzrpFKbQvnfjB7T/ft8Xuqy5GljL0pIVzdH0X38wZbCeQYA+i+TS5/0i",
+	"0MIYSppiDUVDhT/Cx2MuI6nBHTN2OAh2utgpR95MpzkZvcccmcqMY1PjK1bxiLFp9JrARt/meQ8bgKuZ",
+	"u5u+EvIlOHLF+jwTPdob4fdWuwe8z9bNhHiFSbOcvZXiPYNMxWNmIFYyKY1qi8gaSUcekEYTXhJJK+GJ",
+	"SiXRCI/9pux5noJx0qcaYpxzaHQPCbu4eEkGvj14n7EOk2q2318C8bpInXU9rt26/EJAJpkSclH7Itxh",
+	"gwqlNl12jD2vizgRE+7MAMI1SioNNIRhZ6fHXjVHOpwoTztzPXXiiPVYPVbZopF2ffvrdQ2b8dgeGN+D",
+	"OYTHmMUTQGdwrKRBrWAMBiLp+USJvKucRQ2mQuXG38uJMN7MveR0uFab52NlJmBFXETPpmrEUiG9LIjR",
+	"M8HVFAoQh20ZkUBtP2iklzVWJB9RQnIeWjkfHR6WRk40mGA3O7cQb3rPDXTrZYAql6AZ2w36Rr8T2uY8",
+	"fcXjsZCwKeenCHxR0vi8nfpYzgUyXDtiuVL/9XKIRP0y6OHGJKL6NCE1A91DEbv2uYaRN9CvFV9vIMGo",
+	"Jr6h9vxCPF9z30d445MM1gpksskGfnVj7yDAK8x3n/S6LcbLk5tbCvUKKRcVP/umsK9wbLvGfW2/HwFJ",
+	"d/seoevKFosMEUySSIR7hm1Kld5cHbJJfaICZE0rU+4VJ9rGBe3fV6i8kYC06s24VlxacaL1gWkBmz56",
+	"8u7arNgrZvXiQfU0pSZVp6zI2JufXpsH1yfobj7Z8kR+rVUAtpA39/HaqI6+e9Iny1IkV8I7mI/uOCrz",
+	"7DA2nu1VE6zalVQvrLtSCHjHxRL2MZhuAGXHY0yZc6iIkSXUOKHoa8Uj6eNHJmJEDZ/YngEIofTf7S9q",
+	"GGViWavdqmS/tdqtIvutVgEJYG1iww6QvbYduxC2voIgzGU2uDEKcynN8T4v+j4v+poRp6v0fulGhU7v",
+	"xMH9QIY6J+WoIuByaUXKyH3oG9eUOFgNENjMTZYdmgatnWsmfVYm7mK5XamYiXnKNUv8i/TC1hWYDOJt",
+	"YZRL7ETIpOwJ6/0Oiy1T47HCinrVGE+sPGes5hZG80guZg23Q0gz6tKU8lIS6v3FXpkGC9ZFkhv2H+dv",
+	"Xv+04LEIp/thA7nZNZJvRVq/mVC+tuewbUe8IlkG9e1eWRVDWSnp69wtmm4ZOV+OcnfN/myRge/nIJOQ",
+	"3W3lpp2eFNZ4NFyr3HbUsDPgEnVTiZy5776ptPgDme9T5r085H0g+yg5H7qRjOQ5ZZGNNJfWp+rTHE8j",
+	"yViH9d316jNGLhmHLI6Yj8CWDR2NH4ndWfs0MkQQyMRfN7YnJo4umPDFwojthIwHhhQfcN/b99+jdEaq",
+	"GqxhoqbAijrIfghGDvgpeZqGYgl8oKbwzLfqXTSf4RsdNKoGg6txcLggYzyGkoe4mfB5sjfi+mNh0zkz",
+	"3AoznGMlA3oYWCq2R+SyBA4C+bSSSthmEzK1Ve3/XkOuRtUEdfbtSSRRgKq4uDC+JpjYF2z/Qv4LQ5UL",
+	"8y/IKZty7W2keGnQbohIUd7MsbVZJbSPDMxremgW3usYRyGHH8yXXXDoVO132S/WZu6+tSN5zidwLiz8",
+	"9dxqEds2+6EzVrlmJhVo8CVjf5dVwYXwe4G+8wKmWCg0s4aBwJ33y7uE3rj+wi76lJdJ5+QjkyfUH44n",
+	"leaxBSZilucexZSQfX2fKR1Juno+7RKfExT328FjY2dOsLNjQ2X2Cm9vJBM1k8Zq4BM07ystDG0Fk0S9",
+	"AdtBmGAa9ImnLfKC9qY59PxqykPjmfgV5q0PHzDFfahqqgK8OL9gjmy41X7zTelS/eabNuNoKiF/Vak/",
+	"gJwKrSR1BOUpJcAED1kkj16fn5+wc4hf5xPqaLd3/vp4n/2e87R0KQ41n4CTuvH4LsbCFF0k9w67D7uH",
+	"+1S0dMZTqnt46e46otQUnNjgqc9LMQUJxnivPU8E/pVpNShogA8k7xfEgR2fvX2OtC0fGPg9x9rBXjJk",
+	"M5GmjCcJ9gpus9eltSMwkjY7VQmS/eDEX4COFXbudakJzzJ0l/pK/QSbmGurRppn4zk55wzhMBZLYEPl",
+	"hDZWlGvY61fM6ge+eMO3/zJKYv3XSGJ/UR824k4yUXHuDocA7aAYCmg6kto/SFRsDshuWXUkVdq7m2fM",
+	"iBESGAzcO8iFv61eTrLKiXIsal3oORPWsZmo5QlIPplwPV9QXDsx+kNiQqdllGGrGFNiR1HJICA6VgfB",
+	"7xydnrTaraJBaQvRxrfQlDwTraet7/AnNDKNkacejIGndvyH+/cIUC0siMZJ0nra+jvYX/wQJ9+RnwVf",
+	"fXR4GPQQH9pdPRd3Hu43Ejq2qRE0Bd3L+iwdgVdrCt0F6aD19J+/VUFcYD/iu4MVHxmntNE2W7+5lw9Q",
+	"/q1ueanrHDkEDauQoAQyJ67J2P2+l3DLB9wA9eXXwONxKOOxAr0zmuxjA49kfqt89IfVfDgUMRrAvj/8",
+	"bsNaqhes+ZpC1ZXNi3IKGC5s86meLZKxdcda8Hl0Oa49XjR0tJkE7BDowyS92UNDrHQCCdINR0KUNF12",
+	"RqKKj8Pp4+e9jNOuyoEDZceFCIR+b186oI8c0hBb9b9RoIfbPclWU2HEQKSOVgbLEAlm9JtVPpMukhSw",
+	"qQrntqN5P2P/dBKNjl4/74TQqi7roxe7zw5YHzW7fugagXtRcZxr7QO9tJPA2d6Yp8OOoxlPWf+f+Hab",
+	"lML90B9jEclfCmOP3KZeTB0OIHlx9MqibWKNMlIOOXgpJsKiz2DLwGMyFbmRy3aVlEL4sOeFE3O8moGe",
+	"J2GKWFwUGH7PQc9LeYE7HY9MziVub7Vcb10Cx1g4x6o5K9TLguGi58KXL/dGUqdAuXVSCEjdSsPbPV/S",
+	"plzuTS9PJFvXsASwHVZQmZCuGBZrD9DAoyLpfj0k6L1rgsCrOk6DKFcU4uW67K1x+jo1COLSzFDKYlFr",
+	"hvY6asYSAkbqQpyiViX+L5LhUmNEX0f7ymMoyhHMT05NRapd2jCNWdhwUa8kE/iSm7s3mrkx1Cj7t1q0",
+	"rf26u+T1+L/R1l//NaQVu3/tt1tkkSV5IhvoKldaSsKioBXEE+SRjw8frpujWPTBW+k1lT8goZe+2/7S",
+	"z0oPRJKAXGaBiwaPf1IZmtZvDupLOmf5bEkYMnZhJxXGSUVulvgm2laDIdatEY2n3sZZKx26KU7cW2fl",
+	"2Gse43WcDdWlzLeW1FpnyF9Fjje/fio44I+tFgf8s1UcQKU6z3wLjfJYS3P4CmZ4f2WBDG7OVqZMDQ5Q",
+	"sMAi6Iu+XT8pap5+I7d4YY63mQHtT6s8VR9PsoSBD29nCXWoQtDwR3+4/eh/4kmINr8rFHNv/Lj9jWMl",
+	"h6nwxuebxMmjJMHuK941400BO+FiM7J18OdYGeu40oeyTtwqAlN3i2UEXpJhkdE5tbnkc+HjrWUE3CSW",
+	"rHK5x3Xd+dmxx9a7RIrH2994rezPTn24caQ4I3N1BS8KM+OuVIrbeLx6yqfu57s85Fumf7ifZuTv8O7I",
+	"3x1yyo+NseR2q2DsA8O0+yV1+mybgcTkMDZM+Si4m8HcCnU7+NMhbY9yZz4cxBowYYSnZq0V5MzHarkL",
+	"lkCs5xlWds7tuBfSIn34th1TbkKRekeFiZhWsyIzRZAetRdW1GaVBe132SuuL1m/8lsf/W49rZTtR7Lw",
+	"7od2q1L50hdddlS6n4pw8k6qRqOQ/rxicVtA0uMKLG7tvq/omm/PXnZAxirBlP9i18/QSoxpiVQ4mz1A",
+	"EDxA2GKhpaD/La6q8o1rcptbogVVMG8gC5+uQPRxed8UeMqylAtp4b1lWg2U7RQlBkrYkpOiuIElI9tG",
+	"U9qt9x1vFm0BBTq2FulM8Nxt1PXOw6Bbt/HdJuZWq7FsNQWUhVg+ZxWwrg7SVntAGIclKRYl6OXonhR9",
+	"fZ6EPyvj8ULS7gC4piABrOmPXvARWMMeHz6MJCd7NHt7wjQkQkNsMdqGqqDUUPkzTJk8L9y720VqeiPp",
+	"fk1ERV0CpbtXM+hrDn3Xy+wXcJK0Pvy2gDDkkNhIQY4yQYEjnzcJCdtoRkO8o+azpiBLMTh7E7A84ZaX",
+	"6ecl/ypqkU3BFPkE+/WYp8wW6RRrnJXftj7Llcc2nTMlYwhxP5VSZxXXuI/Y82mhwhrG9UjJRyJxkubY",
+	"V1ehZO0cyrzQSGpwcvYUfCRul50MWaqMbfuMbZRHJ5h/isHdSkIdrSKLUECYWzKNhc/7zJ07toqF2V8J",
+	"WXsbKDPZgQqSZ5WzpKJ21TPEaMNPWVa84av1qkSfhQu2jTXTLdzKmM+xaIcvMNDjtv+MKktSiI9HRFPh",
+	"zqF4gYYYxBQi+fjwIROTCSSCW0jnXUZnqdWMnM2XkFkfOpMIatcjZC4skYTc+FKySAmLfG3M0ZkKmLGM",
+	"Y43CqfJZsuuZ/cIFuuf2a7j9VizalesizFc5PcYgbGT0b3HEZ83ki4JPWxm8L/n0OfP3smiZ2cio65gb",
+	"Fqu6HcZWqb92x0yNKnCtnrz7PYQfd+/9POvR6jjUxCtRaxtbKysgbuJqx9zEPKGEjFAL7IEp1FqUy96c",
+	"PD/2NXWtANNlRSqALwyGBfNIJPFRfJiblLC9N6/Z8xcvX1y8YGcvzi/OTo4v9n1EPdJYO4ZJJOF9EduO",
+	"IWRtKmrEqTbIJChdwWaKyjDuEcO1zmCYG58DyB4f/lgpx4L1wpkg2RdlVkpVw1Ad/GgkKdwdC8qk3NhO",
+	"CH+fci24tPu4mOKTFKbNZipPExRsEa6e3wvNnAzmbU117JeU++KKb2O9NPxTZr0f+174bvp83Y1or43E",
+	"rT+EwzsheV+PLPV3LMC19nB2E2gc6E6oiEHhmFyfbGVgwqUVsbmtGouYM4tVRZuUWeT2Y9RZ3EQeCUxE",
+	"ygpqy5KyI6h7JZJ/gFZhS1QwHSm46EKXJTBRuJm9vlYpIESkkkREKW+FoEVjFqtT7q8nywV5X6Gg5Cnc",
+	"SUialEjx7e532GcE3rFzeC31oCoCPgj3S/IDfWxOUrigvQTk8LldlJ5us4C7JJxUb+gGQSy34wMiJ51q",
+	"YdJ6Q12RK4GCRq6xvki5AE+vSAJCCxnbC+a3/XYkQ7XROhpGiaShOCZWdiNS5XOM1hSGxVqhRLUIuh2y",
+	"aJAURFH3jw+/860HQw4jGv1oASU4ixredVY9HHtaKRt8C8rP4iTFdWhyrR/XJT742vMh1fZzsrMtX4hl",
+	"XYOOroqFS4dYxfh8IWcEER6LFm6NlriUakDoTFwr4yOH2ZAYsmlhgRm0KKuEz7EFJUY3YNIlqSQLBRK5",
+	"TNpMDJlRbTJ/5tYqSXn/Xcpkk5TGns59RVdsxo2Nd3SoPoolMLGMvzTCXYo1gRGOzhzTRm811rqYpYYZ",
+	"uKcFBCjfd2PuzymVseUrrwWHIUE/00DV+jcfMw1ZS81evC+qCrMiCubbsmkDed8Xk3lDFVjvyiy6eFP5",
+	"ktBbeqCSOUlFJPjkGtieVI5CWyEpC2IAdgYgIxmKxKKK6mjggJedI/ZRGsMKzct5rhhUE7KH2bcr6cPk",
+	"lx1oNUMThu9rJSy1lijMwo6CdpQWI4FVVL2NOFSHxyLLtWlAHvy3QQjx29elf6HTTmG7abfGwBNvyDwH",
+	"21mXxH2+eOIb804+3CVRffTjXWbuXQTRfUlkZxdOgRhxIb2nbOONPrdc28IqVOOVrr22Krfr7201/oCq",
+	"DHaMSErZQKsZ3iMvblB1DzzKSJ7ncYwkxIgUJNpzlC6khUpCsCO5U8EXKstGci9QY/JpqEvYZwYjF5ys",
+	"JQwTCUwy5c5nzaVxO9sJfamfSHeLNFkrRi5xzRc+7iKwzB2OhCqSbQ0tLEoEeFPcvO2FVCoVjwIclgcg",
+	"YY+SEmulQYyjpKK4GCbCsUyLqDDeSLpPdzi2HpR8Kka+9gFmwlNYSTAZovacdLzE56tG1fHMV3CbvPIV",
+	"1OYQkMEugOyqlpdro8c/xorxCTuhs/F5b5KdsERtRg4lkvigWMpaRHklMBORDTWYMeklbXb66/ELFqsE",
+	"eqG+udNG0hTooIT29WWkkjE8K937dgxlRfRvmQxe5b5bTA/DWHEG038Wye8OHxXW44o4dpKcPjCsWHjh",
+	"sKzy+Mc+XDVIc6g4FJ+ow6I3IomPCmAsYdN3h4/qbtAitp4kp0vc6qV3mC6iWpm1qkVNht2HUsNdCs+s",
+	"3QsVaxam0leACWksx+Zp20k8NnF3X+bV8jodd7bYj6YBDjnyMeDUsqIWhY6VNPkkkH60PR0QChW4cOBx",
+	"wVinjGLPxuKEI2nFxFGjQvAjjEigrMZwkpy2w9fo+cnzgvpjWSGHknmCTeXaWCiC21xDm+bdb7Mh1r5Q",
+	"wWvk88jNmCdqRkLeJcwJ3v3iiyYf7Pfb6KEwpdDZZh51I4lVKPpd9jOJk4alWIBDVspT/A1xH7RW+q9U",
+	"zUgDN6pSzqgWWY8D1OsDppfSPR20do2Wrk1C9XaJq0c3N7pLb08aXaXVu7MB34/VJEOb/vVQnsrarxdz",
+	"sLCJ5CkWp89NyG/f3HqE/e//fL+PCLN70xEWeo4wId0X0EGlc2MhYX8oCVh4yBEdU5peiugqrNNDGgcy",
+	"nkhORJKkgOxZ59JgF/cQIEpMuhQcqMmAE6xIhAipBk6CqEoMvt1ByK6eqMT3yXBy6i8XF6eFRboaFfbA",
+	"UOn5SEbym2+w2k4RnCKKzHA08yq52FdlcvHynNIRCOKRDCnj33zD9kLSB5aJefnm9d/fvui9e/uid/L6",
+	"7y/OL3ovT84vXrzuHT1/ftbf7y58OJJ1HVt8iQxfz1ZYEoCw7cuYy8SM+SV4Z2EkjUphQWJVkk3AUTZh",
+	"Jt5AJgwCNDQV074ORyQXaqAxuh+hXH84JKqU+sz3bxZOZIxB20oaSFXqc9popdh/lx3JOVracfl+jDCh",
+	"U0fZTndxdx7HA1gcpPq+IseRTKiFyzEu5hi07TNDvgpfRwkWDlZzCx3Mz6HZKpyNChNMHGwypz9gwn3n",
+	"5DSSgzzBniyODDuyaKzKnGQRc5/M4Tf4oOiQQX1G3NYGcyfAhioDg3w0mrNBLtJaQaHSjuaW9OiaHkd3",
+	"7CSoa7mzNmKwaKFTYMsmGhDsYXdo19zAE2ijbFFfXEv/Q3f0jSFVx2HQXVRY2TLyRMZpnsAFaKy8jvaI",
+	"VXMaj21o/E41X4dYhKPLsOOYAYylJaLPHfE2Fn0EwsJkXekPn5z1cXKe/Ak0CwoLZ/oZx7M6Nbs2Wiwu",
+	"UTEgdPHT+rDuk8IWgnIqVgjFsGqpCjQp5O6RmIIkrMFi8+6yMwkzp+bPqH+UAaxogKWWHh0+ZD75vk8F",
+	"rzw1cN/nK5+PJEorlOdYrWlvyBKP/0YrO01WGNupMeujw0P25td+mbpSJLqohJpbjaRyOhSW9vTGpBmX",
+	"1puKfIlPKoMaSfKXF3OGxZoxOrp9Bbw885OXfWMDzKlp7Pro8+OiDvutuKno67uE6d34lay1oyyeuRN0",
+	"Vo/72cbj3qArLGd8noRaqsvH2F1TWWqtjn6TUYwNwFNvD2+0VQmzdF7UYr3qfj9P2ojFe1fjsL2orjQD",
+	"abB+Liu7INTQyiUBoCb4sS4cr3qhtxmOwzknn3xk3maAe4isi6bbCOX1MXVrIXmnJIq6OprP9mzqBAWK",
+	"o9tyLLsJsh5cVwioexpKjqtQgTyUF0GOzTUs1CD31csdI9/Yy6cu0GtXZnv1WC8/08cJ99qA1SHiq2AI",
+	"X0/yfy1X8HFai/Xzsc5cI94AKj0ISftP//Q/LmX4b63Q9i6MbGTURRvJAh9PqCV96+n3h9iOgpowPDqs",
+	"acOwzsLrW71cwTZcqXSw87vUeElDpq7ytg+pv8qrY27I9l73cqUN5ZoT4OgEBWzDTdbZT6umYhWr1inE",
+	"n0zhvLWKbNE+pmxOgwhjCk1RaN+ihuENLS/quro9KxV70L9ZNesv5zfigOVbunRwj27l4Pzcm0xxR9g6",
+	"IBzKV5C3dKHFaISRV2Xmq8cTDDGP53EKbI+SbpRM5/vrkaK9HF67hBx/ltTpw6Ya7NUza1THaIHqfUIF",
+	"g8IevqjaYeukX7Rlul0/MFUE2uNpyjxjMftNKIocaTBmWyHWYtQnYR/GxRTdIk4Sqr98uxm7ftZm9tkC",
+	"ql+igVZUkKFAr+K3rdVcaeRt1XGlr3+ctN6wtRr08I9uziDmAf7FGMQ+doLMZpMbNnMKeFuH88vU9EBD",
+	"rGQsqFXj5tBSSj3xr4bTLl0U1E53NlbG+xR8NJWQkexfAmTYCc706+tb+FVUCfht3LtiooIqYy+z5K4t",
+	"B8U6zjDIo+4qhiHC93zyATafMaUurJd1cmi9abOAU0nNfQpCtZtuI0xvZlWukv1tVuVALL9sq/I2krLe",
+	"rrwWlod3ycq+WLvy9oPZTQT2ALsjy3LRNJN81zWtMhtbm3cV1a5ubfYzfRxr8wZcD9bmQtq6tzavsTY3",
+	"FJAKDN2sb74uh32yAUlbXiq2UDiW7kJLLWZtpqeWx/ElKqqyikUBKSs/blNVX1dEodsQmksU+Sjqarm9",
+	"GjwpHt6cylpA/l5pvRultVaWX8D/Faq8u95aqqgLmmsRFHc9vXWBEdyq4urJ9L3a+nmorSXKer111du9",
+	"BdOb6a2LPGBrd53iMnzhEVFbKct67XUDRA/vmrd9ubFRDQ5oN7m64m65dT3W3+Wb0WJ3l+KurscWc30c",
+	"TXYj1gddtiKG3Wuz62KnGktOKtmmyuKIz1aLVckdK7Aqaaq7OsB+kWqrx5gC7/DvrcpqmSt943qqQ4KP",
+	"o6K6TdVxcJXcpGKqknud9M50UsLTZeSu0tMrKKEOH66qf7K3lXz3LDdjFqs0hdhiH3w24nrAR9DxP0Yy",
+	"9Ck3VMY0EYZnGRbOKeWaVEyB/ZoPQEtcZkp5O5t1XX/v79XcezW3UHMdTqzXcOsuT0O9NrCL7Q1jky9f",
+	"m62nSRt02FroHd4N3/uCldZ157CjqqqSz09L3UV8u4aCqpKPpZuuQelCLUUh7F4jXauRbpSbfK0ykHaq",
+	"0nwCccrFZLNielq88g5fOaZXPgFNtXZldxzuW7uGZoppeRaMDoPRaXyJuuq6vVYwdQ1qbtNnaw/glqTj",
+	"2rk+jsZbv+06nKsbeHM68ZqDvVeT70hNXgP/JvdqI0vYXbc+fXd8S0HJaznQfYTyvQ5c6sCn7443BSdf",
+	"8R40U5PXc6GtLRFq6fMXrkhfg2qtV7YbnsHhp8KDv1z9/FrHu5taUQvazy+E+npS7NX1/Np5P47i3/g2",
+	"BUvAWtHz3jiwzjhw89LibraDT9RscId+6+XJr2gq+DqMBJvMA7tbBu7KKPBJ2AOaiCG3aAW41/8/lv6/",
+	"5cqsI+NX0fdvJZK7jmXce7rvtfyg5a8yibVu753w/2p6/pVU/K9Ou9/Kxpuq9HepzTfioF+RDr9dFruW",
+	"4v65OeKvLF3enLL+aejpO6no98r5Dsp5Q1amki1KuBvwKejdKqlxzjd6D+u27fTGa5WgB2enl/6h9GWq",
+	"eHJHpgCVNNT+VfJl6vuEmAWOuz+3KvXqtjpdn6rkI6nuKqnFAZXcoIKuknuV/K5UcpWsYnWFWO+uamcq",
+	"uS3XOl3Be0f6vYpdUbFVstGRvorRDZVnT7u36ssq+eJV5DoasUEProPc4V1woC9Ywa0/gh21WJV8hs7m",
+	"HWSoa2irKvlICmo9Nhc6qUrutdANWugG6cUA1/F4tRHE4u/dP0RWfaanYlsdr/Mw6BNQU/1a7jiO3M/a",
+	"TCEMMP0SlUJTokJAwuKnbcqhB+ItCbT+6x9HSQxbq8EN/+jmlEUP73uF8Y4URlOgbQ3GL5HR3ZVH/+Yt",
+	"KZAVyn2vRN4rkaUSGRB2gyK5AcubKZRVer9NqQxU8gtXLDfSkvUK5lpIHt4lB/tylc0tx7Kb0OvB9fkp",
+	"nrvKZ1dXPv1MH0cB3YDpQQktRKx7RXSdItpEKpp5h91m7fIfxajPtbxW2MGV/Kfh5V+FvMJbC67X29SA",
+	"w4TNVODi5L9EHXhWQdiA/OVv27TgAMhbEsnD5z+OHlxsrgZDwrOb04QD0O9V4TtShWcl7tYh/jLZ310b",
+	"Dq9uVof3LoVM2vjzfiRtnqUV7Zjqf3HN0xRSRpqyG2/67IBVFWfGteZzs1F/rvKmW1Wgy4nuVedPXHUu",
+	"0HuD7rzxVjTTnhf4xDb1uaCtX7j+vIUArdeg10Pz8G6Z35erRG89m92E+zLa72716DbrO3bRb19fod5Z",
+	"1Lu6Rh2m+jgq9SbMDzp1KazdK9XrlOpt8tXG2Wq5Gc0Nehpu3eLhHOdag7RMaTESku05gW0yAZm4S6M0",
+	"G2g1M6A7A24gYVHrQs+ZsEzlNmqxqeDsIFGxOdhvtVu5TltPWweovC5O4iT7lCUwhVRlE8Be+TR6bG32",
+	"9OAgdQPGytinPxz+cIjX3W9/5VNOHgRj8G46UiTwr0yrARi2l+PxgyMCDuf2u5Ve+8BTO65ZXaW8q89A",
+	"MEx7kRd7hiHhOH71/KfK18LIzd+jsp977ghBswPsIK9V2slSLoFNeDx2y9/HRvJClklSlYmoQNzmWcoe",
+	"Gps+VJY93/g1jC7793/9N+6aWzURMSsIw7SUflguhTWVCTAWYeOni1c9HFIH6r3nkKVq7tCizc4ttzDM",
+	"03Owbfacw0TJc7D73UgeMSPkKIVQ1NcJoplK5xOls7GImaJjItLNEuGWgBYcpZ8xA8COnp91Dg8PvyNq",
+	"7ddcXq6NCw9etBK+C02Q/McK+9fGbxUtXLvsOOXGiKEosaxfgXSfpXwOmmWgw+IfP4ukGxa1ZmNuHxgm",
+	"pMXvduB9pgwkf4tajOeJsAzJpgOScHfFzBCX3YUd5jbXEEmIlZkbC5MOTaMhRcpvxiIzbdSl3HB6OIHJ",
+	"ALR7tAC+sjPc6pZ93mbHoEOQraRmleWXHbIpCUyrGW42Hufy0tHDAY8vhRxF0lil+QgQRCGPNeaSjR0V",
+	"ULntspe4zL6QQ82N1XnsNtnLxnMjYp722Z7hE4gkN+y1SmD/KX7q9B2b8MwwJa1iYazDnUt2wI7PT0IR",
+	"BuOwcmHjq/keqwAojIHrQEBlZhbh4JYVkLJjRAKR9JIDkmMPiDYbOO7DrGJ8FbJKxgSqALbY4VkkM62m",
+	"wjEH0GzMDTPcCkPYV0KwioAbt+wrT6zu+5d8wiWr0GGHhW5vuQGNjuwDlnFjZkonLFUjIdvMENdiEy75",
+	"CJAWRLIYRJJa1+003IS/LKzNTVazkqNkImRHyXTOQCaZEtKap7iM6kSBDnesugR3X0zOZQztSPLYgaET",
+	"FqdhKmDWZX9HcSYQHO4m6TM8Y7anVQp/xZ/2F1fofmp9+O3D/x8AAP//IcDwkp7QAQA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/api/audit.go
+++ b/internal/api/audit.go
@@ -377,6 +377,9 @@ func scrubSecrets(raw []byte) any {
 		// bodies, but we redact request-side `secret_key` / `access_key`
 		// defensively too because admins POST them on /credentials.
 		"secret_key", "access_key",
+		// ADR-0026: image-registry mirror robot-account token, posted by
+		// admins on POST/PATCH /v1/admin/image-versions/registries/*.
+		"auth_token",
 	} {
 		if _, ok := obj[k]; ok {
 			obj[k] = "[redacted]"

--- a/internal/api/audit_test.go
+++ b/internal/api/audit_test.go
@@ -103,7 +103,7 @@ const redactedValue = "[redacted]"
 
 func TestScrubSecrets(t *testing.T) {
 	t.Parallel()
-	body := []byte(`{"username":"alice","password":"hunter2","new_password":"xyz","keep":"ok"}`)
+	body := []byte(`{"username":"alice","password":"hunter2","new_password":"xyz","auth_token":"robot$pat","keep":"ok"}`)
 	out := scrubSecrets(body)
 	m, ok := out.(map[string]any)
 	if !ok {
@@ -114,6 +114,10 @@ func TestScrubSecrets(t *testing.T) {
 	}
 	if m["new_password"] != redactedValue {
 		t.Errorf("new_password not redacted: %v", m["new_password"])
+	}
+	// ADR-0026: mirror robot-account token posted on image-registry CRUD.
+	if m["auth_token"] != redactedValue {
+		t.Errorf("auth_token not redacted: %v", m["auth_token"])
 	}
 	if m["username"] != "alice" {
 		t.Errorf("username mangled: %v", m["username"])

--- a/internal/api/image_registry_handlers.go
+++ b/internal/api/image_registry_handlers.go
@@ -6,6 +6,17 @@ import (
 	"net/http"
 )
 
+// pathPrefixFromRequest decodes the path_prefix path param, mapping the
+// literal "_root" sentinel to an empty string (the canonical form for
+// non-mirror / unscoped rows). Empty value is treated as "_root" too.
+func pathPrefixFromRequest(r *http.Request) string {
+	p := r.PathValue("path_prefix")
+	if p == "" || p == "_root" {
+		return ""
+	}
+	return p
+}
+
 // HandleListImageRegistries returns all rows from image_versions_registries.
 func HandleListImageRegistries(s Store) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -49,7 +60,6 @@ func HandleCreateImageRegistry(s Store) http.Handler {
 }
 
 // HandleUpdateImageRegistry applies a merge-patch to a registry row.
-// Returns 400 on bad rate, 404 on missing hostname, 200 with the row otherwise.
 func HandleUpdateImageRegistry(s Store) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		host := r.PathValue("hostname")
@@ -57,6 +67,7 @@ func HandleUpdateImageRegistry(s Store) http.Handler {
 			writeProblem(w, http.StatusBadRequest, "Bad Request", "hostname is required")
 			return
 		}
+		prefix := pathPrefixFromRequest(r)
 		var p ImageRegistryPatch
 		if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
 			writeProblem(w, http.StatusBadRequest, "Bad Request", err.Error())
@@ -66,7 +77,7 @@ func HandleUpdateImageRegistry(s Store) http.Handler {
 			writeProblem(w, http.StatusBadRequest, "Bad Request", "rate_limit_per_sec must be > 0")
 			return
 		}
-		out, err := s.UpdateImageRegistry(r.Context(), host, p)
+		out, err := s.UpdateImageRegistry(r.Context(), host, prefix, p)
 		switch {
 		case errors.Is(err, ErrNotFound):
 			writeProblem(w, http.StatusNotFound, "Not Found", "registry not found")
@@ -87,7 +98,8 @@ func HandleDeleteImageRegistry(s Store) http.Handler {
 			writeProblem(w, http.StatusBadRequest, "Bad Request", "hostname is required")
 			return
 		}
-		err := s.DeleteImageRegistry(r.Context(), host)
+		prefix := pathPrefixFromRequest(r)
+		err := s.DeleteImageRegistry(r.Context(), host, prefix)
 		switch {
 		case errors.Is(err, ErrNotFound):
 			writeProblem(w, http.StatusNotFound, "Not Found", "registry not found")
@@ -97,5 +109,44 @@ func HandleDeleteImageRegistry(s Store) http.Handler {
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+// HandleGetImageRegistryCredentials returns the plaintext robot-account
+// credentials for a mirror registry row. Admin-only, audit-logged.
+func HandleGetImageRegistryCredentials(s Store) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		host := r.PathValue("hostname")
+		if host == "" {
+			writeProblem(w, http.StatusBadRequest, "Bad Request", "hostname is required")
+			return
+		}
+		prefix := pathPrefixFromRequest(r)
+		reg, err := s.GetImageRegistry(r.Context(), host, prefix)
+		switch {
+		case errors.Is(err, ErrNotFound):
+			writeProblem(w, http.StatusNotFound, "Not Found", "registry not found")
+			return
+		case err != nil:
+			writeProblem(w, http.StatusInternalServerError, "Internal Server Error", err.Error())
+			return
+		}
+		if !reg.IsMirror {
+			writeProblem(w, http.StatusBadRequest, "Bad Request", "not a mirror registry")
+			return
+		}
+		tok, err := s.GetMirrorAuthToken(r.Context(), host, prefix)
+		if err != nil {
+			writeProblem(w, http.StatusInternalServerError, "Internal Server Error", err.Error())
+			return
+		}
+		user := ""
+		if reg.AuthUsername != nil {
+			user = *reg.AuthUsername
+		}
+		writeJSON(w, http.StatusOK, map[string]string{
+			"auth_username": user,
+			"auth_token":    tok,
+		})
 	})
 }

--- a/internal/api/image_registry_handlers_test.go
+++ b/internal/api/image_registry_handlers_test.go
@@ -135,6 +135,82 @@ func TestHandleDeleteImageRegistry(t *testing.T) {
 	}
 }
 
+func TestHandleGetImageRegistryCredentials_NotMirror(t *testing.T) {
+	s := newMemStore()
+	username := "robot$lv"
+	token := "ignored"
+	if _, err := s.CreateImageRegistry(context.Background(), ImageRegistryUpsert{
+		Hostname:        "registry.example.com",
+		PathPrefix:      "",
+		RateLimitPerSec: 1.0,
+		IsMirror:        false,
+		AuthUsername:    &username,
+		AuthToken:       &token,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	h := HandleGetImageRegistryCredentials(s)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/v1/admin/image-versions/registries/registry.example.com/_root/credentials", http.NoBody)
+	req.SetPathValue("hostname", "registry.example.com")
+	req.SetPathValue("path_prefix", "_root")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status: want 400, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleGetImageRegistryCredentials_Mirror(t *testing.T) {
+	s := newMemStore()
+	username := "robot$lv"
+	token := "s3cret"
+	if _, err := s.CreateImageRegistry(context.Background(), ImageRegistryUpsert{
+		Hostname:        "ma-registry.io",
+		PathPrefix:      "container/",
+		RateLimitPerSec: 2.0,
+		IsMirror:        true,
+		AuthUsername:    &username,
+		AuthToken:       &token,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	h := HandleGetImageRegistryCredentials(s)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/v1/admin/image-versions/registries/ma-registry.io/container%2F/credentials", http.NoBody)
+	req.SetPathValue("hostname", "ma-registry.io")
+	req.SetPathValue("path_prefix", "container/")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["auth_username"] != username {
+		t.Errorf("auth_username=%q want %q", body["auth_username"], username)
+	}
+	if body["auth_token"] == "" {
+		t.Errorf("auth_token unexpectedly empty")
+	}
+}
+
+func TestHandleGetImageRegistryCredentials_NotFound(t *testing.T) {
+	s := newMemStore()
+	h := HandleGetImageRegistryCredentials(s)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/v1/admin/image-versions/registries/missing/_root/credentials", http.NoBody)
+	req.SetPathValue("hostname", "missing")
+	req.SetPathValue("path_prefix", "_root")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status: want 404, got %d", w.Code)
+	}
+}
+
 // seedImageRegistriesForTest inserts the 7 default registries into the
 // memStore for tests that need them.
 func seedImageRegistriesForTest(t *testing.T, s Store) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1681,7 +1681,7 @@ func (s *Server) CreateImageRegistry(ctx context.Context, req CreateImageRegistr
 
 // PatchImageRegistry applies a merge-patch to an existing registry row.
 func (s *Server) PatchImageRegistry(ctx context.Context, req PatchImageRegistryRequestObject) (PatchImageRegistryResponseObject, error) {
-	out, err := s.store.UpdateImageRegistry(ctx, req.Hostname, *req.Body)
+	out, err := s.store.UpdateImageRegistry(ctx, req.Hostname, "", *req.Body)
 	switch {
 	case errors.Is(err, ErrNotFound):
 		return PatchImageRegistry404ApplicationProblemPlusJSONResponse{
@@ -1695,7 +1695,7 @@ func (s *Server) PatchImageRegistry(ctx context.Context, req PatchImageRegistryR
 
 // DeleteImageRegistry removes a registry from the allowlist.
 func (s *Server) DeleteImageRegistry(ctx context.Context, req DeleteImageRegistryRequestObject) (DeleteImageRegistryResponseObject, error) {
-	err := s.store.DeleteImageRegistry(ctx, req.Hostname)
+	err := s.store.DeleteImageRegistry(ctx, req.Hostname, "")
 	switch {
 	case errors.Is(err, ErrNotFound):
 		return DeleteImageRegistry404ApplicationProblemPlusJSONResponse{

--- a/internal/api/server_cloud_fake_test.go
+++ b/internal/api/server_cloud_fake_test.go
@@ -618,6 +618,7 @@ func (m *memStore) ListImageRegistries(_ context.Context) ([]ImageRegistry, erro
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	out := make([]ImageRegistry, 0, len(m.registries))
+	//nolint:gocritic // memStore stub; copies are required because the map value is the canonical row
 	for _, r := range m.registries {
 		out = append(out, r)
 	}
@@ -639,6 +640,7 @@ func (m *memStore) FindMirrorForRef(_ context.Context, hostname, imagePath strin
 	defer m.mu.Unlock()
 	var best ImageRegistry
 	bestLen := -1
+	//nolint:gocritic // memStore stub; per-row copy is unavoidable for the map iteration
 	for k, r := range m.registries {
 		if k[0] != hostname || !r.IsMirror || !r.Enabled {
 			continue
@@ -672,6 +674,7 @@ func (m *memStore) GetMirrorAuthToken(_ context.Context, hostname, pathPrefix st
 	return "memstore-token", nil
 }
 
+//nolint:gocritic // memStore stub; in matches the api.Store interface signature (hugeParam expected)
 func (m *memStore) CreateImageRegistry(_ context.Context, in ImageRegistryUpsert) (ImageRegistry, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/api/server_cloud_fake_test.go
+++ b/internal/api/server_cloud_fake_test.go
@@ -624,7 +624,7 @@ func (m *memStore) ListImageRegistries(_ context.Context) ([]ImageRegistry, erro
 	return out, nil
 }
 
-func (m *memStore) GetImageRegistry(_ context.Context, hostname string) (ImageRegistry, error) {
+func (m *memStore) GetImageRegistry(_ context.Context, hostname, _ string) (ImageRegistry, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	r, ok := m.registries[hostname]
@@ -632,6 +632,14 @@ func (m *memStore) GetImageRegistry(_ context.Context, hostname string) (ImageRe
 		return ImageRegistry{}, ErrNotFound
 	}
 	return r, nil
+}
+
+func (m *memStore) FindMirrorForRef(_ context.Context, _, _ string) (ImageRegistry, error) {
+	return ImageRegistry{}, ErrNotFound
+}
+
+func (m *memStore) GetMirrorAuthToken(_ context.Context, _, _ string) (string, error) {
+	return "", nil
 }
 
 func (m *memStore) CreateImageRegistry(_ context.Context, in ImageRegistryUpsert) (ImageRegistry, error) {
@@ -657,7 +665,7 @@ func (m *memStore) CreateImageRegistry(_ context.Context, in ImageRegistryUpsert
 	return r, nil
 }
 
-func (m *memStore) UpdateImageRegistry(_ context.Context, hostname string, p ImageRegistryPatch) (ImageRegistry, error) {
+func (m *memStore) UpdateImageRegistry(_ context.Context, hostname, _ string, p ImageRegistryPatch) (ImageRegistry, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	r, ok := m.registries[hostname]
@@ -678,7 +686,7 @@ func (m *memStore) UpdateImageRegistry(_ context.Context, hostname string, p Ima
 	return r, nil
 }
 
-func (m *memStore) DeleteImageRegistry(_ context.Context, hostname string) error {
+func (m *memStore) DeleteImageRegistry(_ context.Context, hostname, _ string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.registries[hostname]; !ok {

--- a/internal/api/server_cloud_fake_test.go
+++ b/internal/api/server_cloud_fake_test.go
@@ -624,28 +624,59 @@ func (m *memStore) ListImageRegistries(_ context.Context) ([]ImageRegistry, erro
 	return out, nil
 }
 
-func (m *memStore) GetImageRegistry(_ context.Context, hostname, _ string) (ImageRegistry, error) {
+func (m *memStore) GetImageRegistry(_ context.Context, hostname, pathPrefix string) (ImageRegistry, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	r, ok := m.registries[hostname]
+	r, ok := m.registries[[2]string{hostname, pathPrefix}]
 	if !ok {
 		return ImageRegistry{}, ErrNotFound
 	}
 	return r, nil
 }
 
-func (m *memStore) FindMirrorForRef(_ context.Context, _, _ string) (ImageRegistry, error) {
-	return ImageRegistry{}, ErrNotFound
+func (m *memStore) FindMirrorForRef(_ context.Context, hostname, imagePath string) (ImageRegistry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var best ImageRegistry
+	bestLen := -1
+	for k, r := range m.registries {
+		if k[0] != hostname || !r.IsMirror || !r.Enabled {
+			continue
+		}
+		if !strings.HasPrefix(imagePath, r.PathPrefix) {
+			continue
+		}
+		if len(r.PathPrefix) > bestLen {
+			best = r
+			bestLen = len(r.PathPrefix)
+		}
+	}
+	if bestLen < 0 {
+		return ImageRegistry{}, ErrNotFound
+	}
+	return best, nil
 }
 
-func (m *memStore) GetMirrorAuthToken(_ context.Context, _, _ string) (string, error) {
-	return "", nil
+func (m *memStore) GetMirrorAuthToken(_ context.Context, hostname, pathPrefix string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r, ok := m.registries[[2]string{hostname, pathPrefix}]
+	if !ok {
+		return "", ErrNotFound
+	}
+	// The memStore does not encrypt; emulate the real store by returning
+	// the username-derived stand-in only when AuthConfigured is set.
+	if !r.AuthConfigured {
+		return "", nil
+	}
+	return "memstore-token", nil
 }
 
 func (m *memStore) CreateImageRegistry(_ context.Context, in ImageRegistryUpsert) (ImageRegistry, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if _, exists := m.registries[in.Hostname]; exists {
+	key := [2]string{in.Hostname, in.PathPrefix}
+	if _, exists := m.registries[key]; exists {
 		return ImageRegistry{}, ErrConflict
 	}
 	enabled := true
@@ -655,20 +686,25 @@ func (m *memStore) CreateImageRegistry(_ context.Context, in ImageRegistryUpsert
 	now := time.Now().UTC()
 	r := ImageRegistry{
 		Hostname:        in.Hostname,
+		PathPrefix:      in.PathPrefix,
 		RateLimitPerSec: in.RateLimitPerSec,
 		Enabled:         enabled,
 		Notes:           in.Notes,
+		IsMirror:        in.IsMirror,
+		AuthUsername:    in.AuthUsername,
+		AuthConfigured:  in.AuthToken != nil && *in.AuthToken != "",
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}
-	m.registries[in.Hostname] = r
+	m.registries[key] = r
 	return r, nil
 }
 
-func (m *memStore) UpdateImageRegistry(_ context.Context, hostname, _ string, p ImageRegistryPatch) (ImageRegistry, error) {
+func (m *memStore) UpdateImageRegistry(_ context.Context, hostname, pathPrefix string, p ImageRegistryPatch) (ImageRegistry, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	r, ok := m.registries[hostname]
+	key := [2]string{hostname, pathPrefix}
+	r, ok := m.registries[key]
 	if !ok {
 		return ImageRegistry{}, ErrNotFound
 	}
@@ -681,18 +717,28 @@ func (m *memStore) UpdateImageRegistry(_ context.Context, hostname, _ string, p 
 	if p.Notes != nil {
 		r.Notes = p.Notes
 	}
+	if p.IsMirror != nil {
+		r.IsMirror = *p.IsMirror
+	}
+	if p.AuthUsername != nil {
+		r.AuthUsername = p.AuthUsername
+	}
+	if p.AuthToken != nil {
+		r.AuthConfigured = *p.AuthToken != ""
+	}
 	r.UpdatedAt = time.Now().UTC()
-	m.registries[hostname] = r
+	m.registries[key] = r
 	return r, nil
 }
 
-func (m *memStore) DeleteImageRegistry(_ context.Context, hostname, _ string) error {
+func (m *memStore) DeleteImageRegistry(_ context.Context, hostname, pathPrefix string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if _, ok := m.registries[hostname]; !ok {
+	key := [2]string{hostname, pathPrefix}
+	if _, ok := m.registries[key]; !ok {
 		return ErrNotFound
 	}
-	delete(m.registries, hostname)
+	delete(m.registries, key)
 	return nil
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -62,7 +62,7 @@ type memStore struct {
 	pingErr           error
 	createdN          int
 	settings          Settings                      // overridable for handler tests
-	registries        map[string]ImageRegistry      // keyed by hostname; image_versions_registries
+	registries        map[[2]string]ImageRegistry   // keyed by [hostname, path_prefix]; image_versions_registries
 	imageVersions     map[[2]string]ImageVersionRow // keyed by [imageRepo, variant]
 }
 
@@ -87,7 +87,7 @@ func newMemStore() *memStore {
 		pvcsByID:          make(map[uuid.UUID]PersistentVolumeClaim),
 		pvcsByNatKey:      make(map[string]uuid.UUID),
 		authState:         newMemAuthState(),
-		registries:        make(map[string]ImageRegistry),
+		registries:        make(map[[2]string]ImageRegistry),
 		imageVersions:     make(map[[2]string]ImageVersionRow),
 	}
 }

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -655,10 +655,12 @@ type Store interface {
 
 	// Image registries
 	ListImageRegistries(ctx context.Context) ([]ImageRegistry, error)
-	GetImageRegistry(ctx context.Context, hostname string) (ImageRegistry, error)
+	GetImageRegistry(ctx context.Context, hostname, pathPrefix string) (ImageRegistry, error)
 	CreateImageRegistry(ctx context.Context, in ImageRegistryUpsert) (ImageRegistry, error)
-	UpdateImageRegistry(ctx context.Context, hostname string, p ImageRegistryPatch) (ImageRegistry, error)
-	DeleteImageRegistry(ctx context.Context, hostname string) error
+	UpdateImageRegistry(ctx context.Context, hostname, pathPrefix string, p ImageRegistryPatch) (ImageRegistry, error)
+	DeleteImageRegistry(ctx context.Context, hostname, pathPrefix string) error
+	FindMirrorForRef(ctx context.Context, hostname, imagePath string) (ImageRegistry, error)
+	GetMirrorAuthToken(ctx context.Context, hostname, pathPrefix string) (string, error)
 
 	// Image versions
 	UpsertImageVersion(ctx context.Context, in ImageVersionUpsert) (ImageVersionRow, error)

--- a/internal/api/swagger/openapi.yaml
+++ b/internal/api/swagger/openapi.yaml
@@ -4828,7 +4828,7 @@ components:
 
     ImageRegistryUpsert:
       type: object
-      required: [hostname, rate_limit_per_sec]
+      required: [hostname, path_prefix, rate_limit_per_sec, is_mirror]
       properties:
         hostname:
           type: string

--- a/internal/api/swagger/openapi.yaml
+++ b/internal/api/swagger/openapi.yaml
@@ -2310,6 +2310,45 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /v1/admin/image-versions/registries/{hostname}/{path_prefix}/credentials:
+    get:
+      summary: Reveal plaintext robot-account credentials for a mirror registry
+      description: |
+        Returns the decrypted auth_username and auth_token for the mirror row
+        identified by (hostname, path_prefix). Mark `path_prefix` as `_root`
+        when the row has no prefix. Admin-only and audit-logged.
+      tags: [admin, image-versions]
+      operationId: getImageRegistryCredentials
+      x-audit: extract
+      security:
+        - BearerAuth: [admin]
+        - SessionCookie: [admin]
+      parameters:
+        - name: hostname
+          in: path
+          required: true
+          schema: { type: string }
+        - name: path_prefix
+          in: path
+          required: true
+          schema: { type: string }
+          description: "URL-encoded path_prefix; use the literal '_root' for empty"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImageRegistryCredentials'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /v1/eol/extract:
     get:
       tags: [eol]
@@ -4754,11 +4793,14 @@ components:
 
     ImageRegistry:
       type: object
-      required: [hostname, rate_limit_per_sec, enabled, created_at, updated_at]
+      required: [hostname, path_prefix, rate_limit_per_sec, enabled, is_mirror, auth_configured, created_at, updated_at]
       properties:
         hostname:
           type: string
           description: "Exact hostname or '*<suffix>' wildcard"
+        path_prefix:
+          type: string
+          description: "Repo-path prefix (empty for non-mirror rows)"
         rate_limit_per_sec:
           type: number
           format: float
@@ -4768,6 +4810,15 @@ components:
         notes:
           type: string
           nullable: true
+        is_mirror:
+          type: boolean
+          description: "True if this row is a Harbor-style mirror needing resolution"
+        auth_username:
+          type: string
+          nullable: true
+        auth_configured:
+          type: boolean
+          description: "True iff an encrypted auth token is stored (token itself is never returned)"
         created_at:
           type: string
           format: date-time
@@ -4781,6 +4832,8 @@ components:
       properties:
         hostname:
           type: string
+        path_prefix:
+          type: string
         rate_limit_per_sec:
           type: number
           format: float
@@ -4789,6 +4842,14 @@ components:
           type: boolean
         notes:
           type: string
+        is_mirror:
+          type: boolean
+        auth_username:
+          type: string
+        auth_token:
+          type: string
+          writeOnly: true
+          description: "Robot-account token; never echoed in responses"
 
     ImageRegistryPatch:
       type: object
@@ -4802,6 +4863,24 @@ components:
         notes:
           type: string
           nullable: true
+        is_mirror:
+          type: boolean
+        auth_username:
+          type: string
+          nullable: true
+        auth_token:
+          type: string
+          writeOnly: true
+          description: "Empty string clears the stored token; omit to leave unchanged"
+
+    ImageRegistryCredentials:
+      type: object
+      required: [auth_username, auth_token]
+      properties:
+        auth_username:
+          type: string
+        auth_token:
+          type: string
 
     ImageVersionVariant:
       type: object

--- a/internal/imageversions/enricher.go
+++ b/internal/imageversions/enricher.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/sthalbert/longue-vue/internal/api"
+	"github.com/sthalbert/longue-vue/internal/imageversions/mirrorresolve"
 	"github.com/sthalbert/longue-vue/internal/imageversions/registry"
 )
 
@@ -23,6 +24,7 @@ const sourceRegistry = "registry"
 type Enricher struct {
 	store    Store
 	lister   TagsLister
+	resolver mirrorresolve.Resolver
 	interval time.Duration
 	metrics  *Metrics
 
@@ -49,6 +51,19 @@ func NewEnricherWithMetrics(s Store, lister TagsLister, interval time.Duration, 
 	return &Enricher{
 		store:     s,
 		lister:    lister,
+		interval:  interval,
+		metrics:   m,
+		triggerCh: make(chan struct{}, 1),
+	}
+}
+
+// NewEnricherWithResolver constructs an Enricher with a mirror resolver and
+// optional metrics. The resolver may be nil (passthrough).
+func NewEnricherWithResolver(s Store, lister TagsLister, resolver mirrorresolve.Resolver, interval time.Duration, m *Metrics) *Enricher {
+	return &Enricher{
+		store:     s,
+		lister:    lister,
+		resolver:  resolver,
 		interval:  interval,
 		metrics:   m,
 		triggerCh: make(chan struct{}, 1),
@@ -123,7 +138,7 @@ func (e *Enricher) RunTick(ctx context.Context) {
 		slog.Warn("imageversions: distinct refs failed", slog.String("err", err.Error()))
 		return
 	}
-	discovered, repoRegistry := discoverWork(refs, enabledRegs)
+	discovered, repoRegistry := e.discoverWork(ctx, refs, enabledRegs)
 
 	processed := e.dispatchWorkers(ctx, discovered, repoRegistry, enabledRegs)
 
@@ -185,14 +200,31 @@ func (e *Enricher) loadEnabledRegistries(ctx context.Context) ([]api.ImageRegist
 // discoverWork parses raw image refs, matches each against the allowlist,
 // and groups them by (image_repo, variant). Returns the per-repo variant set
 // and the per-repo matched registry hostname.
-func discoverWork(refs []string, enabledRegs []api.ImageRegistry) (
+func (e *Enricher) discoverWork(ctx context.Context, refs []string, enabledRegs []api.ImageRegistry) (
 	discovered map[string]map[string]struct{},
 	repoRegistry map[string]string,
 ) {
 	discovered = map[string]map[string]struct{}{}
 	repoRegistry = map[string]string{}
 	for _, raw := range refs {
-		ref, err := ParseImageRef(raw)
+		resolved := raw
+		if e.resolver != nil {
+			r, err := e.resolver.Resolve(ctx, raw)
+			switch {
+			case errors.Is(err, mirrorresolve.ErrNoOriginAnnotation),
+				errors.Is(err, mirrorresolve.ErrAmbiguousAnnotation):
+				slog.Debug("imageversions: skip mirror ref",
+					slog.String("ref", raw), slog.String("reason", err.Error()))
+				continue
+			case err != nil:
+				slog.Warn("imageversions: mirror resolve error",
+					slog.String("ref", raw), slog.String("err", err.Error()))
+				continue
+			default:
+				resolved = r
+			}
+		}
+		ref, err := ParseImageRef(resolved)
 		if err != nil {
 			slog.Debug("imageversions: skip ref", slog.String("ref", raw), slog.String("reason", err.Error()))
 			continue

--- a/internal/imageversions/enricher.go
+++ b/internal/imageversions/enricher.go
@@ -181,7 +181,9 @@ func (e *Enricher) loadEnabledRegistries(ctx context.Context) ([]api.ImageRegist
 	}
 	enabled := make([]api.ImageRegistry, 0, len(regs))
 	for _, r := range regs {
-		if r.Enabled {
+		// Mirror rows participate only in the resolver path (ADR-0026);
+		// they must not appear in the public-registry allowlist iteration.
+		if r.Enabled && !r.IsMirror {
 			enabled = append(enabled, r)
 		}
 	}

--- a/internal/imageversions/enricher.go
+++ b/internal/imageversions/enricher.go
@@ -207,36 +207,16 @@ func (e *Enricher) discoverWork(ctx context.Context, refs []string, enabledRegs 
 	discovered = map[string]map[string]struct{}{}
 	repoRegistry = map[string]string{}
 	for _, raw := range refs {
-		resolved := raw
-		if e.resolver != nil {
-			r, err := e.resolver.Resolve(ctx, raw)
-			switch {
-			case errors.Is(err, mirrorresolve.ErrNoOriginAnnotation),
-				errors.Is(err, mirrorresolve.ErrAmbiguousAnnotation):
-				slog.Debug("imageversions: skip mirror ref",
-					slog.String("ref", raw), slog.String("reason", err.Error()))
-				continue
-			case err != nil:
-				slog.Warn("imageversions: mirror resolve error",
-					slog.String("ref", raw), slog.String("err", err.Error()))
-				continue
-			default:
-				resolved = r
-			}
+		resolved, skip := e.resolveMirrorRef(ctx, raw)
+		if skip {
+			continue
 		}
 		ref, err := ParseImageRef(resolved)
 		if err != nil {
 			slog.Debug("imageversions: skip ref", slog.String("ref", raw), slog.String("reason", err.Error()))
 			continue
 		}
-		matched := false
-		for i := range enabledRegs {
-			if registry.Match(enabledRegs[i].Hostname, ref.Registry) {
-				matched = true
-				break
-			}
-		}
-		if !matched {
+		if !matchAnyRegistry(enabledRegs, ref.Registry) {
 			slog.Debug("imageversions: registry not allowlisted",
 				slog.String("registry", ref.Registry), slog.String("ref", raw))
 			continue
@@ -253,6 +233,40 @@ func (e *Enricher) discoverWork(ctx context.Context, refs []string, enabledRegs 
 		repoRegistry[ref.ImageRepo] = ref.Registry
 	}
 	return discovered, repoRegistry
+}
+
+// resolveMirrorRef runs the mirror resolver if configured. Returns the
+// resolved ref and skip=true when the caller must drop this ref (no mirror
+// configured returns raw, skip=false).
+func (e *Enricher) resolveMirrorRef(ctx context.Context, raw string) (string, bool) {
+	if e.resolver == nil {
+		return raw, false
+	}
+	r, err := e.resolver.Resolve(ctx, raw)
+	switch {
+	case errors.Is(err, mirrorresolve.ErrNoOriginAnnotation),
+		errors.Is(err, mirrorresolve.ErrAmbiguousAnnotation):
+		slog.Debug("imageversions: skip mirror ref",
+			slog.String("ref", raw), slog.String("reason", err.Error()))
+		return "", true
+	case err != nil:
+		slog.Warn("imageversions: mirror resolve error",
+			slog.String("ref", raw), slog.String("err", err.Error()))
+		return "", true
+	default:
+		return r, false
+	}
+}
+
+// matchAnyRegistry reports whether the candidate registry matches any
+// enabled allowlist entry.
+func matchAnyRegistry(enabledRegs []api.ImageRegistry, candidate string) bool {
+	for i := range enabledRegs {
+		if registry.Match(enabledRegs[i].Hostname, candidate) {
+			return true
+		}
+	}
+	return false
 }
 
 // dispatchWorkers fans out one goroutine per image_repo (bounded to 5

--- a/internal/imageversions/enricher.go
+++ b/internal/imageversions/enricher.go
@@ -180,11 +180,12 @@ func (e *Enricher) loadEnabledRegistries(ctx context.Context) ([]api.ImageRegist
 		return nil, false
 	}
 	enabled := make([]api.ImageRegistry, 0, len(regs))
-	for _, r := range regs {
+	for i := range regs {
+		r := &regs[i]
 		// Mirror rows participate only in the resolver path (ADR-0026);
 		// they must not appear in the public-registry allowlist iteration.
 		if r.Enabled && !r.IsMirror {
-			enabled = append(enabled, r)
+			enabled = append(enabled, *r)
 		}
 	}
 	if e.metrics != nil {
@@ -281,7 +282,8 @@ func (e *Enricher) dispatchWorkers(
 	enabledRegs []api.ImageRegistry,
 ) [][2]string {
 	limiters := map[string]*rate.Limiter{}
-	for _, r := range enabledRegs {
+	for i := range enabledRegs {
+		r := &enabledRegs[i]
 		limiters[r.Hostname] = rate.NewLimiter(rate.Limit(r.RateLimitPerSec), 1)
 	}
 	pickLimiter := func(reg string) *rate.Limiter {

--- a/internal/imageversions/enricher_test.go
+++ b/internal/imageversions/enricher_test.go
@@ -9,7 +9,10 @@ import (
 	"time"
 
 	"github.com/sthalbert/longue-vue/internal/api"
+	"github.com/sthalbert/longue-vue/internal/imageversions/mirrorresolve"
 )
+
+func mirrorresolveErrNoOriginAnnotation() error { return mirrorresolve.ErrNoOriginAnnotation }
 
 type fakeStore struct {
 	mu         sync.Mutex
@@ -53,6 +56,14 @@ func (s *fakeStore) DeleteImageVersionsNotIn(_ context.Context, keep [][2]string
 	defer s.mu.Unlock()
 	s.reaped = append(s.reaped, keep)
 	return 0, nil
+}
+
+func (s *fakeStore) FindMirrorForRef(_ context.Context, _, _ string) (api.ImageRegistry, error) {
+	return api.ImageRegistry{}, api.ErrNotFound
+}
+
+func (s *fakeStore) GetMirrorAuthToken(_ context.Context, _, _ string) (string, error) {
+	return "", nil
 }
 
 type fakeLister struct {
@@ -184,5 +195,65 @@ func TestEnricher_AnnotationShape(t *testing.T) {
 	}
 	if m["latest_available"] != testLatest {
 		t.Errorf("expected latest_available, got %v", m)
+	}
+}
+
+// fakeResolver covers the mirror-resolver injection path.
+type fakeResolver struct {
+	rewrite map[string]string
+	skip    map[string]error
+}
+
+func (f fakeResolver) Resolve(_ context.Context, ref string) (string, error) {
+	if err, ok := f.skip[ref]; ok {
+		return "", err
+	}
+	if v, ok := f.rewrite[ref]; ok {
+		return v, nil
+	}
+	return ref, nil
+}
+
+func TestEnricher_MirrorResolver_RewritesRef(t *testing.T) {
+	s := &fakeStore{
+		settings: api.Settings{ImageVersionsEnabled: true},
+		registries: []api.ImageRegistry{
+			{Hostname: "docker.io", Enabled: true, RateLimitPerSec: 5},
+		},
+		refs: []string{"ma-registry.io/container/library/nginx:1.25"},
+	}
+	lister := &fakeLister{byRepo: map[string][]string{
+		"library/nginx": {"1.25", "1.26"},
+	}}
+	resolver := fakeResolver{rewrite: map[string]string{
+		"ma-registry.io/container/library/nginx:1.25": "docker.io/library/nginx:1.25",
+	}}
+	e := NewEnricherWithResolver(s, lister, resolver, time.Hour, nil)
+	e.RunTick(context.Background())
+
+	if len(s.upserted) != 1 {
+		t.Fatalf("expected 1 upsert, got %d", len(s.upserted))
+	}
+	if s.upserted[0].Registry != "docker.io" {
+		t.Fatalf("expected resolved registry docker.io, got %q", s.upserted[0].Registry)
+	}
+}
+
+func TestEnricher_MirrorResolver_SkipsUnresolved(t *testing.T) {
+	s := &fakeStore{
+		settings: api.Settings{ImageVersionsEnabled: true},
+		registries: []api.ImageRegistry{
+			{Hostname: "docker.io", Enabled: true, RateLimitPerSec: 5},
+		},
+		refs: []string{"ma-registry.io/container/library/nginx:1.25"},
+	}
+	resolver := fakeResolver{skip: map[string]error{
+		"ma-registry.io/container/library/nginx:1.25": mirrorresolveErrNoOriginAnnotation(),
+	}}
+	e := NewEnricherWithResolver(s, &fakeLister{}, resolver, time.Hour, nil)
+	e.RunTick(context.Background())
+
+	if len(s.upserted) != 0 {
+		t.Fatalf("expected zero upserts when resolver skips, got %d", len(s.upserted))
 	}
 }

--- a/internal/imageversions/integration_test.go
+++ b/internal/imageversions/integration_test.go
@@ -3,25 +3,121 @@
 package imageversions_test
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/sthalbert/longue-vue/internal/api"
+	"github.com/sthalbert/longue-vue/internal/imageversions"
+	"github.com/sthalbert/longue-vue/internal/imageversions/mirrorresolve"
 )
 
-// TestEnricher_Integration_FullCycle is a placeholder for a hermetic
-// full-cycle integration test against a real Postgres instance and a
-// fake registry server. The full integration is non-trivial because the
-// OCI client constructs URLs via registry.EffectiveHost from a fixed
-// hostname → URL mapping (Docker Hub maps to registry-1.docker.io). To
-// make a hermetic test, EffectiveHost would need to be parametrizable,
-// or the workload's image string would need a host that DNS-resolves
-// to the test server.
-//
-// For V1, this gap is acceptable: the unit tests in enricher_test.go
-// cover the loop's branching and concurrency; the live smoke tests in
-// internal/imageversions/registry/live_test.go (Task 23) cover the
-// real-registry path. Promote this scaffold to a proper test in V2 if
-// the gap proves insufficient.
-func TestEnricher_Integration_FullCycle(t *testing.T) {
-	t.Skip("Hermetic full-cycle integration test is deferred. " +
-		"Unit tests in enricher_test.go cover loop logic; live smoke in " +
-		"registry/live_test.go (Task 23) covers real-registry behavior.")
+// mirrorIntegrationStore is an in-memory Store wired only with the methods
+// the enricher needs for this test.
+type mirrorIntegrationStore struct {
+	mu       sync.Mutex
+	settings api.Settings
+	regs     []api.ImageRegistry
+	refs     []string
+	mirror   api.ImageRegistry
+	upserted []api.ImageVersionUpsert
+}
+
+func (s *mirrorIntegrationStore) GetSettings(_ context.Context) (api.Settings, error) {
+	return s.settings, nil
+}
+func (s *mirrorIntegrationStore) ListImageRegistries(_ context.Context) ([]api.ImageRegistry, error) {
+	return s.regs, nil
+}
+func (s *mirrorIntegrationStore) DistinctImageRefs(_ context.Context) ([]string, error) {
+	return s.refs, nil
+}
+
+//nolint:gocritic
+func (s *mirrorIntegrationStore) UpsertImageVersion(_ context.Context, in api.ImageVersionUpsert) (api.ImageVersionRow, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.upserted = append(s.upserted, in)
+	return api.ImageVersionRow{ImageRepo: in.ImageRepo, Variant: in.Variant}, nil
+}
+func (s *mirrorIntegrationStore) DeleteImageVersionsNotIn(_ context.Context, _ [][2]string) (int64, error) {
+	return 0, nil
+}
+func (s *mirrorIntegrationStore) FindMirrorForRef(_ context.Context, hostname, _ string) (api.ImageRegistry, error) {
+	if hostname == s.mirror.Hostname {
+		return s.mirror, nil
+	}
+	return api.ImageRegistry{}, api.ErrNotFound
+}
+func (s *mirrorIntegrationStore) GetMirrorAuthToken(_ context.Context, _, _ string) (string, error) {
+	return "", nil
+}
+
+// stubLister satisfies imageversions.TagsLister.
+type stubLister struct {
+	tags map[string][]string
+}
+
+func (l *stubLister) ListTags(_ context.Context, _, repoPath string) ([]string, error) {
+	return l.tags[repoPath], nil
+}
+
+// TestImageVersions_Integration verifies that a mirror ref is resolved to
+// its public origin via the OCI annotation path, then enriched against the
+// expected origin registry.
+func TestImageVersions_Integration(t *testing.T) {
+	mirror := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"schemaVersion": 2,
+			"mediaType":     "application/vnd.oci.image.manifest.v1+json",
+			"annotations": map[string]string{
+				"org.opencontainers.image.base.name": "docker.io/library/nginx:1.25",
+			},
+		})
+	}))
+	defer mirror.Close()
+	u, _ := url.Parse(mirror.URL)
+
+	store := &mirrorIntegrationStore{
+		settings: api.Settings{ImageVersionsEnabled: true},
+		regs: []api.ImageRegistry{
+			{Hostname: "docker.io", Enabled: true, RateLimitPerSec: 5},
+		},
+		refs: []string{u.Host + "/container/library/nginx:1.25"},
+		mirror: api.ImageRegistry{
+			Hostname:   u.Host,
+			PathPrefix: "container/",
+			IsMirror:   true,
+			Enabled:    true,
+		},
+	}
+
+	lister := &stubLister{tags: map[string][]string{
+		"library/nginx": {"1.25", "1.26"},
+	}}
+
+	resolver := &mirrorresolve.HTTPResolver{
+		Lookup: imageversions.NewStoreMirrorLookup(store),
+		Client: mirror.Client(),
+		Scheme: "http",
+	}
+	enricher := imageversions.NewEnricherWithResolver(store, lister, resolver, time.Hour, nil)
+	enricher.RunTick(context.Background())
+
+	if len(store.upserted) != 1 {
+		t.Fatalf("expected 1 upsert, got %d", len(store.upserted))
+	}
+	got := store.upserted[0]
+	if got.ImageRepo != "docker.io/library/nginx" {
+		t.Fatalf("image_repo=%q want docker.io/library/nginx", got.ImageRepo)
+	}
+	if got.LatestTag == nil || *got.LatestTag != "1.26" {
+		t.Fatalf("latest_tag=%v want 1.26", got.LatestTag)
+	}
 }

--- a/internal/imageversions/integration_test.go
+++ b/internal/imageversions/integration_test.go
@@ -31,9 +31,11 @@ type mirrorIntegrationStore struct {
 func (s *mirrorIntegrationStore) GetSettings(_ context.Context) (api.Settings, error) {
 	return s.settings, nil
 }
+
 func (s *mirrorIntegrationStore) ListImageRegistries(_ context.Context) ([]api.ImageRegistry, error) {
 	return s.regs, nil
 }
+
 func (s *mirrorIntegrationStore) DistinctImageRefs(_ context.Context) ([]string, error) {
 	return s.refs, nil
 }
@@ -45,15 +47,18 @@ func (s *mirrorIntegrationStore) UpsertImageVersion(_ context.Context, in api.Im
 	s.upserted = append(s.upserted, in)
 	return api.ImageVersionRow{ImageRepo: in.ImageRepo, Variant: in.Variant}, nil
 }
+
 func (s *mirrorIntegrationStore) DeleteImageVersionsNotIn(_ context.Context, _ [][2]string) (int64, error) {
 	return 0, nil
 }
+
 func (s *mirrorIntegrationStore) FindMirrorForRef(_ context.Context, hostname, _ string) (api.ImageRegistry, error) {
 	if hostname == s.mirror.Hostname {
 		return s.mirror, nil
 	}
 	return api.ImageRegistry{}, api.ErrNotFound
 }
+
 func (s *mirrorIntegrationStore) GetMirrorAuthToken(_ context.Context, _, _ string) (string, error) {
 	return "", nil
 }

--- a/internal/imageversions/metrics.go
+++ b/internal/imageversions/metrics.go
@@ -1,6 +1,12 @@
 package imageversions
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sthalbert/longue-vue/internal/imageversions/mirrorresolve"
+)
 
 // Metrics bundles the Prometheus collectors for the image versions enricher.
 // Constructed once at startup and passed into the enricher and the registry client.
@@ -13,6 +19,8 @@ type Metrics struct {
 	WithErrorTotal         prometheus.Gauge
 	LastTickTimestamp      prometheus.Gauge
 	RegistriesEnabledTotal prometheus.Gauge
+	MirrorResolveTotal     *prometheus.CounterVec
+	MirrorResolveDuration  prometheus.Histogram
 }
 
 // NewMetrics constructs and registers the metric collectors.
@@ -53,13 +61,41 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		RegistriesEnabledTotal: prometheus.NewGauge(
 			prometheus.GaugeOpts{Name: "imageversions_registries_enabled", Help: "Count of enabled rows in image_versions_registries."},
 		),
+		MirrorResolveTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{Name: "imageversions_mirror_resolve_total", Help: "Mirror-resolve attempts by result."},
+			[]string{"result"},
+		),
+		MirrorResolveDuration: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name:    "imageversions_mirror_resolve_duration_seconds",
+				Help:    "Mirror-resolve wall time in seconds.",
+				Buckets: prometheus.DefBuckets,
+			},
+		),
 	}
 	reg.MustRegister(
 		m.TickTotal, m.TickDuration, m.QueryTotal, m.QueryDuration,
 		m.KnownTotal, m.WithErrorTotal, m.LastTickTimestamp, m.RegistriesEnabledTotal,
+		m.MirrorResolveTotal, m.MirrorResolveDuration,
 	)
 	return m
 }
+
+// observerAdapter bridges mirrorresolve.Observer to *Metrics.
+type observerAdapter struct{ m *Metrics }
+
+// ObserveResolve implements mirrorresolve.Observer.
+func (o observerAdapter) ObserveResolve(result string, d time.Duration) {
+	if o.m == nil {
+		return
+	}
+	o.m.MirrorResolveTotal.WithLabelValues(result).Inc()
+	o.m.MirrorResolveDuration.Observe(d.Seconds())
+}
+
+// NewObserver returns a mirrorresolve.Observer that records into m. Safe
+// with a nil *Metrics (the resulting Observer is a no-op).
+func NewObserver(m *Metrics) mirrorresolve.Observer { return observerAdapter{m: m} }
 
 // ObserveQuery is the implementation of the registry.QueryObserver interface.
 func (m *Metrics) ObserveQuery(registryHost, status string, durationSeconds float64) {

--- a/internal/imageversions/mirror_lookup.go
+++ b/internal/imageversions/mirror_lookup.go
@@ -3,6 +3,7 @@ package imageversions
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/sthalbert/longue-vue/internal/api"
 	"github.com/sthalbert/longue-vue/internal/imageversions/mirrorresolve"
@@ -22,7 +23,7 @@ func (l storeLookup) FindMirror(ctx context.Context, hostname, imagePath string)
 		return mirrorresolve.MirrorRow{}, false, nil
 	}
 	if err != nil {
-		return mirrorresolve.MirrorRow{}, false, err
+		return mirrorresolve.MirrorRow{}, false, fmt.Errorf("find mirror: %w", err)
 	}
 	user := ""
 	if row.AuthUsername != nil {

--- a/internal/imageversions/mirror_lookup.go
+++ b/internal/imageversions/mirror_lookup.go
@@ -1,0 +1,39 @@
+package imageversions
+
+import (
+	"context"
+	"errors"
+
+	"github.com/sthalbert/longue-vue/internal/api"
+	"github.com/sthalbert/longue-vue/internal/imageversions/mirrorresolve"
+)
+
+// storeLookup adapts a Store into a mirrorresolve.MirrorLookup.
+type storeLookup struct{ s Store }
+
+// NewStoreMirrorLookup returns a MirrorLookup backed by the given Store.
+func NewStoreMirrorLookup(s Store) mirrorresolve.MirrorLookup { return storeLookup{s: s} }
+
+// FindMirror implements mirrorresolve.MirrorLookup. Returns (zero, false, nil)
+// when no mirror row applies (api.ErrNotFound from the store).
+func (l storeLookup) FindMirror(ctx context.Context, hostname, imagePath string) (mirrorresolve.MirrorRow, bool, error) {
+	row, err := l.s.FindMirrorForRef(ctx, hostname, imagePath)
+	if errors.Is(err, api.ErrNotFound) {
+		return mirrorresolve.MirrorRow{}, false, nil
+	}
+	if err != nil {
+		return mirrorresolve.MirrorRow{}, false, err
+	}
+	user := ""
+	if row.AuthUsername != nil {
+		user = *row.AuthUsername
+	}
+	return mirrorresolve.MirrorRow{
+		Hostname:     row.Hostname,
+		PathPrefix:   row.PathPrefix,
+		AuthUsername: user,
+		TokenSource: func(ctx context.Context) (string, error) {
+			return l.s.GetMirrorAuthToken(ctx, row.Hostname, row.PathPrefix)
+		},
+	}, true, nil
+}

--- a/internal/imageversions/mirrorresolve/doc.go
+++ b/internal/imageversions/mirrorresolve/doc.go
@@ -1,0 +1,5 @@
+// Package mirrorresolve resolves mirrored container image references
+// (Harbor with replication) back to their public origin by reading OCI
+// manifest annotations preserved during replication. Used by the
+// image-versions enricher (see ADR-0022, ADR-0026).
+package mirrorresolve

--- a/internal/imageversions/mirrorresolve/resolver.go
+++ b/internal/imageversions/mirrorresolve/resolver.go
@@ -2,8 +2,12 @@ package mirrorresolve
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -17,8 +21,17 @@ var (
 	ErrAmbiguousAnnotation = errors.New("mirrorresolve: annotation not a registry ref")
 )
 
+const (
+	annBaseName = "org.opencontainers.image.base.name"
+	annSource   = "org.opencontainers.image.source"
+
+	manifestAccept = "application/vnd.oci.image.manifest.v1+json," +
+		"application/vnd.docker.distribution.manifest.v2+json," +
+		"application/vnd.oci.image.index.v1+json," +
+		"application/vnd.docker.distribution.manifest.list.v2+json"
+)
+
 // MirrorRow is the subset of api.ImageRegistry the resolver needs.
-// Keeping this narrow makes the package easy to test in isolation.
 type MirrorRow struct {
 	Hostname     string
 	PathPrefix   string
@@ -34,35 +47,279 @@ type MirrorLookup interface {
 	FindMirror(ctx context.Context, hostname, imagePath string) (MirrorRow, bool, error)
 }
 
-// Resolver resolves a mirrored ref to its public origin.
-//
-// Passthrough contract: if the ref's hostname does not match any configured
-// mirror row, Resolve returns (ref, nil) — the caller can treat the value
-// as the ordinary public ref.
+// Resolver resolves a mirrored ref to its public origin. When the ref does
+// not match any mirror row, Resolve returns (ref, nil).
 type Resolver interface {
 	Resolve(ctx context.Context, ref string) (origin string, err error)
 }
 
-// Observer receives one event per Resolve call. Implementations should be
-// goroutine-safe. A nil Observer is allowed; the resolver no-ops then.
+// Observer receives one event per Resolve call.
 type Observer interface {
 	ObserveResolve(result string, d time.Duration)
 }
 
 // HTTPResolver implements Resolver against an OCI distribution v2 endpoint.
-// Zero value is not usable — Lookup must be set.
 type HTTPResolver struct {
 	Lookup  MirrorLookup
-	Client  *http.Client     // defaults to a 10s-timeout client when nil
-	Metrics Observer         // optional
-	Scheme  string           // "https" by default; "http" for httptest
-	Now     func() time.Time // optional; defaults to time.Now
+	Client  *http.Client
+	Metrics Observer
+	Scheme  string // "https" by default; "http" for httptest
+	Now     func() time.Time
 }
 
-// Resolve is the entry point. Implemented in resolve.go (added in Task 7).
-// The skeleton commit only declares the type and dependencies.
-//
-// (No body yet; T6 writes failing tests; T7 implements.)
+type ociManifest struct {
+	SchemaVersion int               `json:"schemaVersion"`
+	MediaType     string            `json:"mediaType"`
+	Annotations   map[string]string `json:"annotations,omitempty"`
+	Config        struct {
+		Digest string `json:"digest"`
+	} `json:"config"`
+	Manifests []struct {
+		Digest      string            `json:"digest"`
+		Annotations map[string]string `json:"annotations,omitempty"`
+	} `json:"manifests,omitempty"`
+}
+
+type imageConfig struct {
+	Config struct {
+		Labels map[string]string `json:"Labels"`
+	} `json:"config"`
+}
+
+type httpAuthErr struct{ status int }
+
+func (e *httpAuthErr) Error() string { return fmt.Sprintf("auth error: HTTP %d", e.status) }
+
+func isAuthErr(err error) bool {
+	var a *httpAuthErr
+	return errors.As(err, &a)
+}
+
+func (h *HTTPResolver) httpClient() *http.Client {
+	if h.Client != nil {
+		return h.Client
+	}
+	return &http.Client{Timeout: 10 * time.Second}
+}
+
+func (h *HTTPResolver) scheme() string {
+	if h.Scheme != "" {
+		return h.Scheme
+	}
+	return "https"
+}
+
+func (h *HTTPResolver) now() time.Time {
+	if h.Now != nil {
+		return h.Now()
+	}
+	return time.Now()
+}
+
+func (h *HTTPResolver) observe(result string, started time.Time) {
+	if h.Metrics != nil {
+		h.Metrics.ObserveResolve(result, h.now().Sub(started))
+	}
+}
+
+// Resolve implements Resolver.
 func (h *HTTPResolver) Resolve(ctx context.Context, ref string) (string, error) {
-	return "", errors.New("mirrorresolve: not implemented")
+	started := h.now()
+
+	hostname, imagePath, tag, err := splitRef(ref)
+	if err != nil {
+		h.observe("parse_error", started)
+		return "", err
+	}
+
+	row, ok, err := h.Lookup.FindMirror(ctx, hostname, imagePath)
+	if err != nil {
+		h.observe("lookup_error", started)
+		return "", err
+	}
+	if !ok {
+		h.observe("passthrough", started)
+		return ref, nil
+	}
+
+	manifest, err := h.fetchManifest(ctx, row, imagePath, tag)
+	if err != nil {
+		if isAuthErr(err) {
+			h.observe("auth_error", started)
+		} else {
+			h.observe("fetch_error", started)
+		}
+		return "", err
+	}
+
+	annotations := manifest.Annotations
+	if len(annotations) == 0 && len(manifest.Manifests) > 0 {
+		annotations = manifest.Manifests[0].Annotations
+	}
+
+	if origin, ok := extractOrigin(annotations, tag); ok {
+		h.observe("ok", started)
+		return origin, nil
+	}
+
+	// Fallback: config blob Labels.
+	if manifest.Config.Digest != "" {
+		cfg, err := h.fetchConfig(ctx, row, imagePath, manifest.Config.Digest)
+		if err == nil {
+			if origin, ok := extractOrigin(cfg.Config.Labels, tag); ok {
+				h.observe("ok", started)
+				return origin, nil
+			}
+		}
+	}
+
+	if _, present := annotations[annSource]; present {
+		h.observe("ambiguous_annotation", started)
+		return "", ErrAmbiguousAnnotation
+	}
+	h.observe("missing_annotation", started)
+	return "", ErrNoOriginAnnotation
+}
+
+func extractOrigin(m map[string]string, originalTag string) (string, bool) {
+	if v := strings.TrimSpace(m[annBaseName]); v != "" {
+		return stripAndRetagToOriginal(v, originalTag), true
+	}
+	if v := strings.TrimSpace(m[annSource]); v != "" {
+		if looksLikeRegistryRef(v) {
+			return stripAndRetagToOriginal(v, originalTag), true
+		}
+	}
+	return "", false
+}
+
+// stripAndRetagToOriginal removes any tag/digest on v and re-attaches the
+// caller's tag so the enricher computes freshness for the right lineage.
+func stripAndRetagToOriginal(v, originalTag string) string {
+	if i := strings.Index(v, "@"); i > 0 {
+		v = v[:i]
+	}
+	if slash := strings.LastIndex(v, "/"); slash >= 0 {
+		if colon := strings.LastIndex(v[slash:], ":"); colon > 0 {
+			v = v[:slash+colon]
+		}
+	}
+	if originalTag != "" {
+		return v + ":" + originalTag
+	}
+	return v
+}
+
+// looksLikeRegistryRef rejects schemes and bare-domain code-host URLs.
+func looksLikeRegistryRef(v string) bool {
+	if strings.Contains(v, "://") {
+		return false
+	}
+	if !strings.Contains(v, "/") {
+		return false
+	}
+	for _, bad := range []string{"github.com/", "gitlab.com/", "bitbucket.org/"} {
+		if strings.HasPrefix(v, bad) {
+			return false
+		}
+	}
+	return true
+}
+
+// splitRef parses "host[:port]/path[:tag|@digest]" into its components.
+// The tag colon search is scoped to the segment after the last '/' so that
+// host:port colons are not mistaken for tag separators.
+func splitRef(ref string) (hostname, imagePath, tag string, err error) {
+	slash := strings.Index(ref, "/")
+	if slash < 0 {
+		return "", "", "", fmt.Errorf("mirrorresolve: invalid ref %q", ref)
+	}
+	hostname = ref[:slash]
+	rest := ref[slash+1:]
+	if at := strings.Index(rest, "@"); at >= 0 {
+		return hostname, rest[:at], "", nil
+	}
+	lastSlash := strings.LastIndex(rest, "/")
+	tail := rest
+	tailStart := 0
+	if lastSlash >= 0 {
+		tail = rest[lastSlash+1:]
+		tailStart = lastSlash + 1
+	}
+	if colon := strings.LastIndex(tail, ":"); colon >= 0 {
+		return hostname, rest[:tailStart+colon], rest[tailStart+colon+1:], nil
+	}
+	return hostname, rest, "latest", nil
+}
+
+func (h *HTTPResolver) fetchManifest(ctx context.Context, row MirrorRow, imagePath, tag string) (*ociManifest, error) {
+	if tag == "" {
+		tag = "latest"
+	}
+	url := h.scheme() + "://" + row.Hostname + "/v2/" + imagePath + "/manifests/" + tag
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", manifestAccept)
+	if err := h.applyAuth(ctx, req, row); err != nil {
+		return nil, err
+	}
+	resp, err := h.httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch manifest: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, &httpAuthErr{status: resp.StatusCode}
+	}
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, fmt.Errorf("fetch manifest: HTTP %d", resp.StatusCode)
+	}
+	var m ociManifest
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		return nil, fmt.Errorf("decode manifest: %w", err)
+	}
+	return &m, nil
+}
+
+func (h *HTTPResolver) fetchConfig(ctx context.Context, row MirrorRow, imagePath, digest string) (*imageConfig, error) {
+	url := h.scheme() + "://" + row.Hostname + "/v2/" + imagePath + "/blobs/" + digest
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := h.applyAuth(ctx, req, row); err != nil {
+		return nil, err
+	}
+	resp, err := h.httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch config: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, fmt.Errorf("fetch config: HTTP %d", resp.StatusCode)
+	}
+	var c imageConfig
+	if err := json.NewDecoder(resp.Body).Decode(&c); err != nil {
+		return nil, fmt.Errorf("decode config: %w", err)
+	}
+	return &c, nil
+}
+
+func (h *HTTPResolver) applyAuth(ctx context.Context, req *http.Request, row MirrorRow) error {
+	if row.TokenSource == nil {
+		return nil
+	}
+	tok, err := row.TokenSource(ctx)
+	if err != nil {
+		return err
+	}
+	if tok == "" {
+		return nil
+	}
+	req.SetBasicAuth(row.AuthUsername, tok)
+	return nil
 }

--- a/internal/imageversions/mirrorresolve/resolver.go
+++ b/internal/imageversions/mirrorresolve/resolver.go
@@ -19,6 +19,12 @@ var (
 	// ErrAmbiguousAnnotation indicates the annotation exists but is not a
 	// parseable registry reference (e.g. a GitHub source URL).
 	ErrAmbiguousAnnotation = errors.New("mirrorresolve: annotation not a registry ref")
+	// ErrInvalidRef indicates an unparseable image reference.
+	ErrInvalidRef = errors.New("mirrorresolve: invalid ref")
+	// ErrFetchManifest indicates a non-2xx response fetching a manifest.
+	ErrFetchManifest = errors.New("mirrorresolve: fetch manifest")
+	// ErrFetchConfig indicates a non-2xx response fetching a config blob.
+	ErrFetchConfig = errors.New("mirrorresolve: fetch config")
 )
 
 const (
@@ -86,12 +92,12 @@ type imageConfig struct {
 	} `json:"config"`
 }
 
-type httpAuthErr struct{ status int }
+type httpAuthError struct{ status int }
 
-func (e *httpAuthErr) Error() string { return fmt.Sprintf("auth error: HTTP %d", e.status) }
+func (e *httpAuthError) Error() string { return fmt.Sprintf("auth error: HTTP %d", e.status) }
 
 func isAuthErr(err error) bool {
-	var a *httpAuthErr
+	var a *httpAuthError
 	return errors.As(err, &a)
 }
 
@@ -135,7 +141,7 @@ func (h *HTTPResolver) Resolve(ctx context.Context, ref string) (string, error) 
 	row, ok, err := h.Lookup.FindMirror(ctx, hostname, imagePath)
 	if err != nil {
 		h.observe("lookup_error", started)
-		return "", err
+		return "", fmt.Errorf("mirror lookup: %w", err)
 	}
 	if !ok {
 		h.observe("passthrough", started)
@@ -232,7 +238,7 @@ func looksLikeRegistryRef(v string) bool {
 func splitRef(ref string) (hostname, imagePath, tag string, err error) {
 	slash := strings.Index(ref, "/")
 	if slash < 0 {
-		return "", "", "", fmt.Errorf("mirrorresolve: invalid ref %q", ref)
+		return "", "", "", fmt.Errorf("%w: %q", ErrInvalidRef, ref)
 	}
 	hostname = ref[:slash]
 	rest := ref[slash+1:]
@@ -257,9 +263,9 @@ func (h *HTTPResolver) fetchManifest(ctx context.Context, row MirrorRow, imagePa
 		tag = "latest"
 	}
 	url := h.scheme() + "://" + row.Hostname + "/v2/" + imagePath + "/manifests/" + tag
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("build manifest request: %w", err)
 	}
 	req.Header.Set("Accept", manifestAccept)
 	if err := h.applyAuth(ctx, req, row); err != nil {
@@ -271,11 +277,11 @@ func (h *HTTPResolver) fetchManifest(ctx context.Context, row MirrorRow, imagePa
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return nil, &httpAuthErr{status: resp.StatusCode}
+		return nil, &httpAuthError{status: resp.StatusCode}
 	}
 	if resp.StatusCode != http.StatusOK {
 		_, _ = io.Copy(io.Discard, resp.Body)
-		return nil, fmt.Errorf("fetch manifest: HTTP %d", resp.StatusCode)
+		return nil, fmt.Errorf("%w: HTTP %d", ErrFetchManifest, resp.StatusCode)
 	}
 	var m ociManifest
 	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
@@ -286,9 +292,9 @@ func (h *HTTPResolver) fetchManifest(ctx context.Context, row MirrorRow, imagePa
 
 func (h *HTTPResolver) fetchConfig(ctx context.Context, row MirrorRow, imagePath, digest string) (*imageConfig, error) {
 	url := h.scheme() + "://" + row.Hostname + "/v2/" + imagePath + "/blobs/" + digest
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("build config request: %w", err)
 	}
 	if err := h.applyAuth(ctx, req, row); err != nil {
 		return nil, err
@@ -300,7 +306,7 @@ func (h *HTTPResolver) fetchConfig(ctx context.Context, row MirrorRow, imagePath
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		_, _ = io.Copy(io.Discard, resp.Body)
-		return nil, fmt.Errorf("fetch config: HTTP %d", resp.StatusCode)
+		return nil, fmt.Errorf("%w: HTTP %d", ErrFetchConfig, resp.StatusCode)
 	}
 	var c imageConfig
 	if err := json.NewDecoder(resp.Body).Decode(&c); err != nil {

--- a/internal/imageversions/mirrorresolve/resolver.go
+++ b/internal/imageversions/mirrorresolve/resolver.go
@@ -101,6 +101,68 @@ func isAuthErr(err error) bool {
 	return errors.As(err, &a)
 }
 
+// Resolve implements Resolver.
+func (h *HTTPResolver) Resolve(ctx context.Context, ref string) (string, error) {
+	started := h.now()
+
+	hostname, imagePath, tag, err := splitRef(ref)
+	if err != nil {
+		h.observe("parse_error", started)
+		return "", err
+	}
+
+	row, ok, err := h.Lookup.FindMirror(ctx, hostname, imagePath)
+	if err != nil {
+		h.observe("lookup_error", started)
+		return "", fmt.Errorf("mirror lookup: %w", err)
+	}
+	if !ok {
+		h.observe("passthrough", started)
+		return ref, nil
+	}
+
+	origin, result, err := h.resolveFromMirror(ctx, row, imagePath, tag)
+	h.observe(result, started)
+	return origin, err
+}
+
+// resolveFromMirror fetches the manifest from the mirror, applies the
+// annotation-extraction priority (base.name → source → config Labels), and
+// returns the resolved public origin together with the metric label to
+// record. Splitting this out keeps Resolve's cyclomatic complexity in check
+// and makes the fetch/extract pipeline easier to test independently.
+func (h *HTTPResolver) resolveFromMirror(ctx context.Context, row MirrorRow, imagePath, tag string) (origin, result string, err error) {
+	manifest, err := h.fetchManifest(ctx, row, imagePath, tag)
+	if err != nil {
+		if isAuthErr(err) {
+			return "", "auth_error", err
+		}
+		return "", "fetch_error", err
+	}
+
+	annotations := manifest.Annotations
+	if len(annotations) == 0 && len(manifest.Manifests) > 0 {
+		annotations = manifest.Manifests[0].Annotations
+	}
+
+	if origin, ok := extractOrigin(annotations, tag); ok {
+		return origin, "ok", nil
+	}
+
+	if manifest.Config.Digest != "" {
+		if cfg, cfgErr := h.fetchConfig(ctx, row, imagePath, manifest.Config.Digest); cfgErr == nil {
+			if origin, ok := extractOrigin(cfg.Config.Labels, tag); ok {
+				return origin, "ok", nil
+			}
+		}
+	}
+
+	if _, present := annotations[annSource]; present {
+		return "", "ambiguous_annotation", ErrAmbiguousAnnotation
+	}
+	return "", "missing_annotation", ErrNoOriginAnnotation
+}
+
 func (h *HTTPResolver) httpClient() *http.Client {
 	if h.Client != nil {
 		return h.Client
@@ -126,65 +188,6 @@ func (h *HTTPResolver) observe(result string, started time.Time) {
 	if h.Metrics != nil {
 		h.Metrics.ObserveResolve(result, h.now().Sub(started))
 	}
-}
-
-// Resolve implements Resolver.
-func (h *HTTPResolver) Resolve(ctx context.Context, ref string) (string, error) {
-	started := h.now()
-
-	hostname, imagePath, tag, err := splitRef(ref)
-	if err != nil {
-		h.observe("parse_error", started)
-		return "", err
-	}
-
-	row, ok, err := h.Lookup.FindMirror(ctx, hostname, imagePath)
-	if err != nil {
-		h.observe("lookup_error", started)
-		return "", fmt.Errorf("mirror lookup: %w", err)
-	}
-	if !ok {
-		h.observe("passthrough", started)
-		return ref, nil
-	}
-
-	manifest, err := h.fetchManifest(ctx, row, imagePath, tag)
-	if err != nil {
-		if isAuthErr(err) {
-			h.observe("auth_error", started)
-		} else {
-			h.observe("fetch_error", started)
-		}
-		return "", err
-	}
-
-	annotations := manifest.Annotations
-	if len(annotations) == 0 && len(manifest.Manifests) > 0 {
-		annotations = manifest.Manifests[0].Annotations
-	}
-
-	if origin, ok := extractOrigin(annotations, tag); ok {
-		h.observe("ok", started)
-		return origin, nil
-	}
-
-	// Fallback: config blob Labels.
-	if manifest.Config.Digest != "" {
-		cfg, err := h.fetchConfig(ctx, row, imagePath, manifest.Config.Digest)
-		if err == nil {
-			if origin, ok := extractOrigin(cfg.Config.Labels, tag); ok {
-				h.observe("ok", started)
-				return origin, nil
-			}
-		}
-	}
-
-	if _, present := annotations[annSource]; present {
-		h.observe("ambiguous_annotation", started)
-		return "", ErrAmbiguousAnnotation
-	}
-	h.observe("missing_annotation", started)
-	return "", ErrNoOriginAnnotation
 }
 
 func extractOrigin(m map[string]string, originalTag string) (string, bool) {

--- a/internal/imageversions/mirrorresolve/resolver.go
+++ b/internal/imageversions/mirrorresolve/resolver.go
@@ -1,0 +1,68 @@
+package mirrorresolve
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+)
+
+// Sentinel errors returned by Resolve.
+var (
+	// ErrNoOriginAnnotation indicates the manifest was fetched successfully
+	// but no usable annotation was found.
+	ErrNoOriginAnnotation = errors.New("mirrorresolve: no usable origin annotation")
+	// ErrAmbiguousAnnotation indicates the annotation exists but is not a
+	// parseable registry reference (e.g. a GitHub source URL).
+	ErrAmbiguousAnnotation = errors.New("mirrorresolve: annotation not a registry ref")
+)
+
+// MirrorRow is the subset of api.ImageRegistry the resolver needs.
+// Keeping this narrow makes the package easy to test in isolation.
+type MirrorRow struct {
+	Hostname     string
+	PathPrefix   string
+	AuthUsername string
+	// TokenSource returns the plaintext token at call time. May return ""
+	// for anonymous mirrors. Called at most once per Resolve.
+	TokenSource func(ctx context.Context) (string, error)
+}
+
+// MirrorLookup finds the longest-prefix mirror row matching (hostname,
+// imagePath). Returns (zero, false, nil) when no mirror row applies.
+type MirrorLookup interface {
+	FindMirror(ctx context.Context, hostname, imagePath string) (MirrorRow, bool, error)
+}
+
+// Resolver resolves a mirrored ref to its public origin.
+//
+// Passthrough contract: if the ref's hostname does not match any configured
+// mirror row, Resolve returns (ref, nil) — the caller can treat the value
+// as the ordinary public ref.
+type Resolver interface {
+	Resolve(ctx context.Context, ref string) (origin string, err error)
+}
+
+// Observer receives one event per Resolve call. Implementations should be
+// goroutine-safe. A nil Observer is allowed; the resolver no-ops then.
+type Observer interface {
+	ObserveResolve(result string, d time.Duration)
+}
+
+// HTTPResolver implements Resolver against an OCI distribution v2 endpoint.
+// Zero value is not usable — Lookup must be set.
+type HTTPResolver struct {
+	Lookup  MirrorLookup
+	Client  *http.Client     // defaults to a 10s-timeout client when nil
+	Metrics Observer         // optional
+	Scheme  string           // "https" by default; "http" for httptest
+	Now     func() time.Time // optional; defaults to time.Now
+}
+
+// Resolve is the entry point. Implemented in resolve.go (added in Task 7).
+// The skeleton commit only declares the type and dependencies.
+//
+// (No body yet; T6 writes failing tests; T7 implements.)
+func (h *HTTPResolver) Resolve(ctx context.Context, ref string) (string, error) {
+	return "", errors.New("mirrorresolve: not implemented")
+}

--- a/internal/imageversions/mirrorresolve/resolver_test.go
+++ b/internal/imageversions/mirrorresolve/resolver_test.go
@@ -40,7 +40,7 @@ func TestHTTPResolver_Resolve(t *testing.T) {
 				SchemaVersion: 2, MediaType: "application/vnd.oci.image.manifest.v1+json",
 				Annotations: map[string]string{
 					"org.opencontainers.image.base.name": "docker.io/library/debian:bookworm",
-					"org.opencontainers.image.source":    "https://github.com/x/y",
+					annSource:                            "https://github.com/x/y",
 				},
 			},
 			wantOrigin: "docker.io/library/debian:1.25",
@@ -50,7 +50,7 @@ func TestHTTPResolver_Resolve(t *testing.T) {
 			manifest: manifestFixture{
 				SchemaVersion: 2, MediaType: "application/vnd.oci.image.manifest.v1+json",
 				Annotations: map[string]string{
-					"org.opencontainers.image.source": "docker.io/library/nginx",
+					annSource: "docker.io/library/nginx",
 				},
 			},
 			wantOrigin: "docker.io/library/nginx:1.25",
@@ -60,7 +60,7 @@ func TestHTTPResolver_Resolve(t *testing.T) {
 			manifest: manifestFixture{
 				SchemaVersion: 2, MediaType: "application/vnd.oci.image.manifest.v1+json",
 				Annotations: map[string]string{
-					"org.opencontainers.image.source": "https://github.com/x/y",
+					annSource: "https://github.com/x/y",
 				},
 			},
 			wantErr: ErrAmbiguousAnnotation,

--- a/internal/imageversions/mirrorresolve/resolver_test.go
+++ b/internal/imageversions/mirrorresolve/resolver_test.go
@@ -36,27 +36,33 @@ func TestHTTPResolver_Resolve(t *testing.T) {
 	}{
 		{
 			name: "base.name preferred",
-			manifest: manifestFixture{SchemaVersion: 2, MediaType: "application/vnd.oci.image.manifest.v1+json",
+			manifest: manifestFixture{
+				SchemaVersion: 2, MediaType: "application/vnd.oci.image.manifest.v1+json",
 				Annotations: map[string]string{
 					"org.opencontainers.image.base.name": "docker.io/library/debian:bookworm",
 					"org.opencontainers.image.source":    "https://github.com/x/y",
-				}},
+				},
+			},
 			wantOrigin: "docker.io/library/debian:1.25",
 		},
 		{
 			name: "source as registry ref",
-			manifest: manifestFixture{SchemaVersion: 2, MediaType: "application/vnd.oci.image.manifest.v1+json",
+			manifest: manifestFixture{
+				SchemaVersion: 2, MediaType: "application/vnd.oci.image.manifest.v1+json",
 				Annotations: map[string]string{
 					"org.opencontainers.image.source": "docker.io/library/nginx",
-				}},
+				},
+			},
 			wantOrigin: "docker.io/library/nginx:1.25",
 		},
 		{
 			name: "source as github URL -> ambiguous",
-			manifest: manifestFixture{SchemaVersion: 2, MediaType: "application/vnd.oci.image.manifest.v1+json",
+			manifest: manifestFixture{
+				SchemaVersion: 2, MediaType: "application/vnd.oci.image.manifest.v1+json",
 				Annotations: map[string]string{
 					"org.opencontainers.image.source": "https://github.com/x/y",
-				}},
+				},
+			},
 			wantErr: ErrAmbiguousAnnotation,
 		},
 		{
@@ -125,7 +131,7 @@ func TestHTTPResolver_AuthError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	var auth *httpAuthErr
+	var auth *httpAuthError
 	if !errors.As(err, &auth) {
 		t.Fatalf("not auth error: %v", err)
 	}

--- a/internal/imageversions/mirrorresolve/resolver_test.go
+++ b/internal/imageversions/mirrorresolve/resolver_test.go
@@ -1,0 +1,162 @@
+package mirrorresolve
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// fakeLookup always returns the configured row.
+type fakeLookup struct {
+	row MirrorRow
+	ok  bool
+}
+
+func (f fakeLookup) FindMirror(_ context.Context, _, _ string) (MirrorRow, bool, error) {
+	return f.row, f.ok, nil
+}
+
+type manifestFixture struct {
+	SchemaVersion int               `json:"schemaVersion"`
+	MediaType     string            `json:"mediaType"`
+	Annotations   map[string]string `json:"annotations,omitempty"`
+}
+
+func TestHTTPResolver_Resolve(t *testing.T) {
+	cases := []struct {
+		name       string
+		manifest   manifestFixture
+		wantOrigin string
+		wantErr    error
+	}{
+		{
+			name: "base.name preferred",
+			manifest: manifestFixture{SchemaVersion: 2, MediaType: "application/vnd.oci.image.manifest.v1+json",
+				Annotations: map[string]string{
+					"org.opencontainers.image.base.name": "docker.io/library/debian:bookworm",
+					"org.opencontainers.image.source":    "https://github.com/x/y",
+				}},
+			wantOrigin: "docker.io/library/debian:1.25",
+		},
+		{
+			name: "source as registry ref",
+			manifest: manifestFixture{SchemaVersion: 2, MediaType: "application/vnd.oci.image.manifest.v1+json",
+				Annotations: map[string]string{
+					"org.opencontainers.image.source": "docker.io/library/nginx",
+				}},
+			wantOrigin: "docker.io/library/nginx:1.25",
+		},
+		{
+			name: "source as github URL -> ambiguous",
+			manifest: manifestFixture{SchemaVersion: 2, MediaType: "application/vnd.oci.image.manifest.v1+json",
+				Annotations: map[string]string{
+					"org.opencontainers.image.source": "https://github.com/x/y",
+				}},
+			wantErr: ErrAmbiguousAnnotation,
+		},
+		{
+			name:     "no annotations",
+			manifest: manifestFixture{SchemaVersion: 2, MediaType: "application/vnd.oci.image.manifest.v1+json"},
+			wantErr:  ErrNoOriginAnnotation,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasPrefix(r.URL.Path, "/v2/container/library/nginx/manifests/") {
+					t.Fatalf("unexpected path: %s", r.URL.Path)
+				}
+				w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+				_ = json.NewEncoder(w).Encode(tc.manifest)
+			}))
+			defer srv.Close()
+			u, _ := url.Parse(srv.URL)
+
+			r := &HTTPResolver{
+				Lookup: fakeLookup{row: MirrorRow{Hostname: u.Host, PathPrefix: "container/"}, ok: true},
+				Client: srv.Client(),
+				Scheme: "http",
+			}
+			origin, err := r.Resolve(context.Background(), u.Host+"/container/library/nginx:1.25")
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("err=%v want=%v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if origin != tc.wantOrigin {
+				t.Fatalf("origin=%q want=%q", origin, tc.wantOrigin)
+			}
+		})
+	}
+}
+
+func TestHTTPResolver_Passthrough_NoMirror(t *testing.T) {
+	r := &HTTPResolver{Lookup: fakeLookup{ok: false}}
+	got, err := r.Resolve(context.Background(), "docker.io/library/nginx:1.25")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "docker.io/library/nginx:1.25" {
+		t.Fatalf("passthrough=%q", got)
+	}
+}
+
+func TestHTTPResolver_AuthError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	u, _ := url.Parse(srv.URL)
+	r := &HTTPResolver{
+		Lookup: fakeLookup{row: MirrorRow{Hostname: u.Host, PathPrefix: "container/"}, ok: true},
+		Client: srv.Client(),
+		Scheme: "http",
+	}
+	_, err := r.Resolve(context.Background(), u.Host+"/container/library/nginx:1.25")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var auth *httpAuthErr
+	if !errors.As(err, &auth) {
+		t.Fatalf("not auth error: %v", err)
+	}
+}
+
+func TestHTTPResolver_DefaultTag(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/manifests/latest") {
+			t.Fatalf("expected manifests/latest, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+		_ = json.NewEncoder(w).Encode(manifestFixture{
+			SchemaVersion: 2,
+			MediaType:     "application/vnd.oci.image.manifest.v1+json",
+			Annotations: map[string]string{
+				"org.opencontainers.image.base.name": "docker.io/library/nginx",
+			},
+		})
+	}))
+	defer srv.Close()
+	u, _ := url.Parse(srv.URL)
+	r := &HTTPResolver{
+		Lookup: fakeLookup{row: MirrorRow{Hostname: u.Host, PathPrefix: "container/"}, ok: true},
+		Client: srv.Client(),
+		Scheme: "http",
+	}
+	got, err := r.Resolve(context.Background(), u.Host+"/container/library/nginx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "docker.io/library/nginx:latest" {
+		t.Fatalf("got=%q", got)
+	}
+}

--- a/internal/imageversions/types.go
+++ b/internal/imageversions/types.go
@@ -14,6 +14,8 @@ type Store interface {
 	DistinctImageRefs(ctx context.Context) ([]string, error)
 	UpsertImageVersion(ctx context.Context, in api.ImageVersionUpsert) (api.ImageVersionRow, error)
 	DeleteImageVersionsNotIn(ctx context.Context, keep [][2]string) (int64, error)
+	FindMirrorForRef(ctx context.Context, hostname, imagePath string) (api.ImageRegistry, error)
+	GetMirrorAuthToken(ctx context.Context, hostname, pathPrefix string) (string, error)
 }
 
 // TagsLister abstracts the OCI client for testing.

--- a/internal/secrets/encrypter.go
+++ b/internal/secrets/encrypter.go
@@ -118,6 +118,10 @@ type Ciphertext struct {
 	KID   string
 }
 
+// NonceSize returns the AEAD nonce length in bytes. Callers that pack
+// (nonce ‖ ciphertext) into a single column need this for unpacking.
+func (e *Encrypter) NonceSize() int { return e.aead.NonceSize() }
+
 // Encrypt seals plaintext under the master key with the given AAD. The
 // AAD typically contains the row's primary key (e.g. the cloud_account
 // UUID's bytes) so a backup-restore cannot move the ciphertext between

--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pressly/goose/v3"
 
 	"github.com/sthalbert/longue-vue/internal/api"
+	"github.com/sthalbert/longue-vue/internal/secrets"
 	"github.com/sthalbert/longue-vue/internal/timetravel"
 	"github.com/sthalbert/longue-vue/migrations"
 )
@@ -39,7 +40,21 @@ const (
 type PG struct {
 	pool          *pgxpool.Pool
 	revokedTokens chan string
+	encrypter     *secrets.Encrypter
 }
+
+// SetEncrypter wires the AES-GCM encrypter used by encrypted-secret tables
+// (currently image_versions_registries auth tokens). Optional — methods
+// that require it return an explicit error when it is unset.
+func (p *PG) SetEncrypter(enc *secrets.Encrypter) {
+	p.encrypter = enc
+}
+
+// Encrypter returns the wired encrypter, or nil. Test-only helper.
+func (p *PG) Encrypter() *secrets.Encrypter { return p.encrypter }
+
+// Pool returns the underlying pool. Test-only helper.
+func (p *PG) Pool() *pgxpool.Pool { return p.pool }
 
 // Open connects to PostgreSQL via the given DSN and verifies the connection.
 func Open(ctx context.Context, dsn string) (*PG, error) {

--- a/internal/store/pg_image_registries.go
+++ b/internal/store/pg_image_registries.go
@@ -103,6 +103,8 @@ FROM image_versions_registries WHERE hostname = $1 AND path_prefix = $2`
 }
 
 // CreateImageRegistry inserts a new registry row.
+//
+//nolint:gocritic // in matches the api.Store interface signature shared by every CRUD method (hugeParam expected)
 func (p *PG) CreateImageRegistry(ctx context.Context, in api.ImageRegistryUpsert) (api.ImageRegistry, error) {
 	enabled := true
 	if in.Enabled != nil {

--- a/internal/store/pg_image_registries.go
+++ b/internal/store/pg_image_registries.go
@@ -8,24 +8,60 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/sthalbert/longue-vue/internal/api"
+	"github.com/sthalbert/longue-vue/internal/secrets"
 )
+
+// imageRegistryColumns lists the SELECT columns in canonical order.
+const imageRegistryColumns = `hostname, path_prefix, rate_limit_per_sec, enabled, notes,
+	is_mirror, auth_username, auth_token_ciphertext, created_at, updated_at`
 
 func scanImageRegistry(row pgx.Row) (api.ImageRegistry, error) {
 	var r api.ImageRegistry
-	if err := row.Scan(&r.Hostname, &r.RateLimitPerSec, &r.Enabled, &r.Notes,
+	var authUser *string
+	var authToken []byte
+	if err := row.Scan(&r.Hostname, &r.PathPrefix, &r.RateLimitPerSec, &r.Enabled, &r.Notes,
+		&r.IsMirror, &authUser, &authToken,
 		&r.CreatedAt, &r.UpdatedAt); err != nil {
 		return api.ImageRegistry{}, fmt.Errorf("scan image registry: %w", err)
 	}
+	r.AuthUsername = authUser
+	r.AuthConfigured = len(authToken) > 0
 	return r, nil
 }
 
-// ListImageRegistries returns all rows from image_versions_registries ordered
-// by hostname.
+// aadForImageRegistry binds the encrypted token to the row's composite PK.
+func aadForImageRegistry(hostname, pathPrefix string) []byte {
+	return []byte("image_versions_registries|" + hostname + "|" + pathPrefix)
+}
+
+// packCiphertext encodes a Ciphertext into a single BYTEA: nonce ‖ sealed.
+// The KID is implicit (always CurrentKID for writes); reads accept the
+// current KID only.
+func packCiphertext(ct secrets.Ciphertext) []byte {
+	out := make([]byte, 0, len(ct.Nonce)+len(ct.Bytes))
+	out = append(out, ct.Nonce...)
+	out = append(out, ct.Bytes...)
+	return out
+}
+
+// unpackCiphertext splits a stored BYTEA back into a Ciphertext. nonceSize
+// must match the encrypter's AEAD nonce size (12 for AES-GCM).
+func unpackCiphertext(raw []byte, nonceSize int) (secrets.Ciphertext, error) {
+	if len(raw) < nonceSize {
+		return secrets.Ciphertext{}, fmt.Errorf("ciphertext too short: %d", len(raw))
+	}
+	return secrets.Ciphertext{
+		Nonce: raw[:nonceSize],
+		Bytes: raw[nonceSize:],
+		KID:   secrets.CurrentKID,
+	}, nil
+}
+
+// ListImageRegistries returns all rows ordered by (hostname, path_prefix).
 func (p *PG) ListImageRegistries(ctx context.Context) ([]api.ImageRegistry, error) {
-	const q = `
-SELECT hostname, rate_limit_per_sec, enabled, notes, created_at, updated_at
+	q := `SELECT ` + imageRegistryColumns + `
 FROM image_versions_registries
-ORDER BY hostname`
+ORDER BY hostname, path_prefix`
 	rows, err := p.pool.Query(ctx, q)
 	if err != nil {
 		return nil, fmt.Errorf("list image registries: %w", err)
@@ -45,13 +81,11 @@ ORDER BY hostname`
 	return out, nil
 }
 
-// GetImageRegistry fetches a single registry by hostname.
-// Returns api.ErrNotFound when the hostname does not exist.
-func (p *PG) GetImageRegistry(ctx context.Context, hostname string) (api.ImageRegistry, error) {
-	const q = `
-SELECT hostname, rate_limit_per_sec, enabled, notes, created_at, updated_at
-FROM image_versions_registries WHERE hostname = $1`
-	r, err := scanImageRegistry(p.pool.QueryRow(ctx, q, hostname))
+// GetImageRegistry fetches a single registry by (hostname, path_prefix).
+func (p *PG) GetImageRegistry(ctx context.Context, hostname, pathPrefix string) (api.ImageRegistry, error) {
+	q := `SELECT ` + imageRegistryColumns + `
+FROM image_versions_registries WHERE hostname = $1 AND path_prefix = $2`
+	r, err := scanImageRegistry(p.pool.QueryRow(ctx, q, hostname, pathPrefix))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return api.ImageRegistry{}, api.ErrNotFound
 	}
@@ -62,18 +96,30 @@ FROM image_versions_registries WHERE hostname = $1`
 }
 
 // CreateImageRegistry inserts a new registry row.
-// Returns api.ErrConflict when a row with the same hostname already exists.
-// Enabled defaults to true when in.Enabled is nil.
 func (p *PG) CreateImageRegistry(ctx context.Context, in api.ImageRegistryUpsert) (api.ImageRegistry, error) {
 	enabled := true
 	if in.Enabled != nil {
 		enabled = *in.Enabled
 	}
-	const q = `
-INSERT INTO image_versions_registries (hostname, rate_limit_per_sec, enabled, notes)
-VALUES ($1, $2, $3, $4)
-RETURNING hostname, rate_limit_per_sec, enabled, notes, created_at, updated_at`
-	r, err := scanImageRegistry(p.pool.QueryRow(ctx, q, in.Hostname, in.RateLimitPerSec, enabled, in.Notes))
+	var tokenCT []byte
+	if in.AuthToken != nil && *in.AuthToken != "" {
+		if p.encrypter == nil {
+			return api.ImageRegistry{}, fmt.Errorf("create image registry: encrypter not configured")
+		}
+		ct, err := p.encrypter.Encrypt([]byte(*in.AuthToken), aadForImageRegistry(in.Hostname, in.PathPrefix))
+		if err != nil {
+			return api.ImageRegistry{}, fmt.Errorf("encrypt token: %w", err)
+		}
+		tokenCT = packCiphertext(ct)
+	}
+	q := `INSERT INTO image_versions_registries
+	(hostname, path_prefix, rate_limit_per_sec, enabled, notes,
+	 is_mirror, auth_username, auth_token_ciphertext)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+RETURNING ` + imageRegistryColumns
+	r, err := scanImageRegistry(p.pool.QueryRow(ctx, q,
+		in.Hostname, in.PathPrefix, in.RateLimitPerSec, enabled, in.Notes,
+		in.IsMirror, in.AuthUsername, tokenCT))
 	if err != nil {
 		if isUniqueViolation(err) {
 			return api.ImageRegistry{}, api.ErrConflict
@@ -83,27 +129,61 @@ RETURNING hostname, rate_limit_per_sec, enabled, notes, created_at, updated_at`
 	return r, nil
 }
 
-// UpdateImageRegistry applies a merge-patch to an existing registry row.
-// Returns api.ErrNotFound when the hostname does not exist.
+// UpdateImageRegistry applies a merge-patch.
 //
-// Notes semantics: a nil pointer leaves the column unchanged; a non-nil
-// pointer overwrites with the pointed-to string (which may be empty).
-// JSON null and an absent field are indistinguishable through *string,
-// so callers cannot use this API to clear notes back to NULL — pass
-// pointer-to-empty-string if a "cleared" placeholder is acceptable, or
-// extend the patch type to **string if true NULL-clearing is needed.
-func (p *PG) UpdateImageRegistry(ctx context.Context, hostname string, patch api.ImageRegistryPatch) (api.ImageRegistry, error) {
-	const q = `
-UPDATE image_versions_registries SET
-    rate_limit_per_sec = COALESCE($2, rate_limit_per_sec),
-    enabled            = COALESCE($3, enabled),
-    notes              = CASE WHEN $4::bool THEN $5 ELSE notes END,
-    updated_at         = now()
-WHERE hostname = $1
-RETURNING hostname, rate_limit_per_sec, enabled, notes, created_at, updated_at`
+// AuthToken semantics:
+//   - nil   → leave ciphertext unchanged
+//   - ""    → clear ciphertext (set to NULL); also clears auth_username
+//   - other → re-encrypt with PK-bound AAD
+func (p *PG) UpdateImageRegistry(ctx context.Context, hostname, pathPrefix string, patch api.ImageRegistryPatch) (api.ImageRegistry, error) {
+	var (
+		tokenProvided bool
+		tokenCT       []byte
+		clearToken    bool
+	)
+	if patch.AuthToken != nil {
+		tokenProvided = true
+		if *patch.AuthToken == "" {
+			clearToken = true
+		} else {
+			if p.encrypter == nil {
+				return api.ImageRegistry{}, fmt.Errorf("update image registry: encrypter not configured")
+			}
+			ct, err := p.encrypter.Encrypt([]byte(*patch.AuthToken), aadForImageRegistry(hostname, pathPrefix))
+			if err != nil {
+				return api.ImageRegistry{}, fmt.Errorf("encrypt token: %w", err)
+			}
+			tokenCT = packCiphertext(ct)
+		}
+	}
+
 	notesProvided := patch.Notes != nil
-	r, err := scanImageRegistry(p.pool.QueryRow(ctx, q, hostname,
-		patch.RateLimitPerSec, patch.Enabled, notesProvided, patch.Notes))
+	userProvided := patch.AuthUsername != nil
+
+	q := `UPDATE image_versions_registries SET
+		rate_limit_per_sec    = COALESCE($3, rate_limit_per_sec),
+		enabled               = COALESCE($4, enabled),
+		notes                 = CASE WHEN $5::bool THEN $6 ELSE notes END,
+		is_mirror             = COALESCE($7, is_mirror),
+		auth_username         = CASE WHEN $8::bool THEN $9 ELSE auth_username END,
+		auth_token_ciphertext = CASE
+		                          WHEN $10::bool THEN NULL
+		                          WHEN $11::bool THEN $12
+		                          ELSE auth_token_ciphertext
+		                       END,
+		updated_at            = now()
+	WHERE hostname = $1 AND path_prefix = $2
+	RETURNING ` + imageRegistryColumns
+
+	r, err := scanImageRegistry(p.pool.QueryRow(ctx, q,
+		hostname, pathPrefix,
+		patch.RateLimitPerSec, patch.Enabled,
+		notesProvided, patch.Notes,
+		patch.IsMirror,
+		userProvided, patch.AuthUsername,
+		clearToken,
+		tokenProvided && !clearToken, tokenCT,
+	))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return api.ImageRegistry{}, api.ErrNotFound
 	}
@@ -113,10 +193,11 @@ RETURNING hostname, rate_limit_per_sec, enabled, notes, created_at, updated_at`
 	return r, nil
 }
 
-// DeleteImageRegistry removes a registry by hostname.
-// Returns api.ErrNotFound when no such row exists.
-func (p *PG) DeleteImageRegistry(ctx context.Context, hostname string) error {
-	tag, err := p.pool.Exec(ctx, `DELETE FROM image_versions_registries WHERE hostname = $1`, hostname)
+// DeleteImageRegistry removes a registry by (hostname, path_prefix).
+func (p *PG) DeleteImageRegistry(ctx context.Context, hostname, pathPrefix string) error {
+	tag, err := p.pool.Exec(ctx,
+		`DELETE FROM image_versions_registries WHERE hostname = $1 AND path_prefix = $2`,
+		hostname, pathPrefix)
 	if err != nil {
 		return fmt.Errorf("delete image registry: %w", err)
 	}
@@ -124,4 +205,56 @@ func (p *PG) DeleteImageRegistry(ctx context.Context, hostname string) error {
 		return api.ErrNotFound
 	}
 	return nil
+}
+
+// FindMirrorForRef returns the longest-prefix mirror row whose hostname
+// matches and whose path_prefix is a prefix of imagePath.
+func (p *PG) FindMirrorForRef(ctx context.Context, hostname, imagePath string) (api.ImageRegistry, error) {
+	q := `SELECT ` + imageRegistryColumns + `
+FROM image_versions_registries
+WHERE hostname = $1
+  AND $2 LIKE path_prefix || '%'
+  AND is_mirror = TRUE
+  AND enabled = TRUE
+ORDER BY length(path_prefix) DESC
+LIMIT 1`
+	r, err := scanImageRegistry(p.pool.QueryRow(ctx, q, hostname, imagePath))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return api.ImageRegistry{}, api.ErrNotFound
+	}
+	if err != nil {
+		return api.ImageRegistry{}, fmt.Errorf("find mirror for ref: %w", err)
+	}
+	return r, nil
+}
+
+// GetMirrorAuthToken decrypts and returns the robot-account token for the
+// row keyed by (hostname, pathPrefix). Empty string when no token is set.
+// Callers MUST NOT log the return value.
+func (p *PG) GetMirrorAuthToken(ctx context.Context, hostname, pathPrefix string) (string, error) {
+	const q = `SELECT auth_token_ciphertext FROM image_versions_registries
+		WHERE hostname=$1 AND path_prefix=$2`
+	var ct []byte
+	err := p.pool.QueryRow(ctx, q, hostname, pathPrefix).Scan(&ct)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", api.ErrNotFound
+	}
+	if err != nil {
+		return "", fmt.Errorf("get mirror token: %w", err)
+	}
+	if len(ct) == 0 {
+		return "", nil
+	}
+	if p.encrypter == nil {
+		return "", fmt.Errorf("get mirror token: encrypter not configured")
+	}
+	packed, err := unpackCiphertext(ct, p.encrypter.NonceSize())
+	if err != nil {
+		return "", fmt.Errorf("unpack mirror token: %w", err)
+	}
+	pt, err := p.encrypter.Decrypt(packed, aadForImageRegistry(hostname, pathPrefix))
+	if err != nil {
+		return "", fmt.Errorf("decrypt mirror token: %w", err)
+	}
+	return string(pt), nil
 }

--- a/internal/store/pg_image_registries.go
+++ b/internal/store/pg_image_registries.go
@@ -15,6 +15,13 @@ import (
 const imageRegistryColumns = `hostname, path_prefix, rate_limit_per_sec, enabled, notes,
 	is_mirror, auth_username, auth_token_ciphertext, created_at, updated_at`
 
+// Static errors for the image-registry store. err113 forbids ad-hoc
+// fmt.Errorf without %w wrapping.
+var (
+	errCiphertextTooShort     = errors.New("image registry: ciphertext too short")
+	errEncrypterNotConfigured = errors.New("image registry: encrypter not configured")
+)
+
 func scanImageRegistry(row pgx.Row) (api.ImageRegistry, error) {
 	var r api.ImageRegistry
 	var authUser *string
@@ -48,7 +55,7 @@ func packCiphertext(ct secrets.Ciphertext) []byte {
 // must match the encrypter's AEAD nonce size (12 for AES-GCM).
 func unpackCiphertext(raw []byte, nonceSize int) (secrets.Ciphertext, error) {
 	if len(raw) < nonceSize {
-		return secrets.Ciphertext{}, fmt.Errorf("ciphertext too short: %d", len(raw))
+		return secrets.Ciphertext{}, fmt.Errorf("%w: %d bytes", errCiphertextTooShort, len(raw))
 	}
 	return secrets.Ciphertext{
 		Nonce: raw[:nonceSize],
@@ -104,7 +111,7 @@ func (p *PG) CreateImageRegistry(ctx context.Context, in api.ImageRegistryUpsert
 	var tokenCT []byte
 	if in.AuthToken != nil && *in.AuthToken != "" {
 		if p.encrypter == nil {
-			return api.ImageRegistry{}, fmt.Errorf("create image registry: encrypter not configured")
+			return api.ImageRegistry{}, fmt.Errorf("create image registry: %w", errEncrypterNotConfigured)
 		}
 		ct, err := p.encrypter.Encrypt([]byte(*in.AuthToken), aadForImageRegistry(in.Hostname, in.PathPrefix))
 		if err != nil {
@@ -147,7 +154,7 @@ func (p *PG) UpdateImageRegistry(ctx context.Context, hostname, pathPrefix strin
 			clearToken = true
 		} else {
 			if p.encrypter == nil {
-				return api.ImageRegistry{}, fmt.Errorf("update image registry: encrypter not configured")
+				return api.ImageRegistry{}, fmt.Errorf("update image registry: %w", errEncrypterNotConfigured)
 			}
 			ct, err := p.encrypter.Encrypt([]byte(*patch.AuthToken), aadForImageRegistry(hostname, pathPrefix))
 			if err != nil {
@@ -246,7 +253,7 @@ func (p *PG) GetMirrorAuthToken(ctx context.Context, hostname, pathPrefix string
 		return "", nil
 	}
 	if p.encrypter == nil {
-		return "", fmt.Errorf("get mirror token: encrypter not configured")
+		return "", fmt.Errorf("get mirror token: %w", errEncrypterNotConfigured)
 	}
 	packed, err := unpackCiphertext(ct, p.encrypter.NonceSize())
 	if err != nil {

--- a/internal/store/pg_image_registries_test.go
+++ b/internal/store/pg_image_registries_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/sthalbert/longue-vue/internal/api"
@@ -10,7 +11,11 @@ import (
 )
 
 func secretsNewEncrypter(key []byte) (*secrets.Encrypter, error) {
-	return secrets.NewEncrypter(key)
+	enc, err := secrets.NewEncrypter(key)
+	if err != nil {
+		return nil, fmt.Errorf("test secrets encrypter: %w", err)
+	}
+	return enc, nil
 }
 
 func TestImageRegistries_SeedDefaults(t *testing.T) {

--- a/internal/store/pg_image_registries_test.go
+++ b/internal/store/pg_image_registries_test.go
@@ -6,7 +6,12 @@ import (
 	"testing"
 
 	"github.com/sthalbert/longue-vue/internal/api"
+	"github.com/sthalbert/longue-vue/internal/secrets"
 )
+
+func secretsNewEncrypter(key []byte) (*secrets.Encrypter, error) {
+	return secrets.NewEncrypter(key)
+}
 
 func TestImageRegistries_SeedDefaults(t *testing.T) {
 	pg := newTestPG(t)
@@ -61,7 +66,7 @@ func TestImageRegistries_CreateGetUpdateDelete(t *testing.T) {
 		t.Fatalf("unexpected created: %+v", created)
 	}
 
-	got, err := pg.GetImageRegistry(ctx, "mirror.example.com")
+	got, err := pg.GetImageRegistry(ctx, "mirror.example.com", "")
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
@@ -70,7 +75,7 @@ func TestImageRegistries_CreateGetUpdateDelete(t *testing.T) {
 	}
 
 	off := false
-	upd, err := pg.UpdateImageRegistry(ctx, "mirror.example.com",
+	upd, err := pg.UpdateImageRegistry(ctx, "mirror.example.com", "",
 		api.ImageRegistryPatch{Enabled: &off})
 	if err != nil {
 		t.Fatalf("update: %v", err)
@@ -79,11 +84,112 @@ func TestImageRegistries_CreateGetUpdateDelete(t *testing.T) {
 		t.Fatalf("expected disabled after patch")
 	}
 
-	if err := pg.DeleteImageRegistry(ctx, "mirror.example.com"); err != nil {
+	if err := pg.DeleteImageRegistry(ctx, "mirror.example.com", ""); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
-	if _, err := pg.GetImageRegistry(ctx, "mirror.example.com"); !errors.Is(err, api.ErrNotFound) {
+	if _, err := pg.GetImageRegistry(ctx, "mirror.example.com", ""); !errors.Is(err, api.ErrNotFound) {
 		t.Fatalf("expected ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestPG_ImageRegistries_FindMirrorForRef(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	t.Cleanup(func() {
+		_, _ = pg.pool.Exec(context.Background(),
+			"DELETE FROM image_versions_registries WHERE hostname = 'ma-registry.io'")
+	})
+
+	_, err := pg.CreateImageRegistry(ctx, api.ImageRegistryUpsert{
+		Hostname: "ma-registry.io", PathPrefix: "container/", RateLimitPerSec: 2.0,
+		IsMirror: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = pg.CreateImageRegistry(ctx, api.ImageRegistryUpsert{
+		Hostname: "ma-registry.io", PathPrefix: "container/special/", RateLimitPerSec: 2.0,
+		IsMirror: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name, hostname, imagePath, wantPrefix string
+		wantErr                               error
+	}{
+		{"longest-prefix wins", "ma-registry.io", "container/special/x/nginx", "container/special/", nil},
+		{"parent prefix", "ma-registry.io", "container/library/nginx", "container/", nil},
+		{"no match (host)", "other.io", "container/library/nginx", "", api.ErrNotFound},
+		{"no match (prefix)", "ma-registry.io", "external/library/nginx", "", api.ErrNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := pg.FindMirrorForRef(ctx, tc.hostname, tc.imagePath)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("err=%v want=%v", err, tc.wantErr)
+			}
+			if err == nil && got.PathPrefix != tc.wantPrefix {
+				t.Fatalf("prefix=%q want=%q", got.PathPrefix, tc.wantPrefix)
+			}
+		})
+	}
+}
+
+func TestPG_ImageRegistries_TokenRoundTrip(t *testing.T) {
+	pg := newTestPG(t)
+	ctx := context.Background()
+
+	// Wire an encrypter for this test.
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	enc, err := secretsNewEncrypter(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pg.SetEncrypter(enc)
+
+	t.Cleanup(func() {
+		_, _ = pg.pool.Exec(context.Background(),
+			"DELETE FROM image_versions_registries WHERE hostname = 'token.example.com'")
+	})
+
+	user := "robot$lv"
+	secret := "s3cr3t-token"
+	_, err = pg.CreateImageRegistry(ctx, api.ImageRegistryUpsert{
+		Hostname: "token.example.com", PathPrefix: "container/", RateLimitPerSec: 2.0,
+		IsMirror: true, AuthUsername: &user, AuthToken: &secret,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := pg.GetMirrorAuthToken(ctx, "token.example.com", "container/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != secret {
+		t.Fatalf("token=%q want=%q", got, secret)
+	}
+
+	// AAD binding: replaying ciphertext under a different prefix MUST fail.
+	var ct []byte
+	if err := pg.Pool().QueryRow(ctx,
+		`SELECT auth_token_ciphertext FROM image_versions_registries
+		 WHERE hostname=$1 AND path_prefix=$2`,
+		"token.example.com", "container/").Scan(&ct); err != nil {
+		t.Fatal(err)
+	}
+	packed, err := unpackCiphertext(ct, pg.Encrypter().NonceSize())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pg.Encrypter().Decrypt(packed, aadForImageRegistry("token.example.com", "other/")); err == nil {
+		t.Fatal("expected decrypt to fail with mismatched AAD")
 	}
 }
 

--- a/migrations/00043_mirror_image_registries.sql
+++ b/migrations/00043_mirror_image_registries.sql
@@ -1,0 +1,29 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE image_versions_registries
+  ADD COLUMN path_prefix           TEXT    NOT NULL DEFAULT '',
+  ADD COLUMN is_mirror             BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN auth_username         TEXT,
+  ADD COLUMN auth_token_ciphertext BYTEA;
+
+ALTER TABLE image_versions_registries DROP CONSTRAINT image_versions_registries_pkey;
+ALTER TABLE image_versions_registries
+  ADD PRIMARY KEY (hostname, path_prefix);
+
+ALTER TABLE image_versions_registries
+  ADD CONSTRAINT image_versions_registries_token_requires_username
+    CHECK (auth_token_ciphertext IS NULL OR auth_username IS NOT NULL);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE image_versions_registries
+  DROP CONSTRAINT image_versions_registries_token_requires_username;
+ALTER TABLE image_versions_registries DROP CONSTRAINT image_versions_registries_pkey;
+ALTER TABLE image_versions_registries ADD PRIMARY KEY (hostname);
+ALTER TABLE image_versions_registries
+  DROP COLUMN auth_token_ciphertext,
+  DROP COLUMN auth_username,
+  DROP COLUMN is_mirror,
+  DROP COLUMN path_prefix;
+-- +goose StatementEnd

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1083,24 +1083,45 @@ export function refreshImageVersions() {
 
 export interface ImageRegistry {
   hostname: string;
+  path_prefix: string;
   rate_limit_per_sec: number;
   enabled: boolean;
   notes: string | null;
+  is_mirror: boolean;
+  auth_username: string | null;
+  auth_configured: boolean;
   created_at: string;
   updated_at: string;
 }
 
 export interface ImageRegistryCreate {
   hostname: string;
+  path_prefix?: string;
   rate_limit_per_sec: number;
   enabled?: boolean;
   notes?: string;
+  is_mirror?: boolean;
+  auth_username?: string;
+  auth_token?: string;
 }
 
 export interface ImageRegistryPatch {
   rate_limit_per_sec?: number;
   enabled?: boolean;
   notes?: string | null;
+  is_mirror?: boolean;
+  auth_username?: string | null;
+  auth_token?: string;
+}
+
+export interface ImageRegistryCredentials {
+  auth_username: string;
+  auth_token: string;
+}
+
+// pathPrefixSegment maps the empty prefix to the "_root" sentinel used in URLs.
+function pathPrefixSegment(prefix: string): string {
+  return prefix === '' ? '_root' : encodeURIComponent(prefix);
 }
 
 export function listImageRegistries() {
@@ -1114,9 +1135,13 @@ export function createImageRegistry(in_: ImageRegistryCreate) {
   });
 }
 
-export function updateImageRegistry(hostname: string, patch: ImageRegistryPatch) {
+export function updateImageRegistry(
+  hostname: string,
+  pathPrefix: string,
+  patch: ImageRegistryPatch,
+) {
   return request<ImageRegistry>(
-    `/v1/admin/image-versions/registries/${encodeURIComponent(hostname)}`,
+    `/v1/admin/image-versions/registries/${encodeURIComponent(hostname)}/${pathPrefixSegment(pathPrefix)}`,
     {
       method: 'PATCH',
       body: JSON.stringify(patch),
@@ -1124,10 +1149,16 @@ export function updateImageRegistry(hostname: string, patch: ImageRegistryPatch)
   );
 }
 
-export function deleteImageRegistry(hostname: string) {
+export function deleteImageRegistry(hostname: string, pathPrefix: string) {
   return request<void>(
-    `/v1/admin/image-versions/registries/${encodeURIComponent(hostname)}`,
+    `/v1/admin/image-versions/registries/${encodeURIComponent(hostname)}/${pathPrefixSegment(pathPrefix)}`,
     { method: 'DELETE' },
+  );
+}
+
+export function getImageRegistryCredentials(hostname: string, pathPrefix: string) {
+  return request<ImageRegistryCredentials>(
+    `/v1/admin/image-versions/registries/${encodeURIComponent(hostname)}/${pathPrefixSegment(pathPrefix)}/credentials`,
   );
 }
 

--- a/ui/src/pages/admin/ImageRegistries.tsx
+++ b/ui/src/pages/admin/ImageRegistries.tsx
@@ -3,9 +3,8 @@ import * as api from '../../api';
 import { useResource } from '../../hooks';
 import { AsyncView, SectionTitle } from '../../components';
 
-// ImageRegistriesPage — admin tab for managing image registry poll targets.
-// Shape mirrors other admin list pages: list with inline create form,
-// per-row enable/disable toggle and delete.
+// ImageRegistriesPage — admin tab for managing image registry poll targets
+// and Harbor-style mirror rows (ADR-0026).
 
 type Reload = () => void;
 
@@ -27,6 +26,8 @@ export default function ImageRegistriesPage() {
               <thead>
                 <tr>
                   <th>Hostname</th>
+                  <th>Path prefix</th>
+                  <th>Type</th>
                   <th>Rate limit (req/s)</th>
                   <th>Status</th>
                   <th>Notes</th>
@@ -34,9 +35,19 @@ export default function ImageRegistriesPage() {
                 </tr>
               </thead>
               <tbody>
-                {resp.items.map((r) => (
-                  <RegistryRow key={r.hostname} registry={r} reload={reload} />
-                ))}
+                {[...resp.items]
+                  .sort((a, b) =>
+                    a.hostname === b.hostname
+                      ? a.path_prefix.localeCompare(b.path_prefix)
+                      : a.hostname.localeCompare(b.hostname),
+                  )
+                  .map((r) => (
+                    <RegistryRow
+                      key={`${r.hostname}|${r.path_prefix}`}
+                      registry={r}
+                      reload={reload}
+                    />
+                  ))}
               </tbody>
             </table>
           )}
@@ -49,15 +60,23 @@ export default function ImageRegistriesPage() {
 function CreateForm({ reload }: { reload: Reload }) {
   const [open, setOpen] = useState(false);
   const [hostname, setHostname] = useState('');
+  const [pathPrefix, setPathPrefix] = useState('');
+  const [isMirror, setIsMirror] = useState(false);
   const [rate, setRate] = useState('5');
   const [notes, setNotes] = useState('');
+  const [authUser, setAuthUser] = useState('');
+  const [authToken, setAuthToken] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const reset = () => {
     setHostname('');
+    setPathPrefix('');
+    setIsMirror(false);
     setRate('5');
     setNotes('');
+    setAuthUser('');
+    setAuthToken('');
     setError(null);
   };
 
@@ -77,8 +96,12 @@ function CreateForm({ reload }: { reload: Reload }) {
     try {
       await api.createImageRegistry({
         hostname: hostname.trim(),
+        path_prefix: isMirror ? pathPrefix.trim() : '',
         rate_limit_per_sec: rateNum,
         notes: notes.trim() || undefined,
+        is_mirror: isMirror,
+        auth_username: isMirror && authUser.trim() ? authUser.trim() : undefined,
+        auth_token: isMirror && authToken !== '' ? authToken : undefined,
       });
       reset();
       setOpen(false);
@@ -105,7 +128,8 @@ function CreateForm({ reload }: { reload: Reload }) {
       <h3>Add registry</h3>
       <p className="muted" style={{ marginTop: 0, fontSize: 'var(--fs-base)' }}>
         Wildcards like <code>*.example.com</code> match any subdomain. Use{' '}
-        <code>docker.io</code> for Docker Hub.
+        <code>docker.io</code> for Docker Hub. Mark as a mirror when this row points
+        at a Harbor-style replication target.
       </p>
       <div className="admin-form-row">
         <div>
@@ -128,6 +152,47 @@ function CreateForm({ reload }: { reload: Reload }) {
           />
         </div>
         <div>
+          <label>
+            <input
+              type="checkbox"
+              checked={isMirror}
+              onChange={(e) => setIsMirror(e.target.checked)}
+            />{' '}
+            Mirror registry
+          </label>
+        </div>
+      </div>
+      {isMirror && (
+        <div className="admin-form-row">
+          <div>
+            <label>Path prefix</label>
+            <input
+              value={pathPrefix}
+              onChange={(e) => setPathPrefix(e.target.value)}
+              placeholder="container/"
+            />
+          </div>
+          <div>
+            <label>Auth username</label>
+            <input
+              value={authUser}
+              onChange={(e) => setAuthUser(e.target.value)}
+              placeholder="robot$lv"
+            />
+          </div>
+          <div>
+            <label>Auth token</label>
+            <input
+              type="password"
+              value={authToken}
+              onChange={(e) => setAuthToken(e.target.value)}
+              autoComplete="new-password"
+            />
+          </div>
+        </div>
+      )}
+      <div className="admin-form-row">
+        <div style={{ flex: 1 }}>
           <label>Notes (optional)</label>
           <input
             value={notes}
@@ -158,11 +223,14 @@ function CreateForm({ reload }: { reload: Reload }) {
 
 function RegistryRow({ registry, reload }: { registry: api.ImageRegistry; reload: Reload }) {
   const [busy, setBusy] = useState(false);
+  const [revealed, setRevealed] = useState<api.ImageRegistryCredentials | null>(null);
 
   const onToggleEnabled = async () => {
     setBusy(true);
     try {
-      await api.updateImageRegistry(registry.hostname, { enabled: !registry.enabled });
+      await api.updateImageRegistry(registry.hostname, registry.path_prefix, {
+        enabled: !registry.enabled,
+      });
       reload();
     } catch (err) {
       alert(err instanceof api.ApiError ? err.message : String(err));
@@ -172,11 +240,29 @@ function RegistryRow({ registry, reload }: { registry: api.ImageRegistry; reload
   };
 
   const onDelete = async () => {
-    if (!confirm(`Delete registry "${registry.hostname}"?`)) return;
+    const label = registry.path_prefix
+      ? `${registry.hostname}/${registry.path_prefix}`
+      : registry.hostname;
+    if (!confirm(`Delete registry "${label}"?`)) return;
     setBusy(true);
     try {
-      await api.deleteImageRegistry(registry.hostname);
+      await api.deleteImageRegistry(registry.hostname, registry.path_prefix);
       reload();
+    } catch (err) {
+      alert(err instanceof api.ApiError ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onReveal = async () => {
+    setBusy(true);
+    try {
+      const creds = await api.getImageRegistryCredentials(
+        registry.hostname,
+        registry.path_prefix,
+      );
+      setRevealed(creds);
     } catch (err) {
       alert(err instanceof api.ApiError ? err.message : String(err));
     } finally {
@@ -189,6 +275,17 @@ function RegistryRow({ registry, reload }: { registry: api.ImageRegistry; reload
       <td>
         <code>{registry.hostname}</code>
       </td>
+      <td>
+        <code>{registry.path_prefix || '—'}</code>
+      </td>
+      <td>
+        <span className={`pill ${registry.is_mirror ? 'status-warn' : 'status-ok'}`}>
+          {registry.is_mirror ? 'Mirror' : 'Source'}
+        </span>
+        {registry.is_mirror && registry.auth_configured && (
+          <span className="pill" style={{ marginLeft: '0.25rem' }}>auth</span>
+        )}
+      </td>
       <td>{registry.rate_limit_per_sec}</td>
       <td>
         <span className={`pill ${registry.enabled ? 'status-ok' : ''}`}>
@@ -199,6 +296,13 @@ function RegistryRow({ registry, reload }: { registry: api.ImageRegistry; reload
         {registry.notes ?? ''}
       </td>
       <td style={{ textAlign: 'right' }}>
+        {registry.is_mirror && registry.auth_configured && (
+          <>
+            <button onClick={onReveal} disabled={busy}>
+              {revealed ? 'Hide' : 'Reveal'}
+            </button>{' '}
+          </>
+        )}
         {registry.enabled ? (
           <button onClick={onToggleEnabled} disabled={busy}>
             Disable
@@ -211,6 +315,16 @@ function RegistryRow({ registry, reload }: { registry: api.ImageRegistry; reload
         <button onClick={onDelete} disabled={busy} className="danger">
           Delete
         </button>
+        {revealed && (
+          <div className="muted" style={{ marginTop: '0.5rem', fontSize: 'var(--fs-sm)' }}>
+            <div>
+              <strong>user:</strong> <code>{revealed.auth_username}</code>
+            </div>
+            <div>
+              <strong>token:</strong> <code>{revealed.auth_token}</code>
+            </div>
+          </div>
+        )}
       </td>
     </tr>
   );


### PR DESCRIPTION
  ## Summary
  - New `internal/imageversions/mirrorresolve` package resolves mirrored
    container refs (e.g. Harbor with replication) back to their public
    origin by reading OCI manifest annotations (`base.name` / `source`).
  - Migration `00043` extends `image_versions_registries` with a composite
    PK `(hostname, path_prefix)`, plus `is_mirror`, encrypted robot-account
    credentials (AAD bound to PK per ADR-0015 §4).
  - New admin-only, audit-logged credentials reveal endpoint mirrors the
    `cloud_accounts.credentials` pattern.
  - Documented in ADR-0026.
  
  ## Test plan
  - [x] Wait for CI: `lint, vet, build, test`, `helm lint`, `docker build`,
        `govulncheck`, `gosec`, `gitleaks`, `trivy fs/config/image`,
        conventional-commit lint.
  - [x] Verify the resolver via the integration test:
        `make test-one TEST=TestImageVersions_Integration`.
  - [x] Smoke-test the credentials endpoint with admin auth:
        `GET /v1/admin/image-versions/registries/{host}/{prefix}/credentials`.