### PR TITLE
fix(ui): walk cursor on list pages so rows past page 1 are visible

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -696,7 +696,7 @@ export function deleteCluster(id: string) {
   return request<void>(`/v1/clusters/${id}`, { method: 'DELETE' });
 }
 
-export function listNodes(filter?: { cluster_id?: string }) {
+export function listNodes(filter?: { cluster_id?: string; cursor?: string; limit?: number }) {
   return request<PagedResponse<Node>>('/v1/nodes' + query({ limit: 200, ...filter }));
 }
 export function getNode(id: string) {
@@ -728,6 +728,8 @@ export function listPods(filter?: {
   node_name?: string;
   workload_id?: string;
   image?: string;
+  cursor?: string;
+  limit?: number;
 }) {
   return request<PagedResponse<Pod>>('/v1/pods' + query({ limit: 200, ...filter }));
 }
@@ -735,21 +737,21 @@ export function getPod(id: string) {
   return request<Pod>(`/v1/pods/${id}`);
 }
 
-export function listServices(filter?: { namespace_id?: string }) {
+export function listServices(filter?: { namespace_id?: string; cursor?: string; limit?: number }) {
   return request<PagedResponse<Service>>('/v1/services' + query({ limit: 200, ...filter }));
 }
 export function getService(id: string) {
   return request<Service>(`/v1/services/${id}`);
 }
 
-export function listIngresses(filter?: { namespace_id?: string }) {
+export function listIngresses(filter?: { namespace_id?: string; cursor?: string; limit?: number }) {
   return request<PagedResponse<Ingress>>('/v1/ingresses' + query({ limit: 200, ...filter }));
 }
 export function getIngress(id: string) {
   return request<Ingress>(`/v1/ingresses/${id}`);
 }
 
-export function listPersistentVolumes(filter?: { cluster_id?: string }) {
+export function listPersistentVolumes(filter?: { cluster_id?: string; cursor?: string; limit?: number }) {
   return request<PagedResponse<PersistentVolume>>(
     '/v1/persistentvolumes' + query({ limit: 200, ...filter }),
   );
@@ -758,7 +760,7 @@ export function getPersistentVolume(id: string) {
   return request<PersistentVolume>(`/v1/persistentvolumes/${id}`);
 }
 
-export function listPersistentVolumeClaims(filter?: { namespace_id?: string }) {
+export function listPersistentVolumeClaims(filter?: { namespace_id?: string; cursor?: string; limit?: number }) {
   return request<PagedResponse<PersistentVolumeClaim>>(
     '/v1/persistentvolumeclaims' + query({ limit: 200, ...filter }),
   );
@@ -1037,6 +1039,8 @@ export interface VirtualMachineListFilter {
   image?: string;
   application?: string;
   application_version?: string;
+  cursor?: string;
+  limit?: number;
 }
 
 // VirtualMachinePatch is the merge-patch shape posted to PATCH
@@ -1063,7 +1067,8 @@ export function listVirtualMachines(filter: VirtualMachineListFilter = {}) {
   return request<PagedResponse<VirtualMachine>>(
     '/v1/virtual-machines' +
       query({
-        limit: 200,
+        limit: filter.limit ?? 200,
+        cursor: filter.cursor,
         cloud_account_id: filter.cloud_account_id,
         cloud_account_name: filter.cloud_account_name,
         region: filter.region,

--- a/ui/src/lib/paginate.ts
+++ b/ui/src/lib/paginate.ts
@@ -1,0 +1,20 @@
+// Walk the server's cursor pagination until exhausted and return every
+// item. List pages render a single table without per-page navigation, so
+// the UI must aggregate all pages itself — a single first-page call
+// silently hides rows beyond the server's default page size.
+
+import type { PagedResponse } from '../api';
+
+export async function fetchAllPages<T>(
+  fetchPage: (cursor?: string) => Promise<PagedResponse<T>>,
+): Promise<{ items: T[] }> {
+  const items: T[] = [];
+  let cursor: string | undefined = undefined;
+  for (let i = 0; i < 1000; i++) {
+    const page = await fetchPage(cursor);
+    items.push(...page.items);
+    if (!page.next_cursor) break;
+    cursor = page.next_cursor;
+  }
+  return { items };
+}

--- a/ui/src/pages/Lists.tsx
+++ b/ui/src/pages/Lists.tsx
@@ -6,6 +6,7 @@
 import { Link } from 'react-router-dom';
 import * as api from '../api';
 import { useResource } from '../hooks';
+import { fetchAllPages } from '../lib/paginate';
 import { AsyncView, Dash, IdLink, LayerPill, LoadBalancerAddresses, Empty, NamespaceLink } from '../components';
 import { useEntityTable } from '../components/column_filters';
 import {
@@ -14,7 +15,10 @@ import {
 } from '../icons';
 
 export function Clusters() {
-  const state = useResource(() => api.listClusters(), []);
+  const state = useResource(
+    () => fetchAllPages((cursor) => api.listClusters({ cursor, limit: 500 })),
+    [],
+  );
   const tableRef = useEntityTable('lists.clusters');
   return (
     <>
@@ -69,7 +73,10 @@ export function Clusters() {
 export function Nodes() {
   const state = useResource(
     () =>
-      Promise.all([api.listNodes(), fetchAllClusters()]).then(([nodes, clItems]) => ({
+      Promise.all([
+        fetchAllPages((cursor) => api.listNodes({ cursor, limit: 500 })),
+        fetchAllClusters(),
+      ]).then(([nodes, clItems]) => ({
         nodes: nodes.items,
         clustersById: new Map(clItems.map((c) => [c.id, c])),
       })),
@@ -156,7 +163,10 @@ function NodeStatusBadge({
 }
 
 export function Namespaces() {
-  const namespaces = useResource(() => api.listNamespaces(), []);
+  const namespaces = useResource(
+    () => fetchAllPages((cursor) => api.listNamespaces({ cursor, limit: 500 })),
+    [],
+  );
   const tableRef = useEntityTable('lists.namespaces');
   return (
     <>
@@ -203,24 +213,14 @@ export function Namespaces() {
 
 // Shared helper: fetch namespaces + clusters so a list of namespace-scoped
 // rows can show "cluster / namespace" breadcrumbs without per-row calls.
-async function fetchAllPaged<T>(
-  fetchPage: (cursor?: string) => Promise<api.PagedResponse<T>>,
-): Promise<T[]> {
-  const out: T[] = [];
-  let cursor: string | undefined = undefined;
-  for (let i = 0; i < 200; i++) {
-    const page = await fetchPage(cursor);
-    out.push(...page.items);
-    if (!page.next_cursor) break;
-    cursor = page.next_cursor;
-  }
-  return out;
-}
-
-const fetchAllClusters = () => fetchAllPaged((cursor) => api.listClusters({ cursor, limit: 500 }));
+const fetchAllClusters = () =>
+  fetchAllPages((cursor) => api.listClusters({ cursor, limit: 500 })).then((r) => r.items);
 
 export function Workloads() {
-  const workloads = useResource(() => api.listWorkloads(), []);
+  const workloads = useResource(
+    () => fetchAllPages((cursor) => api.listWorkloads({ cursor, limit: 500 })),
+    [],
+  );
   const tableRef = useEntityTable('lists.workloads');
 
   return (
@@ -283,7 +283,10 @@ export function Workloads() {
 }
 
 export function Pods() {
-  const pods = useResource(() => api.listPods(), []);
+  const pods = useResource(
+    () => fetchAllPages((cursor) => api.listPods({ cursor, limit: 500 })),
+    [],
+  );
   const tableRef = useEntityTable('lists.pods');
   return (
     <>
@@ -346,7 +349,10 @@ export function Pods() {
 }
 
 export function Services() {
-  const services = useResource(() => api.listServices(), []);
+  const services = useResource(
+    () => fetchAllPages((cursor) => api.listServices({ cursor, limit: 500 })),
+    [],
+  );
   const tableRef = useEntityTable('lists.services');
   return (
     <>
@@ -407,7 +413,10 @@ export function Services() {
 }
 
 export function Ingresses() {
-  const ingresses = useResource(() => api.listIngresses(), []);
+  const ingresses = useResource(
+    () => fetchAllPages((cursor) => api.listIngresses({ cursor, limit: 500 })),
+    [],
+  );
   const tableRef = useEntityTable('lists.ingresses');
   return (
     <>
@@ -468,9 +477,12 @@ export function Ingresses() {
 export function PersistentVolumes() {
   const state = useResource(
     () =>
-      Promise.all([api.listPersistentVolumes(), api.listClusters()]).then(([pvs, clusters]) => ({
+      Promise.all([
+        fetchAllPages((cursor) => api.listPersistentVolumes({ cursor, limit: 500 })),
+        fetchAllClusters(),
+      ]).then(([pvs, clItems]) => ({
         pvs: pvs.items,
-        clustersById: new Map(clusters.items.map((c) => [c.id, c])),
+        clustersById: new Map(clItems.map((c) => [c.id, c])),
       })),
     [],
   );
@@ -530,7 +542,10 @@ export function PersistentVolumes() {
 }
 
 export function PersistentVolumeClaims() {
-  const pvcs = useResource(() => api.listPersistentVolumeClaims(), []);
+  const pvcs = useResource(
+    () => fetchAllPages((cursor) => api.listPersistentVolumeClaims({ cursor, limit: 500 })),
+    [],
+  );
   const tableRef = useEntityTable('lists.persistent_volume_claims');
   return (
     <>

--- a/ui/src/pages/VirtualMachines.tsx
+++ b/ui/src/pages/VirtualMachines.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import * as api from '../api';
 import { useResource } from '../hooks';
+import { fetchAllPages } from '../lib/paginate';
 import { isAdmin, useMe } from '../me';
 import { AsyncView, Dash } from '../components';
 import { useEntityTable } from '../components/column_filters';
@@ -188,7 +189,7 @@ export default function VirtualMachines() {
   const appsState = useResource(() => api.listDistinctVMApplications(), []);
 
   const vmsState = useResource(
-    () => api.listVirtualMachines(filter),
+    () => fetchAllPages((cursor) => api.listVirtualMachines({ ...filter, cursor, limit: 500 })),
     [
       cloudAccountId,
       region,
@@ -631,11 +632,6 @@ export default function VirtualMachines() {
                   </tbody>
                 </table>
                 </div>
-              )}
-              {vms.next_cursor && (
-                <p className="muted" style={{ marginTop: '0.75rem' }}>
-                  More results available — refine filters to narrow the page.
-                </p>
               )}
             </>
           );


### PR DESCRIPTION
List pages called listX() once and rendered only the first server page, silently hiding rows beyond limit=200. New fetchAllPages helper walks next_cursor until exhausted; all list pages (clusters, nodes, namespaces, workloads, pods, services, ingresses, PVs, PVCs, VMs) now aggregate every page.