### PR TITLE
fix(store): cascade soft-delete workloads when collector reaps a name…

### DIFF
--- a/internal/store/pg.go
+++ b/internal/store/pg.go
@@ -1139,7 +1139,14 @@ func (p *PG) DeleteNodesNotIn(ctx context.Context, clusterID uuid.UUID, keepName
 
 // DeleteNamespacesNotIn mirrors DeleteNodesNotIn: soft-deletes namespaces of
 // the given cluster not in keepNames and not already terminated. Per
-// ADR-0021 §5.
+// ADR-0021 §5. For each soft-deleted namespace, this mirrors
+// SoftDeleteNamespace by cascade-soft-deleting its live workloads and
+// hard-deleting its unhistoried children (pods, services, ingresses, PVCs)
+// — otherwise workloads in a vanished namespace would linger forever in
+// list/EOL outputs because reconcileWorkloads only walks namespaces that
+// were present in the current tick.
+//
+//nolint:gocyclo // cascade + history capture adds branches; mirrors SoftDeleteNamespace
 func (p *PG) DeleteNamespacesNotIn(ctx context.Context, clusterID uuid.UUID, keepNames []string) (int64, error) {
 	tx, err := p.pool.Begin(ctx)
 	if err != nil {
@@ -1161,6 +1168,43 @@ func (p *PG) DeleteNamespacesNotIn(ctx context.Context, clusterID uuid.UUID, kee
 		return 0, fmt.Errorf("scan namespaces to soft-delete: %w", err)
 	}
 
+	actor := timetravel.ActorFromContext(ctx)
+
+	// Per-namespace cascade: capture each namespace's live workload IDs
+	// before mutating, hard-delete unhistoried children, soft-delete
+	// workloads, then capture workload snapshots so history reflects the
+	// final terminated state.
+	wlIDsByNS := make(map[uuid.UUID][]uuid.UUID, len(toDelete))
+	for _, nsID := range toDelete {
+		wlIDs, err := liveWorkloadIDsForNamespace(ctx, tx, nsID)
+		if err != nil {
+			return 0, fmt.Errorf("list workloads for soft-delete namespace %s: %w", nsID, err)
+		}
+		wlIDsByNS[nsID] = wlIDs
+
+		if _, err := tx.Exec(ctx,
+			`DELETE FROM pods WHERE namespace_id = $1`, nsID); err != nil {
+			return 0, fmt.Errorf("cascade-delete pods for %s: %w", nsID, err)
+		}
+		if _, err := tx.Exec(ctx,
+			`DELETE FROM services WHERE namespace_id = $1`, nsID); err != nil {
+			return 0, fmt.Errorf("cascade-delete services for %s: %w", nsID, err)
+		}
+		if _, err := tx.Exec(ctx,
+			`DELETE FROM ingresses WHERE namespace_id = $1`, nsID); err != nil {
+			return 0, fmt.Errorf("cascade-delete ingresses for %s: %w", nsID, err)
+		}
+		if _, err := tx.Exec(ctx,
+			`DELETE FROM persistent_volume_claims WHERE namespace_id = $1`, nsID); err != nil {
+			return 0, fmt.Errorf("cascade-delete persistent_volume_claims for %s: %w", nsID, err)
+		}
+		if _, err := tx.Exec(ctx,
+			`UPDATE workloads SET terminated_at = NOW(), updated_at = NOW()
+			   WHERE namespace_id = $1 AND terminated_at IS NULL`, nsID); err != nil {
+			return 0, fmt.Errorf("soft-delete workloads for %s: %w", nsID, err)
+		}
+	}
+
 	tag, err := tx.Exec(ctx,
 		`UPDATE namespaces
 		    SET terminated_at = NOW(), updated_at = NOW()
@@ -1173,8 +1217,12 @@ func (p *PG) DeleteNamespacesNotIn(ctx context.Context, clusterID uuid.UUID, kee
 		return 0, fmt.Errorf("soft-delete namespaces not in: %w", err)
 	}
 
-	actor := timetravel.ActorFromContext(ctx)
 	for _, nsID := range toDelete {
+		for _, wlID := range wlIDsByNS[nsID] {
+			if snap, err := workloadRowMapNoLock(ctx, tx, wlID); err == nil {
+				_ = timetravel.Capture(ctx, tx, timetravel.KindWorkload, wlID, nil, snap, changeTypeSoftDelete, actor)
+			}
+		}
 		if snap, err := namespaceRowMapNoLock(ctx, tx, nsID); err == nil {
 			_ = timetravel.Capture(ctx, tx, timetravel.KindNamespace, nsID, nil, snap, changeTypeSoftDelete, actor)
 		}

--- a/internal/store/pg_test.go
+++ b/internal/store/pg_test.go
@@ -732,6 +732,7 @@ func TestPGUpsertWorkload_ResurrectsTerminated(t *testing.T) {
 	}
 }
 
+//nolint:gocyclo // integration test exercises cascade across multiple kinds
 func TestPGDeleteNamespacesNotIn(t *testing.T) {
 	pg := newTestPG(t)
 	ctx := context.Background()
@@ -744,6 +745,47 @@ func TestPGDeleteNamespacesNotIn(t *testing.T) {
 		if _, err := pg.CreateNamespace(ctx, api.NamespaceCreate{ClusterId: *cluster.Id, Name: name}); err != nil {
 			t.Fatalf("create %s: %v", name, err)
 		}
+	}
+
+	// Seed a workload + pod + service + ingress + PVC in the namespace
+	// that will be reconciled away, plus a workload in a kept namespace,
+	// so we can prove the cascade scope.
+	var extraNS, defaultNS api.Namespace
+	if err := pg.pool.QueryRow(ctx,
+		`SELECT id, name FROM namespaces WHERE cluster_id=$1 AND name='extra'`,
+		*cluster.Id).Scan(&extraNS.Id, &extraNS.Name); err != nil {
+		t.Fatalf("lookup extra ns: %v", err)
+	}
+	if err := pg.pool.QueryRow(ctx,
+		`SELECT id, name FROM namespaces WHERE cluster_id=$1 AND name='default'`,
+		*cluster.Id).Scan(&defaultNS.Id, &defaultNS.Name); err != nil {
+		t.Fatalf("lookup default ns: %v", err)
+	}
+	extraWL, _, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{
+		NamespaceId: *extraNS.Id, Kind: "Deployment", Name: "doomed",
+	})
+	if err != nil {
+		t.Fatalf("upsert extra workload: %v", err)
+	}
+	keptWL, _, err := pg.UpsertWorkload(ctx, api.WorkloadCreate{
+		NamespaceId: *defaultNS.Id, Kind: "Deployment", Name: "kept",
+	})
+	if err != nil {
+		t.Fatalf("upsert kept workload: %v", err)
+	}
+	if _, err := pg.CreatePod(ctx, api.PodCreate{NamespaceId: *extraNS.Id, Name: "doomed-pod"}); err != nil {
+		t.Fatalf("create pod: %v", err)
+	}
+	if _, err := pg.CreateService(ctx, api.ServiceCreate{NamespaceId: *extraNS.Id, Name: "doomed-svc"}); err != nil {
+		t.Fatalf("create service: %v", err)
+	}
+	if _, err := pg.CreateIngress(ctx, api.IngressCreate{NamespaceId: *extraNS.Id, Name: "doomed-ing"}); err != nil {
+		t.Fatalf("create ingress: %v", err)
+	}
+	if _, err := pg.CreatePersistentVolumeClaim(ctx, api.PersistentVolumeClaimCreate{
+		NamespaceId: *extraNS.Id, Name: "doomed-pvc",
+	}); err != nil {
+		t.Fatalf("create pvc: %v", err)
 	}
 
 	deleted, err := pg.DeleteNamespacesNotIn(ctx, *cluster.Id, []string{"default", "kube-system"})
@@ -763,6 +805,41 @@ func TestPGDeleteNamespacesNotIn(t *testing.T) {
 	}
 	if live != 2 {
 		t.Errorf("live=%d, want 2", live)
+	}
+
+	// Cascade: the doomed workload must be soft-deleted; the kept workload
+	// in the surviving namespace must remain live.
+	var extraTerm *time.Time
+	if err := pg.pool.QueryRow(ctx,
+		"SELECT terminated_at FROM workloads WHERE id=$1", *extraWL.Id).Scan(&extraTerm); err != nil {
+		t.Fatalf("query extra workload: %v", err)
+	}
+	if extraTerm == nil {
+		t.Errorf("expected doomed workload to be soft-deleted")
+	}
+	var keptTerm *time.Time
+	if err := pg.pool.QueryRow(ctx,
+		"SELECT terminated_at FROM workloads WHERE id=$1", *keptWL.Id).Scan(&keptTerm); err != nil {
+		t.Fatalf("query kept workload: %v", err)
+	}
+	if keptTerm != nil {
+		t.Errorf("kept workload terminated_at=%v, want nil", keptTerm)
+	}
+
+	// Unhistoried children must be hard-deleted.
+	for _, q := range []struct{ name, sql string }{
+		{"pods", "SELECT COUNT(*) FROM pods WHERE namespace_id=$1"},
+		{"services", "SELECT COUNT(*) FROM services WHERE namespace_id=$1"},
+		{"ingresses", "SELECT COUNT(*) FROM ingresses WHERE namespace_id=$1"},
+		{"pvcs", "SELECT COUNT(*) FROM persistent_volume_claims WHERE namespace_id=$1"},
+	} {
+		var n int
+		if err := pg.pool.QueryRow(ctx, q.sql, *extraNS.Id).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", q.name, err)
+		}
+		if n != 0 {
+			t.Errorf("%s left in vanished namespace: %d, want 0", q.name, n)
+		}
 	}
 }
 


### PR DESCRIPTION
…space

DeleteNamespacesNotIn now mirrors SoftDeleteNamespace: for each namespace it soft-deletes, it cascade-soft-deletes the live workloads and hard-deletes the unhistoried children (pods, services, ingresses, PVCs), with time-travel history capture.

Without this, workloads in a namespace that vanished between collector ticks lingered forever — reconcileWorkloads only walks namespaces present in the current tick — so the EOL dashboard kept flagging old container images from clusters that were already torn down.