### PR TITLE
fix(mirrorresolve): passthrough unparseable refs instead of erroring

### DIFF
--- a/internal/imageversions/mirrorresolve/resolver.go
+++ b/internal/imageversions/mirrorresolve/resolver.go
@@ -107,8 +107,15 @@ func (h *HTTPResolver) Resolve(ctx context.Context, ref string) (string, error) 
 
 	hostname, imagePath, tag, err := splitRef(ref)
 	if err != nil {
-		h.observe("parse_error", started)
-		return "", err
+		// Ref that lacks the host/path shape (bare digest like
+		// sha256:abc…, Docker Hub library shortcut like "nginx" or
+		// "debian:latest", etc.) is by definition not a mirror ref.
+		// Pass it through unchanged so the public-registry enricher
+		// path can parse and route it normally — refusing here would
+		// drop the image from version tracking entirely.
+		h.observe("passthrough", started)
+		//nolint:nilerr // intentional: unparseable refs are passed through to downstream parsing
+		return ref, nil
 	}
 
 	row, ok, err := h.Lookup.FindMirror(ctx, hostname, imagePath)

--- a/internal/imageversions/mirrorresolve/resolver_test.go
+++ b/internal/imageversions/mirrorresolve/resolver_test.go
@@ -116,6 +116,31 @@ func TestHTTPResolver_Passthrough_NoMirror(t *testing.T) {
 	}
 }
 
+// TestHTTPResolver_Passthrough_UnparseableRef covers the regression where
+// refs that lack the host/path shape (bare digests, Docker Hub library
+// shortcuts) were being WARN-logged and dropped from the enricher entirely
+// instead of flowing through to ParseImageRef. See ADR-0026 follow-up.
+func TestHTTPResolver_Passthrough_UnparseableRef(t *testing.T) {
+	cases := []struct{ name, ref string }{
+		{"bare digest", "sha256:e792110c581423bf8ec4d8476bca3658810a24a9437f6f8ff24cdeafd9521dbd"},
+		{"library shortcut with tag", "nginx:1.25"},
+		{"library shortcut no tag", "busybox"},
+		{"namespaced library", "python:3.11-slim"},
+	}
+	r := &HTTPResolver{Lookup: fakeLookup{ok: false}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := r.Resolve(context.Background(), tc.ref)
+			if err != nil {
+				t.Fatalf("expected passthrough, got error: %v", err)
+			}
+			if got != tc.ref {
+				t.Fatalf("got=%q, want unchanged %q", got, tc.ref)
+			}
+		})
+	}
+}
+
 func TestHTTPResolver_AuthError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)


### PR DESCRIPTION
ADR-0026 introduced a regression: any image ref that splitRef could not parse (bare digests like sha256:abc…, Docker Hub library shortcuts like 'nginx' or 'debian:latest') was surfaced as an error from Resolve. The enricher then WARN-logged it and dropped the image entirely, before ParseImageRef had a chance to normalize it.

Production v0.24.0 shows the impact: 958 refs discovered per tick, only 68 processed; mirror_resolve_total{result=parse_error}=34 and 17+ WARN lines per tick for common images that used to be tracked.

These refs are by definition not mirror refs (no host/path shape), so the right behavior is passthrough — return the ref unchanged so the public-registry path can handle it. The result label changes from 'parse_error' to 'passthrough' for these inputs, which also stops the noisy WARN log.