### PR TITLE
fix(ui): show latest_tag instead of behind badge in workload containe…

### DIFF
--- a/ui/src/pages/Details.tsx
+++ b/ui/src/pages/Details.tsx
@@ -871,7 +871,7 @@ export function WorkloadDetail() {
                   <tr>
                     <th>Name</th>
                     <th>Image</th>
-                    <th>Version</th>
+                    <th>Last version</th>
                     <th>Init</th>
                   </tr>
                 </thead>
@@ -887,7 +887,22 @@ export function WorkloadDetail() {
                           <code>{c.image}</code>
                           <OriginLine image={c.image} info={info} />
                         </td>
-                        <td><ContainerVersionBadge info={info ?? undefined} /></td>
+                        <td>
+                          {info?.latest_tag ? (
+                            <code
+                              className={info.is_behind ? 'pill status-bad' : 'pill status-ok'}
+                              title={
+                                info.is_behind
+                                  ? `Behind: latest available is ${info.latest_tag} (checked ${new Date(info.last_checked_at ?? '').toLocaleString()})`
+                                  : `Up to date (checked ${new Date(info.last_checked_at ?? '').toLocaleString()})`
+                              }
+                            >
+                              {info.latest_tag}
+                            </code>
+                          ) : (
+                            <ContainerVersionBadge info={info ?? undefined} />
+                          )}
+                        </td>
                         <td>{c.init ? 'yes' : <Dash />}</td>
                       </tr>
                     )


### PR DESCRIPTION
…rs table

The PodDetail container table was migrated in 1879487 to display the resolved latest_tag as a pill (red when behind, green when up to date), but the WorkloadDetail 'Containers (template)' table was missed and still rendered the legacy ContainerVersionBadge with the opaque '↑ behind' label.