### PR TITLE
feat: make ingest verify and collector kube rate limits configurable

### DIFF
--- a/charts/longue-vue-collector/templates/deployment.yaml
+++ b/charts/longue-vue-collector/templates/deployment.yaml
@@ -44,6 +44,14 @@ spec:
               value: {{ .Values.fetchTimeout | quote }}
             - name: LONGUE_VUE_COLLECTOR_RECONCILE
               value: {{ .Values.reconcile | quote }}
+            {{- if .Values.kubeQPS }}
+            - name: LONGUE_VUE_COLLECTOR_KUBE_QPS
+              value: {{ .Values.kubeQPS | quote }}
+            {{- end }}
+            {{- if .Values.kubeBurst }}
+            - name: LONGUE_VUE_COLLECTOR_KUBE_BURST
+              value: {{ .Values.kubeBurst | quote }}
+            {{- end }}
             {{- if eq .Values.kubeconfig.mode "secret" }}
             - name: LONGUE_VUE_KUBECONFIG
               value: {{ .Values.kubeconfig.mountPath | quote }}

--- a/charts/longue-vue-collector/values.yaml
+++ b/charts/longue-vue-collector/values.yaml
@@ -59,6 +59,15 @@ interval: 5m
 fetchTimeout: 30s
 reconcile: true
 
+# client-go rate limiter for the collector → local Kubernetes API.
+# Upstream defaults (5/10) starve as soon as a tick fans out ~12 LISTs in a
+# row, surfacing as `client rate limiter Wait returned an error: context
+# deadline exceeded` in the collector logs. The collector binary applies
+# safer defaults (50 / 100). Raise these for clusters with many namespaces
+# or slow apiservers. Empty = use the binary's built-in defaults.
+kubeQPS: ""
+kubeBurst: ""
+
 # ── mTLS to longue-vue / DMZ gateway ─────────────────────────────────
 # Used together with serverURL pointing at the DMZ gateway (ADR-0016).
 # Leave existingSecret / caSecret empty to talk to longue-vue's public

--- a/charts/longue-vue/templates/deployment.yaml
+++ b/charts/longue-vue/templates/deployment.yaml
@@ -70,6 +70,16 @@ spec:
             - name: LONGUE_VUE_REQUIRE_HTTPS
               value: "true"
             {{- end }}
+            {{- with .Values.server.verifyRateLimit }}
+            {{- if .rps }}
+            - name: LONGUE_VUE_VERIFY_RATE_LIMIT_RPS
+              value: {{ .rps | quote }}
+            {{- end }}
+            {{- if .burst }}
+            - name: LONGUE_VUE_VERIFY_RATE_LIMIT_BURST
+              value: {{ .burst | quote }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.collector.enabled }}
             - name: LONGUE_VUE_COLLECTOR_ENABLED
               value: "true"

--- a/charts/longue-vue/templates/deployment.yaml
+++ b/charts/longue-vue/templates/deployment.yaml
@@ -89,6 +89,14 @@ spec:
               value: {{ .Values.collector.interval | quote }}
             - name: LONGUE_VUE_COLLECTOR_FETCH_TIMEOUT
               value: {{ .Values.collector.fetchTimeout | quote }}
+            {{- if .Values.collector.kubeQPS }}
+            - name: LONGUE_VUE_COLLECTOR_KUBE_QPS
+              value: {{ .Values.collector.kubeQPS | quote }}
+            {{- end }}
+            {{- if .Values.collector.kubeBurst }}
+            - name: LONGUE_VUE_COLLECTOR_KUBE_BURST
+              value: {{ .Values.collector.kubeBurst | quote }}
+            {{- end }}
             {{- if .Values.collector.clusters }}
             - name: LONGUE_VUE_COLLECTOR_CLUSTERS
               value: {{ .Values.collector.clusters | toJson | quote }}

--- a/charts/longue-vue/values.yaml
+++ b/charts/longue-vue/values.yaml
@@ -71,6 +71,15 @@ server:
   #    sessionSecureCookie is "always" (trusted-proxy posture).
   requireHTTPS: false
 
+  # -- Per-IP rate limits for the ingest /v1/auth/verify endpoint (ADR-0016 §5).
+  #    Every push-collector verify reaches longue-vue from the single ingest-gw
+  #    pod IP, so the per-IP bucket is shared across all agents. Raise these
+  #    when adding many push-mode collectors. Defaults: 100 rps / burst 200.
+  #    Empty = use the built-in defaults.
+  verifyRateLimit:
+    rps: ""
+    burst: ""
+
 # -- Secret-encryption master key for cloud-account credentials (ADR-0015).
 # Required when the VM collector is in use; safe to leave empty otherwise.
 # The key is a base64-encoded 32-byte AES-256 master key used to envelope-

--- a/charts/longue-vue/values.yaml
+++ b/charts/longue-vue/values.yaml
@@ -111,6 +111,12 @@ collector:
   fetchTimeout: "10s"
   # -- Delete rows that vanish from the live listing.
   reconcile: true
+  # -- client-go QPS/Burst for collector→K8s-API calls. Upstream defaults
+  #    (5/10) starve once a tick fans out ~12 LISTs; the binary applies
+  #    safer defaults (50/100). Override for very busy or slow apiservers.
+  #    Empty = use the binary's defaults.
+  kubeQPS: ""
+  kubeBurst: ""
   # -- Name of an existing Secret containing kubeconfig files.
   # Each key in the Secret is mounted as a file under /etc/longue-vue/kubeconfigs/.
   # Reference the mounted path in kubeconfig or clusters[].kubeconfig.

--- a/cmd/longue-vue-collector/main.go
+++ b/cmd/longue-vue-collector/main.go
@@ -49,6 +49,12 @@ type collectorConfig struct {
 	interval     time.Duration
 	fetchTimeout time.Duration
 	reconcile    bool
+	// kubeQPS / kubeBurst tune the client-go rate limiter for calls from
+	// the collector to the local Kubernetes API. Defaults handled by the
+	// collector package; <=0 means "use default". Override via
+	// LONGUE_VUE_COLLECTOR_KUBE_QPS / _KUBE_BURST.
+	kubeQPS   float32
+	kubeBurst int
 }
 
 // loadCollectorConfig reads and validates all environment variables needed
@@ -79,6 +85,14 @@ func loadCollectorConfig() (collectorConfig, error) {
 	if err != nil {
 		return collectorConfig{}, err
 	}
+	kubeQPS, err := parseFloat32Env("LONGUE_VUE_COLLECTOR_KUBE_QPS", 0)
+	if err != nil {
+		return collectorConfig{}, err
+	}
+	kubeBurst, err := parseIntEnv("LONGUE_VUE_COLLECTOR_KUBE_BURST", 0)
+	if err != nil {
+		return collectorConfig{}, err
+	}
 
 	return collectorConfig{
 		serverURL:    serverURL,
@@ -88,6 +102,8 @@ func loadCollectorConfig() (collectorConfig, error) {
 		interval:     interval,
 		fetchTimeout: fetchTimeout,
 		reconcile:    reconcile,
+		kubeQPS:      kubeQPS,
+		kubeBurst:    kubeBurst,
 	}, nil
 }
 
@@ -113,7 +129,7 @@ func run() error {
 	}
 
 	// Build the Kubernetes source (in-cluster or kubeconfig).
-	source, err := collector.NewKubeClient(cfg.kubeconfig)
+	source, err := collector.NewKubeClientWithLimits(cfg.kubeconfig, cfg.kubeQPS, cfg.kubeBurst)
 	if err != nil {
 		return fmt.Errorf("init kube client: %w", err)
 	}
@@ -177,4 +193,28 @@ func parseBoolEnv(key string, fallback bool) (bool, error) {
 		return false, fmt.Errorf("parse %s=%q: %w", key, v, err)
 	}
 	return b, nil
+}
+
+func parseIntEnv(key string, fallback int) (int, error) {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback, nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s=%q: %w", key, v, err)
+	}
+	return n, nil
+}
+
+func parseFloat32Env(key string, fallback float32) (float32, error) {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback, nil
+	}
+	f, err := strconv.ParseFloat(v, 32)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s=%q: %w", key, v, err)
+	}
+	return float32(f), nil
 }

--- a/cmd/longue-vue/main.go
+++ b/cmd/longue-vue/main.go
@@ -1038,6 +1038,12 @@ type collectorEnvConfig struct {
 	interval     time.Duration
 	fetchTimeout time.Duration
 	reconcile    bool
+	// kubeQPS / kubeBurst override the client-go rate limiter. <=0 = use
+	// collector package defaults. Override via
+	// LONGUE_VUE_COLLECTOR_KUBE_QPS / _KUBE_BURST. Applies to every cluster
+	// declared in LONGUE_VUE_COLLECTOR_CLUSTERS.
+	kubeQPS   float32
+	kubeBurst int
 }
 
 // loadCollectorEnvConfig reads collector-specific env vars.
@@ -1054,10 +1060,20 @@ func loadCollectorEnvConfig() (collectorEnvConfig, error) {
 	if err != nil {
 		return collectorEnvConfig{}, err
 	}
+	kubeQPS, err := parseFloat32Env("LONGUE_VUE_COLLECTOR_KUBE_QPS", 0)
+	if err != nil {
+		return collectorEnvConfig{}, err
+	}
+	kubeBurst, err := parseIntEnv("LONGUE_VUE_COLLECTOR_KUBE_BURST", 0)
+	if err != nil {
+		return collectorEnvConfig{}, err
+	}
 	return collectorEnvConfig{
 		interval:     interval,
 		fetchTimeout: fetchTimeout,
 		reconcile:    reconcile,
+		kubeQPS:      kubeQPS,
+		kubeBurst:    kubeBurst,
 	}, nil
 }
 
@@ -1086,7 +1102,7 @@ func maybeStartCollectors(ctx context.Context, s api.Store) (func(), error) {
 
 	var wg sync.WaitGroup
 	for _, cfg := range clusters {
-		source, err := collector.NewKubeClient(cfg.Kubeconfig)
+		source, err := collector.NewKubeClientWithLimits(cfg.Kubeconfig, envCfg.kubeQPS, envCfg.kubeBurst)
 		if err != nil {
 			return nil, fmt.Errorf("init kube client for cluster %q: %w", cfg.Name, err)
 		}
@@ -1306,6 +1322,18 @@ func parseIntEnv(key string, fallback int) (int, error) {
 		return 0, fmt.Errorf("parse %s=%q: %w", key, v, err)
 	}
 	return n, nil
+}
+
+func parseFloat32Env(key string, fallback float32) (float32, error) {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback, nil
+	}
+	f, err := strconv.ParseFloat(v, 32)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s=%q: %w", key, v, err)
+	}
+	return float32(f), nil
 }
 
 // maybeStartEOLEnricher spawns the EOL enrichment goroutine (ADR-0012).

--- a/cmd/longue-vue/main.go
+++ b/cmd/longue-vue/main.go
@@ -65,7 +65,9 @@ var (
 	errTransportPostureRefused = errors.New("LONGUE_VUE_REQUIRE_HTTPS=true but neither native TLS " +
 		"(LONGUE_VUE_PUBLIC_LISTEN_TLS_CERT + _KEY) nor a trusted-proxy + always-secure-cookie posture " +
 		"(LONGUE_VUE_TRUSTED_PROXIES non-empty AND LONGUE_VUE_SESSION_SECURE_COOKIE=always) is configured — see ADR-0017 §3")
-	errExtractMaxRowsInvalid = errors.New("LONGUE_VUE_EXTRACT_MAX_ROWS is not a positive integer")
+	errExtractMaxRowsInvalid       = errors.New("LONGUE_VUE_EXTRACT_MAX_ROWS is not a positive integer")
+	errVerifyRateLimitRPSInvalid   = errors.New("LONGUE_VUE_VERIFY_RATE_LIMIT_RPS is not a positive number")
+	errVerifyRateLimitBurstInvalid = errors.New("LONGUE_VUE_VERIFY_RATE_LIMIT_BURST is not a positive integer")
 )
 
 func main() {
@@ -109,6 +111,13 @@ type runConfig struct {
 	// extractMaxRows caps the number of rows returned by the /v1/*/extract
 	// endpoints. Defaults to 50 000; overridden via LONGUE_VUE_EXTRACT_MAX_ROWS.
 	extractMaxRows int
+	// verifyRateLimitRPS / Burst tune the per-IP /v1/auth/verify limiter
+	// (ADR-0016 §5). Since every push-collector verify hits longue-vue from
+	// the single ingest-gw pod IP, the defaults can become a bottleneck once
+	// many agents are deployed. Override via
+	// LONGUE_VUE_VERIFY_RATE_LIMIT_{RPS,BURST}.
+	verifyRateLimitRPS   float64
+	verifyRateLimitBurst int
 }
 
 // ingestListenerConfig captures the env-var surface for the ADR-0016
@@ -169,19 +178,38 @@ func loadRunConfig() (runConfig, error) {
 		extractMaxRows = n
 	}
 
+	verifyRPS := float64(api.DefaultVerifyRateLimitRPS)
+	if v := os.Getenv("LONGUE_VUE_VERIFY_RATE_LIMIT_RPS"); v != "" {
+		n, err := strconv.ParseFloat(v, 64)
+		if err != nil || n <= 0 {
+			return runConfig{}, fmt.Errorf("%w: LONGUE_VUE_VERIFY_RATE_LIMIT_RPS=%q", errVerifyRateLimitRPSInvalid, v)
+		}
+		verifyRPS = n
+	}
+	verifyBurst := api.DefaultVerifyRateLimitBurst
+	if v := os.Getenv("LONGUE_VUE_VERIFY_RATE_LIMIT_BURST"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			return runConfig{}, fmt.Errorf("%w: LONGUE_VUE_VERIFY_RATE_LIMIT_BURST=%q", errVerifyRateLimitBurstInvalid, v)
+		}
+		verifyBurst = n
+	}
+
 	cfg := runConfig{
-		addr:            envOr("LONGUE_VUE_ADDR", ":8080"),
-		dsn:             dsn,
-		cookiePolicy:    cookiePolicy,
-		oidcCfg:         loadOIDCConfig(),
-		shutdownTimeout: shutdownTimeout,
-		autoMigrate:     autoMigrate,
-		ingest:          ingest,
-		publicTLSCert:   os.Getenv("LONGUE_VUE_PUBLIC_LISTEN_TLS_CERT"),
-		publicTLSKey:    os.Getenv("LONGUE_VUE_PUBLIC_LISTEN_TLS_KEY"),
-		trustedProxies:  trustedProxies,
-		requireHTTPS:    requireHTTPS,
-		extractMaxRows:  extractMaxRows,
+		addr:                 envOr("LONGUE_VUE_ADDR", ":8080"),
+		dsn:                  dsn,
+		cookiePolicy:         cookiePolicy,
+		oidcCfg:              loadOIDCConfig(),
+		shutdownTimeout:      shutdownTimeout,
+		autoMigrate:          autoMigrate,
+		ingest:               ingest,
+		publicTLSCert:        os.Getenv("LONGUE_VUE_PUBLIC_LISTEN_TLS_CERT"),
+		publicTLSKey:         os.Getenv("LONGUE_VUE_PUBLIC_LISTEN_TLS_KEY"),
+		trustedProxies:       trustedProxies,
+		requireHTTPS:         requireHTTPS,
+		extractMaxRows:       extractMaxRows,
+		verifyRateLimitRPS:   verifyRPS,
+		verifyRateLimitBurst: verifyBurst,
 	}
 	if err := checkTransportPosture(&cfg); err != nil {
 		return runConfig{}, err
@@ -339,6 +367,8 @@ func run() error { //nolint:gocyclo // daemon bootstrap; flat structure is clear
 
 	slog.Info("longue-vue config",
 		slog.Int("extract_max_rows", cfg.extractMaxRows),
+		slog.Float64("verify_rate_limit_rps", cfg.verifyRateLimitRPS),
+		slog.Int("verify_rate_limit_burst", cfg.verifyRateLimitBurst),
 	)
 	return serveAndShutdown(rootCtx, srv, ingestSrv, cfg.shutdownTimeout)
 }
@@ -560,7 +590,7 @@ func buildHTTPServer(
 		requireScope(auth.ScopeRead)(extractAuth(auditWrap(api.HandleEolExtract(pg, cfg.extractMaxRows)))))
 
 	loginLimiter := api.NewLoginRateLimiter()
-	verifyLimiter := api.NewVerifyRateLimiter()
+	verifyLimiter := api.NewVerifyRateLimiterWithLimits(cfg.verifyRateLimitRPS, cfg.verifyRateLimitBurst)
 	apiServer := api.NewServer(version, pg, cfg.cookiePolicy, oidcProvider, loginLimiter, verifyLimiter)
 	apiServer.SetTrustedProxies(cfg.trustedProxies)
 	apiServer.SetEnricher(imgVersionsEnricher)
@@ -753,7 +783,7 @@ func buildIngestServer(
 	}
 
 	loginLimiter := api.NewLoginRateLimiter() // unused on ingest, but Server requires non-nil
-	verifyLimiter := api.NewVerifyRateLimiter()
+	verifyLimiter := api.NewVerifyRateLimiterWithLimits(cfg.verifyRateLimitRPS, cfg.verifyRateLimitBurst)
 	ingestServer := api.NewServer(version, pg, cfg.cookiePolicy, oidcProvider, loginLimiter, verifyLimiter)
 	ingestServer.SetTrustedProxies(cfg.trustedProxies)
 	strict := api.NewStrictHandlerWithOptions(

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -58,22 +58,48 @@ func (rl *LoginRateLimiter) cleanup() {
 	}
 }
 
+// Default per-IP limits for the ingest /v1/auth/verify endpoint (ADR-0016 §5).
+// Generous enough that a healthy gateway never hits it, strict enough to make
+// a buggy build that bypassed the verify cache visible immediately. The
+// "source IP" in practice is always the gateway pod's IP since this listener
+// is only reachable across one mTLS hop — but with many push-collectors
+// fanning through a single gateway IP, operators may need to raise these via
+// LONGUE_VUE_VERIFY_RATE_LIMIT_{RPS,BURST}.
+const (
+	DefaultVerifyRateLimitRPS   = 100
+	DefaultVerifyRateLimitBurst = 200
+)
+
 // VerifyRateLimiter provides per-IP rate limiting for the ingest-listener
-// /v1/auth/verify endpoint (ADR-0016 §5). 100 req/s per source IP with a
-// burst of 200 — generous enough that a healthy gateway never hits it,
-// strict enough to make a buggy build that bypassed the verify cache
-// visible immediately. The "source IP" in practice is always the gateway
-// pod's IP since this listener is only reachable across one mTLS hop.
+// /v1/auth/verify endpoint (ADR-0016 §5).
 type VerifyRateLimiter struct {
 	mu       sync.Mutex
 	limiters map[string]*rlEntry
+	rps      rate.Limit
+	burst    int
 }
 
-// NewVerifyRateLimiter creates a rate limiter allowing 100 verify calls
-// per second per source IP with a burst of 200.
+// NewVerifyRateLimiter creates a rate limiter with the default 100 rps /
+// burst 200 per source IP. Kept for tests and call sites that don't need
+// to tune the limits.
 func NewVerifyRateLimiter() *VerifyRateLimiter {
+	return NewVerifyRateLimiterWithLimits(DefaultVerifyRateLimitRPS, DefaultVerifyRateLimitBurst)
+}
+
+// NewVerifyRateLimiterWithLimits creates a rate limiter with the given
+// per-IP rps and burst. Values <= 0 fall back to the defaults so a typo'd
+// env var can't accidentally disable the limiter.
+func NewVerifyRateLimiterWithLimits(rps float64, burst int) *VerifyRateLimiter {
+	if rps <= 0 {
+		rps = DefaultVerifyRateLimitRPS
+	}
+	if burst <= 0 {
+		burst = DefaultVerifyRateLimitBurst
+	}
 	rl := &VerifyRateLimiter{
 		limiters: make(map[string]*rlEntry),
+		rps:      rate.Limit(rps),
+		burst:    burst,
 	}
 	go rl.cleanup()
 	return rl
@@ -84,8 +110,7 @@ func (rl *VerifyRateLimiter) Allow(ip string) bool {
 	rl.mu.Lock()
 	e, ok := rl.limiters[ip]
 	if !ok {
-		// 100 tokens per second, burst of 200 — see ADR-0016 §5.
-		e = &rlEntry{lim: rate.NewLimiter(rate.Limit(100), 200)} //nolint:mnd // documented in ADR
+		e = &rlEntry{lim: rate.NewLimiter(rl.rps, rl.burst)}
 		rl.limiters[ip] = e
 	}
 	e.lastSeen = time.Now()

--- a/internal/collector/kube.go
+++ b/internal/collector/kube.go
@@ -106,15 +106,42 @@ type KubeClient struct {
 	clientset *kubernetes.Clientset
 }
 
-// NewKubeClient constructs a client. Resolution order:
+// Default client-go QPS/Burst for the collector. The upstream defaults
+// (5/10) are too low for a single tick that issues ~12 cluster-wide LISTs
+// in a tight loop — token starvation manifests as
+// "client rate limiter Wait returned an error: context deadline exceeded"
+// once any single list takes long enough to exhaust the burst window.
+// Operators override via LONGUE_VUE_COLLECTOR_KUBE_QPS / _KUBE_BURST.
+const (
+	DefaultKubeQPS   = 50
+	DefaultKubeBurst = 100
+)
+
+// NewKubeClient constructs a client with the default QPS/Burst. Resolution
+// order for the kubeconfig:
 //   - explicit kubeconfigPath when non-empty;
 //   - in-cluster config when running inside a pod;
 //   - the default kubectl loading rules (KUBECONFIG env var, then ~/.kube/config).
 func NewKubeClient(kubeconfigPath string) (*KubeClient, error) {
+	return NewKubeClientWithLimits(kubeconfigPath, DefaultKubeQPS, DefaultKubeBurst)
+}
+
+// NewKubeClientWithLimits is NewKubeClient with explicit client-go QPS/Burst.
+// Values <= 0 fall back to the defaults so a typo'd env var can't accidentally
+// pin the client to the upstream-default 5/10.
+func NewKubeClientWithLimits(kubeconfigPath string, qps float32, burst int) (*KubeClient, error) {
 	cfg, err := loadKubeConfig(kubeconfigPath)
 	if err != nil {
 		return nil, err
 	}
+	if qps <= 0 {
+		qps = DefaultKubeQPS
+	}
+	if burst <= 0 {
+		burst = DefaultKubeBurst
+	}
+	cfg.QPS = qps
+	cfg.Burst = burst
 	cs, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("kubernetes.NewForConfig: %w", err)


### PR DESCRIPTION
  ## Summary
  
  - **Ingest verify limiter** (ADR-0016 §5): expose `LONGUE_VUE_VERIFY_RATE_LIMIT_RPS` / `_BURST` so the per-IP `/v1/auth/verify` bucket on the ingest listener can be raised without a rebuild as the push-collector fleet grows. Defaults
  unchanged (100 rps / burst 200). Helm: `server.verifyRateLimit.{rps,burst}`.
  - **Collector client-go limiter**: the K8s client was instantiated with the upstream defaults (QPS=5, Burst=10), which starve as soon as a tick fans out the ~12 cluster-wide LISTs, surfacing as `client rate limiter Wait returned an error:
  context deadline exceeded` and cascading into POST `/v1/.../reconcile` timeouts. Bump the binary defaults to 50 / 100 and expose `LONGUE_VUE_COLLECTOR_KUBE_QPS` / `_KUBE_BURST`. Helm: `kubeQPS` / `kubeBurst` on the `longue-vue-collector`
  chart, and `collector.kubeQPS` / `.kubeBurst` on the embedded collector in the `longue-vue` chart.
  
  Both knobs fail closed on a non-numeric value and fall back to the binary defaults on `<= 0`, so a typo can't accidentally disable the limiter or pin it to the upstream-default 5/10.
  
  ## Test plan
  
  - [x] `go vet`, `go build`, `go test -race -short`
  - [x] `golangci-lint --new-from-rev=main` — 0 new issues
  - [x] `gosec` / `govulncheck` clean (no new findings)
  - [x] `make swagger-sync-check`, `go generate` clean
  - [x] `scripts/check-forbidden-words.sh`
  - [x] `helm lint` + `helm template` on both charts
  - [x] commitlint: both commits valid Conventional Commits
  - [ ] Apply on cluster, confirm `client rate limiter Wait` messages disappear
  - [ ] If still tight, raise via values without rebuild and confirm env vars take effect