### PR TITLE
docs(adr): normalize ADR header format across all 28 records

### DIFF
--- a/docs/adr/adr-0001-cmdb-for-snc-using-kube.md
+++ b/docs/adr/adr-0001-cmdb-for-snc-using-kube.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0001: CMDB for SNC using Kubernetes"
 status: "Accepted"
@@ -17,6 +13,10 @@ superseded_by: ""
 ## Status
 
 Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-04-18
+- **Supersedes:** none
+- **Superseded by:** none
 
 ## Context
 

--- a/docs/adr/adr-0002-kubernetes-to-anssi-cartography-layers.md
+++ b/docs/adr/adr-0002-kubernetes-to-anssi-cartography-layers.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0002: Kubernetes-to-ANSSI cartography layer mapping"
 status: "Accepted"
@@ -17,6 +13,10 @@ superseded_by: ""
 ## Status
 
 Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-04-18
+- **Supersedes:** none
+- **Superseded by:** none
 
 ## Context
 

--- a/docs/adr/adr-0003-workload-polymorphism.md
+++ b/docs/adr/adr-0003-workload-polymorphism.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0003: Workload polymorphism — one table with a kind discriminator"
 status: "Accepted"
@@ -17,6 +13,10 @@ superseded_by: ""
 ## Status
 
 Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-04-18
+- **Supersedes:** none
+- **Superseded by:** none
 
 ## Context
 

--- a/docs/adr/adr-0004-ingress-layer-classification.md
+++ b/docs/adr/adr-0004-ingress-layer-classification.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0004: Ingress layer classification — applicative, with future ecosystem linkage"
 status: "Accepted"
@@ -17,6 +13,10 @@ superseded_by: ""
 ## Status
 
 Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-04-18
+- **Supersedes:** none
+- **Superseded by:** none
 
 ## Context
 

--- a/docs/adr/adr-0005-multi-cluster-collector.md
+++ b/docs/adr/adr-0005-multi-cluster-collector.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0005: Multi-cluster collector topology"
 status: "Accepted"
@@ -17,6 +13,10 @@ superseded_by: ""
 ## Status
 
 Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-04-18
+- **Supersedes:** none
+- **Superseded by:** none
 
 ## Context
 

--- a/docs/adr/adr-0006-ui-for-audit-and-curated-metadata.md
+++ b/docs/adr/adr-0006-ui-for-audit-and-curated-metadata.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0006: Web UI for audit and curated asset metadata"
 status: "Accepted"
@@ -17,6 +13,10 @@ superseded_by: ""
 ## Status
 
 Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-04-18
+- **Supersedes:** none
+- **Superseded by:** none
 
 ## Context
 

--- a/docs/adr/adr-0007-auth-and-rbac.md
+++ b/docs/adr/adr-0007-auth-and-rbac.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0007: Human authentication, roles, and admin-issued machine tokens"
 status: "Accepted"
@@ -17,6 +13,10 @@ superseded_by: ""
 ## Status
 
 Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-04-19
+- **Supersedes:** none
+- **Superseded by:** none
 
 ## Context
 

--- a/docs/adr/adr-0008-secnumcloud-chapter-8-asset-management.md
+++ b/docs/adr/adr-0008-secnumcloud-chapter-8-asset-management.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0008: Asset-management data model for SecNumCloud v3.2 chapter 8"
 status: "Accepted"
@@ -16,7 +12,11 @@ superseded_by: ""
 
 ## Status
 
-**Accepted**
+Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-04-20
+- **Supersedes:** none
+- **Superseded by:** none
 
 ## Context
 

--- a/docs/adr/adr-0009-push-collector-for-airgapped-clusters.md
+++ b/docs/adr/adr-0009-push-collector-for-airgapped-clusters.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0009: Push-based collector for air-gapped clusters"
 status: "Accepted"
@@ -17,6 +13,10 @@ superseded_by: ""
 ## Status
 
 Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-04-21
+- **Supersedes:** none
+- **Superseded by:** none
 
 ## Context
 

--- a/docs/adr/adr-0010-admin-only-cluster-deletion-with-audit.md
+++ b/docs/adr/adr-0010-admin-only-cluster-deletion-with-audit.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0010: Admin-only cluster deletion with mandatory audit trail"
 status: "Accepted"
@@ -17,6 +13,10 @@ superseded_by: ""
 ## Status
 
 Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-04-23
+- **Supersedes:** none
+- **Superseded by:** none
 
 ## Context
 

--- a/docs/adr/adr-0011-collector-auto-creates-cluster.md
+++ b/docs/adr/adr-0011-collector-auto-creates-cluster.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0011: Collector auto-creates cluster record on first contact"
 status: "Accepted"
@@ -17,6 +13,10 @@ superseded_by: ""
 ## Status
 
 Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-04-24
+- **Supersedes:** none
+- **Superseded by:** none
 
 ## Context
 

--- a/docs/adr/adr-0012-eol-enrichment-via-endoflife-date.md
+++ b/docs/adr/adr-0012-eol-enrichment-via-endoflife-date.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0012: End-of-life enrichment via endoflife.date"
 status: "Accepted"
@@ -17,6 +13,10 @@ superseded_by: ""
 ## Status
 
 Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-04-24
+- **Supersedes:** none
+- **Superseded by:** none
 
 ## Context
 

--- a/docs/adr/adr-0013-impact-analysis-graph.md
+++ b/docs/adr/adr-0013-impact-analysis-graph.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0013: Impact analysis graph"
 status: "Accepted"
@@ -17,6 +13,10 @@ superseded_by: ""
 ## Status
 
 Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-04-24
+- **Supersedes:** none
+- **Superseded by:** none
 
 ## Context
 

--- a/docs/adr/adr-0014-mcp-server.md
+++ b/docs/adr/adr-0014-mcp-server.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0014: MCP server for AI-driven CMDB queries"
 status: "Accepted"
@@ -17,6 +13,10 @@ superseded_by: ""
 ## Status
 
 Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-04-25
+- **Supersedes:** none
+- **Superseded by:** none
 
 ## Context
 

--- a/docs/adr/adr-0015-vm-collector-for-non-kubernetes-platform-vms.md
+++ b/docs/adr/adr-0015-vm-collector-for-non-kubernetes-platform-vms.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0015: VM collector for non-Kubernetes platform infrastructure"
 status: "Accepted"
@@ -17,6 +13,10 @@ superseded_by: ""
 ## Status
 
 Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-04-26
+- **Supersedes:** none
+- **Superseded by:** none
 
 ## Context
 

--- a/docs/adr/adr-0016-dmz-ingest-gateway.md
+++ b/docs/adr/adr-0016-dmz-ingest-gateway.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0016: DMZ ingest gateway for collector push traffic"
 status: "Accepted"
@@ -17,6 +13,10 @@ superseded_by: ""
 ## Status
 
 Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-04-28
+- **Supersedes:** none
+- **Superseded by:** none
 
 ## Context
 

--- a/docs/adr/adr-0017-public-listener-tls-posture-and-proxy-trust.md
+++ b/docs/adr/adr-0017-public-listener-tls-posture-and-proxy-trust.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0017: Public listener TLS posture and proxy trust model"
 status: "Accepted"
@@ -17,6 +13,10 @@ superseded_by: ""
 ## Status
 
 Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-04-29
+- **Supersedes:** none
+- **Superseded by:** none
 
 ## Context
 

--- a/docs/adr/adr-0018-helm-chart-per-deployable-binary.md
+++ b/docs/adr/adr-0018-helm-chart-per-deployable-binary.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0018: Helm chart per deployable binary"
 status: "Accepted"
@@ -17,6 +13,10 @@ superseded_by: ""
 ## Status
 
 Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-04-29
+- **Supersedes:** none
+- **Superseded by:** none
 
 ## Context
 

--- a/docs/adr/adr-0019-vm-applications-and-eol-and-search.md
+++ b/docs/adr/adr-0019-vm-applications-and-eol-and-search.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0019: VM applications inventory, EOL enrichment for platform software, and VM list search filters"
 status: "Accepted"
@@ -17,6 +13,10 @@ superseded_by: ""
 ## Status
 
 Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-04-29
+- **Supersedes:** none
+- **Superseded by:** none
 
 ## Context
 

--- a/docs/adr/adr-0020-rename-argos-to-longue-vue.md
+++ b/docs/adr/adr-0020-rename-argos-to-longue-vue.md
@@ -1,7 +1,3 @@
-<div align="center"><img src="../logo.svg" alt="longue-vue" height="38" /></div>
-
----
-
 ---
 title: "ADR-0020: Rename product Argos to longue-vue"
 status: "Accepted"
@@ -12,7 +8,7 @@ supersedes: ""
 superseded_by: ""
 ---
 
-# ADR-0020 — Rename product "Argos" to "longue-vue"
+# ADR-0020: Rename product "Argos" to "longue-vue"
 
 ## Status
 


### PR DESCRIPTION
Align ADRs 0001-0020 with the canonical format established by recent
ADRs (0021-0028) for a consistent, professional presentation in the
open-source repo:

- Drop the leading logo div and stray divider above the YAML frontmatter
  so each file begins directly with the frontmatter block
- Add the standard "Date / Supersedes / Superseded by" bullets under
  the Status enumeration line on ADRs that lacked them
- Replace ADR-0008's truncated `**Accepted**` status with the full
  enumeration line + bullets
- Fix ADR-0020's title separator from em-dash to colon to match the
  rest of the series

Pure formatting; no ADR body content was modified.