### PR TITLE
feat(imageversions): make manual origin mappings authoritative (ADR-0031)

### DIFF
--- a/docs/adr/adr-0031-manual-mappings-authoritative.md
+++ b/docs/adr/adr-0031-manual-mappings-authoritative.md
@@ -1,0 +1,98 @@
+---
+title: "ADR-0031: Manual image origin mappings become authoritative"
+status: "Accepted"
+date: "2026-05-28"
+authors: "Steve ALBERT"
+tags: ["architecture", "decision", "cmdb", "enrichment", "image-versions", "containers", "mirror", "harbor", "oci"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0031: Manual image origin mappings become authoritative
+
+## Status
+
+Proposed | **Accepted** | Rejected | Superseded | Deprecated
+
+- **Date:** 2026-05-28
+- **Amends:** ADR-0030
+- **Supersedes:** none
+- **Superseded by:** none
+
+## Context
+
+ADR-0030 introduced an operator-curated `image_origin_mappings` table as
+a *tie-breaker* consulted by the mirror resolver only after a successful
+`FindMirror(hostname, imagePath)` lookup. The table fixed the
+"missing_annotation" case but left a class of refs unreachable: pods
+whose `image` field carries a misconfigured hostname (commonly the
+`docker.io/` default, or a public registry such as `quay.io/` or
+`ghcr.io/`) prefixing a path that actually belongs to a private mirror.
+
+A canonical example observed in production:
+
+    docker.io/containers/grafana/alloy:v1.16.1
+
+The cluster's containerd `registry.mirrors` rewrites `docker.io` at pull
+time to a private mirror, so the workload runs correctly. Longue-Vue,
+which only reads the pod spec, sees a literal `docker.io/...` ref. The
+hostname does not match any row in `image_registries`, the FindMirror
+gate misses, and the resolver passes the ref through unchanged. The
+image-versions enricher then normalises it under `docker.io/...` and the
+operator sees a row that no public registry can resolve.
+
+Twenty-one such rows were observed in production after ADR-0030 was
+deployed.
+
+## Decision
+
+The manual mapping table is **authoritative**. The resolver consults it
+*before* the FindMirror gate, by progressive suffix stripping:
+
+1. Try `FindOrigin(imagePath)`.
+2. If miss, strip one leading segment from imagePath and retry.
+3. Repeat until a hit or no slash remains.
+
+On hit, the resolver returns `<public_registry>/<matched_key>:<tag>` and
+emits the existing `ok_manual` metric label. On miss, the resolver
+continues to the existing FindMirror → replica → OCI annotation flow,
+which itself still includes the original post-mirror FindOrigin
+tie-breaker. The OCI flow is unchanged.
+
+`FindOrigin` errors fail open: a transient store error is logged at WARN
+and the resolver falls through to the existing flow. We accept the
+possibility of a one-tick stale resolution over abandoning the whole
+resolve.
+
+## Consequences
+
+### Positive
+
+- Misconfigured refs (`docker.io/containers/...`, `quay.io/<mirror-prefix>/...`,
+  etc.) are rewritten to the curated public registry without requiring
+  Helm chart fixes upstream.
+- No data migration: the 198 mappings already in production immediately
+  match more cases.
+- No new metric label, no new store method, no migration, no
+  configuration knob.
+
+### Negative — accepted
+
+- A legitimate public ref whose name collides with a mapping will be
+  rewritten. For example, with mapping `grafana/loki → docker.io`, a
+  `quay.io/grafana/loki` ref (if one ever existed) would be rewritten
+  to `docker.io/grafana/loki`. Operators must curate the table with
+  this in mind; the CRUD endpoints, audit logging, and admin scope from
+  ADR-0030 remain the safety boundary.
+- Each resolve incurs one DB hit per segment-strip iteration. Image
+  paths are short (typically ≤ 5 segments); the enricher tick runs at
+  most every 24h. No caching added in this iteration. Revisit if
+  `imageversions_mirror_resolve_total{result="ok_manual"}` growth makes
+  the tick observably slower.
+
+### Unchanged
+
+- ADR-0030's table schema, CRUD endpoints, audit rules, and admin
+  scope.
+- ADR-0026 / ADR-0028 OCI annotation and replica chain flow.
+- All existing metric labels.

--- a/internal/imageversions/mirrorresolve/resolver.go
+++ b/internal/imageversions/mirrorresolve/resolver.go
@@ -224,6 +224,8 @@ func (h *HTTPResolver) tryManualMapping(ctx context.Context, imagePath, tag stri
 			}
 			return reg + "/" + candidate, true
 		}
+		// Suffix-match is intentional (ADR-0031): a mapping for "grafana/loki"
+		// rewrites any ref ending with that path. Curate the table accordingly.
 		i := strings.Index(candidate, "/")
 		if i < 0 {
 			return "", false

--- a/internal/imageversions/mirrorresolve/resolver.go
+++ b/internal/imageversions/mirrorresolve/resolver.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -135,6 +136,19 @@ func (h *HTTPResolver) Resolve(ctx context.Context, ref string) (string, error) 
 		return ref, nil
 	}
 
+	// ADR-0031: the operator-curated mapping table is consulted first.
+	// We try FindOrigin on the full imagePath, then strip one leading
+	// segment and retry, until a mapping matches or no slash remains.
+	// First hit wins and short-circuits the mirror lookup. Store errors
+	// are logged and fall through (fail-open) to preserve resolver
+	// availability when the mappings table is transiently unreachable.
+	if h.Origins != nil {
+		if rewritten, matched := h.tryManualMapping(ctx, imagePath, tag); matched {
+			h.observe("ok_manual", started)
+			return rewritten, nil
+		}
+	}
+
 	row, ok, err := h.Lookup.FindMirror(ctx, hostname, imagePath)
 	if err != nil {
 		h.observe("lookup_error", started)
@@ -187,6 +201,35 @@ func (h *HTTPResolver) Resolve(ctx context.Context, ref string) (string, error) 
 	origin, result, err := h.resolveFromMirror(ctx, row, imagePath, tag)
 	h.observe(result, started)
 	return origin, err
+}
+
+// tryManualMapping implements the ADR-0031 pre-mirror lookup. It returns
+// the rewritten ref and matched=true on the first FindOrigin hit while
+// progressively stripping leading segments from imagePath. On any
+// FindOrigin error it logs once and returns matched=false so the caller
+// falls through to the existing mirror/OCI flow.
+func (h *HTTPResolver) tryManualMapping(ctx context.Context, imagePath, tag string) (rewritten string, matched bool) {
+	candidate := imagePath
+	for {
+		reg, ok, err := h.Origins.FindOrigin(ctx, candidate)
+		if err != nil {
+			slog.Warn("mirrorresolve: manual mapping lookup failed",
+				slog.String("candidate", candidate),
+				slog.String("err", err.Error()))
+			return "", false
+		}
+		if ok {
+			if tag != "" {
+				return reg + "/" + candidate + ":" + tag, true
+			}
+			return reg + "/" + candidate, true
+		}
+		i := strings.Index(candidate, "/")
+		if i < 0 {
+			return "", false
+		}
+		candidate = candidate[i+1:]
+	}
 }
 
 // resolveFromMirror fetches the manifest from the mirror, applies the

--- a/internal/imageversions/mirrorresolve/resolver_test.go
+++ b/internal/imageversions/mirrorresolve/resolver_test.go
@@ -303,9 +303,11 @@ func TestResolve_ManualMappingHit(t *testing.T) {
 	}
 }
 
-// When the mirror lookup misses entirely, the OriginLookup MUST NOT be
-// consulted (we only know it's a known image once a mirror row matches).
-// This guards against accidentally short-circuiting passthrough refs.
+// "nginx:latest" has no slash, so splitRef returns ErrInvalidRef and Resolve
+// exits before reaching either the manual-mapping or mirror-lookup paths.
+// The passthrough here is caused by the unparseable ref shape, not by any
+// guarantee that OriginLookup is skipped when no mirror row exists (ADR-0031
+// pre-mirror lookup would consult OriginLookup for a parseable mirrored ref).
 func TestResolve_NoMirrorRow_StillPassthrough(t *testing.T) {
 	r := &HTTPResolver{
 		Lookup:  fakeMirrorLookup{}, // empty: no mirror row

--- a/internal/imageversions/mirrorresolve/resolver_test.go
+++ b/internal/imageversions/mirrorresolve/resolver_test.go
@@ -386,13 +386,15 @@ func TestResolve_ManualMapping_PreMirror_FullPathMatch(t *testing.T) {
 	}
 }
 
+const ghcrIO = "ghcr.io"
+
 // Misconfigured Helm value: hostname is docker.io but the path includes
 // the private mirror's prefix. Strip-and-lookup should peel "containers/"
 // and match the bare "grafana/alloy" mapping.
 func TestResolve_ManualMapping_PreMirror_StripOneSegment(t *testing.T) {
 	r := &HTTPResolver{
 		Lookup:  fakeMirrorLookup{}, // no mirror rows
-		Origins: fakeOriginLookup{"grafana/alloy": "ghcr.io"},
+		Origins: fakeOriginLookup{"grafana/alloy": ghcrIO},
 	}
 	got, err := r.Resolve(context.Background(), "docker.io/containers/grafana/alloy:v1.16.1")
 	if err != nil {
@@ -407,7 +409,7 @@ func TestResolve_ManualMapping_PreMirror_StripOneSegment(t *testing.T) {
 func TestResolve_ManualMapping_PreMirror_StripTwoSegments(t *testing.T) {
 	r := &HTTPResolver{
 		Lookup:  fakeMirrorLookup{},
-		Origins: fakeOriginLookup{"foo/bar": "ghcr.io"},
+		Origins: fakeOriginLookup{"foo/bar": ghcrIO},
 	}
 	got, err := r.Resolve(context.Background(), "mirror.priv/team/containers/foo/bar:1.2.3")
 	if err != nil {
@@ -442,7 +444,7 @@ func TestResolve_ManualMapping_PreMirror_SingleSegment(t *testing.T) {
 func TestResolve_ManualMapping_PreMirror_DigestOnly(t *testing.T) {
 	r := &HTTPResolver{
 		Lookup:  fakeMirrorLookup{},
-		Origins: fakeOriginLookup{"foo/bar": "ghcr.io"},
+		Origins: fakeOriginLookup{"foo/bar": ghcrIO},
 	}
 	got, err := r.Resolve(context.Background(), "quay.io/foo/bar@sha256:0000000000000000000000000000000000000000000000000000000000000000")
 	if err != nil {
@@ -476,7 +478,7 @@ func TestResolve_ManualMapping_PreMirror_OriginsNil_Passthrough(t *testing.T) {
 // the resolve.
 type erroringOriginLookup struct{ err error }
 
-func (e erroringOriginLookup) FindOrigin(_ context.Context, _ string) (string, bool, error) {
+func (e erroringOriginLookup) FindOrigin(_ context.Context, _ string) (publicRegistry string, ok bool, err error) {
 	return "", false, e.err
 }
 

--- a/internal/imageversions/mirrorresolve/resolver_test.go
+++ b/internal/imageversions/mirrorresolve/resolver_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
 
 // fakeLookup always returns the configured row.
@@ -362,5 +363,153 @@ func TestHTTPResolver_ReplicaChain_TooDeep(t *testing.T) {
 		"local.example.com/containers/sthalbert/x:1.0")
 	if !errors.Is(err, ErrChainTooDeep) {
 		t.Fatalf("want ErrChainTooDeep, got %v", err)
+	}
+}
+
+// New semantics (ADR-0031): the manual mapping table is consulted before
+// the FindMirror gate. A ref whose imagePath matches a mapping is
+// rewritten even when no mirror row exists for the hostname.
+func TestResolve_ManualMapping_PreMirror_FullPathMatch(t *testing.T) {
+	r := &HTTPResolver{
+		Lookup:  fakeMirrorLookup{}, // no mirror rows at all
+		Origins: fakeOriginLookup{"grafana/loki": "docker.io"},
+	}
+	got, err := r.Resolve(context.Background(), "quay.io/grafana/loki:3.0")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	want := "docker.io/grafana/loki:3.0"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// Misconfigured Helm value: hostname is docker.io but the path includes
+// the private mirror's prefix. Strip-and-lookup should peel "containers/"
+// and match the bare "grafana/alloy" mapping.
+func TestResolve_ManualMapping_PreMirror_StripOneSegment(t *testing.T) {
+	r := &HTTPResolver{
+		Lookup:  fakeMirrorLookup{}, // no mirror rows
+		Origins: fakeOriginLookup{"grafana/alloy": "ghcr.io"},
+	}
+	got, err := r.Resolve(context.Background(), "docker.io/containers/grafana/alloy:v1.16.1")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	want := "ghcr.io/grafana/alloy:v1.16.1"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolve_ManualMapping_PreMirror_StripTwoSegments(t *testing.T) {
+	r := &HTTPResolver{
+		Lookup:  fakeMirrorLookup{},
+		Origins: fakeOriginLookup{"foo/bar": "ghcr.io"},
+	}
+	got, err := r.Resolve(context.Background(), "mirror.priv/team/containers/foo/bar:1.2.3")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	want := "ghcr.io/foo/bar:1.2.3"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// Single-segment imagePath (no slash to strip). The mapping key matches
+// the whole path on the first iteration.
+func TestResolve_ManualMapping_PreMirror_SingleSegment(t *testing.T) {
+	r := &HTTPResolver{
+		Lookup:  fakeMirrorLookup{},
+		Origins: fakeOriginLookup{"nginx": "docker.io"},
+	}
+	got, err := r.Resolve(context.Background(), "quay.io/nginx:1.27")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	want := "docker.io/nginx:1.27"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// When the ref carries a digest instead of a tag, splitRef returns tag="".
+// The rewrite must omit the trailing ":" — same shape as the existing
+// post-mirror manual branch in resolveFromMirror.
+func TestResolve_ManualMapping_PreMirror_DigestOnly(t *testing.T) {
+	r := &HTTPResolver{
+		Lookup:  fakeMirrorLookup{},
+		Origins: fakeOriginLookup{"foo/bar": "ghcr.io"},
+	}
+	got, err := r.Resolve(context.Background(), "quay.io/foo/bar@sha256:0000000000000000000000000000000000000000000000000000000000000000")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	want := "ghcr.io/foo/bar"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// When Origins is nil (feature disabled / no admin mappings configured),
+// the resolver MUST behave exactly as before: passthrough when no mirror
+// row matches.
+func TestResolve_ManualMapping_PreMirror_OriginsNil_Passthrough(t *testing.T) {
+	r := &HTTPResolver{
+		Lookup:  fakeMirrorLookup{},
+		Origins: nil,
+	}
+	got, err := r.Resolve(context.Background(), "quay.io/grafana/loki:3.0")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != "quay.io/grafana/loki:3.0" {
+		t.Fatalf("got %q, want passthrough", got)
+	}
+}
+
+// erroringOriginLookup always returns an error. Used to verify the
+// pre-mirror lookup fails open: a transient store error must not abort
+// the resolve.
+type erroringOriginLookup struct{ err error }
+
+func (e erroringOriginLookup) FindOrigin(_ context.Context, _ string) (string, bool, error) {
+	return "", false, e.err
+}
+
+func TestResolve_ManualMapping_PreMirror_FindOriginError_FailsOpen(t *testing.T) {
+	r := &HTTPResolver{
+		Lookup:  fakeMirrorLookup{}, // no mirror row → after fail-open, passthrough
+		Origins: erroringOriginLookup{err: errors.New("db boom")},
+	}
+	got, err := r.Resolve(context.Background(), "quay.io/grafana/loki:3.0")
+	if err != nil {
+		t.Fatalf("resolve must not return the store error: %v", err)
+	}
+	if got != "quay.io/grafana/loki:3.0" {
+		t.Fatalf("got %q, want passthrough on origins error", got)
+	}
+}
+
+// recordingObserver captures all observed results in order.
+type recordingObserver struct{ results []string }
+
+func (r *recordingObserver) ObserveResolve(result string, _ time.Duration) {
+	r.results = append(r.results, result)
+}
+
+func TestResolve_ManualMapping_PreMirror_EmitsOkManualMetric(t *testing.T) {
+	obs := &recordingObserver{}
+	r := &HTTPResolver{
+		Lookup:  fakeMirrorLookup{},
+		Origins: fakeOriginLookup{"grafana/loki": "docker.io"},
+		Metrics: obs,
+	}
+	if _, err := r.Resolve(context.Background(), "quay.io/grafana/loki:3.0"); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if len(obs.results) != 1 || obs.results[0] != "ok_manual" {
+		t.Fatalf("observer results = %v, want [ok_manual]", obs.results)
 	}
 }


### PR DESCRIPTION
  ## Summary

  Inverts the resolver flow so the operator-curated `image_origin_mappings`                                                                                                                     
  table is consulted **before** the `FindMirror` gate via progressive
  suffix stripping. Refs whose hostname is not a known mirror — e.g.
  misconfigured Helm values like `docker.io/containers/grafana/alloy` — are
  now rewritten through the mapping table instead of being passed through
  unchanged. Amends ADR-0030.

  - `internal/imageversions/mirrorresolve/resolver.go` — new
    `tryManualMapping` helper invoked at the top of `Resolve`. Strips one
    leading segment per iteration until a `FindOrigin` hit or no slash
    remains. Fails open on store errors (WARN log, fall through).
  - `internal/imageversions/mirrorresolve/resolver_test.go` — 8 new tests:
    full-path match, strip-one-segment, strip-two-segments, single-segment
    path, digest-only ref, `Origins == nil`, fail-open on store error, and
    `ok_manual` metric emission.
  - `docs/adr/adr-0031-manual-mappings-authoritative.md` — new ADR
    documenting the precedence change, the accepted false-positive risk,
    and rationale for fail-open.

  No store changes, no migration, no new metric label, no config knob, no
  UI work. The 198 mappings already in production immediately match more
  cases.

  ## Test plan
  
  - [x] `go test -race ./internal/imageversions/...` green
  - [x] `golangci-lint run --new-from-rev origin/main ./internal/imageversions/mirrorresolve/...` clean
  - [x] `bash scripts/check-forbidden-words.sh` no findings
  - [x] All 4 commits follow Conventional Commits
  - [ ] Post-merge: trigger `POST /v1/image-versions/refresh` and verify
        `docker.io/containers/grafana/alloy:v1.16.1` rows disappear from
        `GET /v1/image-versions?registry=docker.io`, replaced by their
        mapped public registry.
  - [ ] Post-merge: `imageversions_mirror_resolve_total{result="ok_manual"}`
        counter increases.