### PR TITLE
ci(commitlint): skip per-commit lint on Dependabot PRs

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -17,6 +17,10 @@ jobs:
   commits:
     name: Conventional Commits
     runs-on: ubuntu-latest
+    # Skip body/footer line-length checks on Dependabot PRs: its auto-generated
+    # bodies include long release-note URLs that can't be wrapped. The PR-title
+    # job below still enforces conventional-commit format on the squash subject.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Dependabot's auto-generated commit bodies include long release-note URLs that can't be wrapped under 100 chars, causing the per-commit lint job to fail on every bot PR. The conventional-PR-title job continues to run unchanged, so the squash subject merged to main still has to be valid.

Targeted skip via the workflow keeps the strict body/footer rules in place for human commits.