### PR TITLE
fix(collector): single cluster-wide ListNetworkPolicies call per tick

### DIFF
--- a/internal/api/network_policy_push_integration_test.go
+++ b/internal/api/network_policy_push_integration_test.go
@@ -135,10 +135,6 @@ type fakeNetpolSource struct {
 	byNamespace map[string][]collector.NetworkPolicyInfo
 }
 
-func (f *fakeNetpolSource) ListNetworkPolicies(_ context.Context, ns string) ([]collector.NetworkPolicyInfo, error) {
-	return f.byNamespace[ns], nil
-}
-
 func (f *fakeNetpolSource) ListAllNetworkPolicies(_ context.Context) ([]collector.NetworkPolicyInfo, error) {
 	var out []collector.NetworkPolicyInfo
 	for ns, infos := range f.byNamespace {

--- a/internal/api/network_policy_push_integration_test.go
+++ b/internal/api/network_policy_push_integration_test.go
@@ -128,9 +128,9 @@ func newNetpolPushTestEnv(t *testing.T) *netpolPushTestEnv {
 }
 
 // fakeNetpolSource implements collector.KubeSource with only
-// ListNetworkPolicies populated — every other method returns empty results.
-// This is sufficient for CollectNetworkPolicies, which calls only
-// ListNetworkPolicies.
+// ListAllNetworkPolicies populated — every other method returns empty results.
+// This is sufficient for CollectNetworkPolicies, which issues a single
+// cluster-wide list call (bugfix 2026-06-10).
 type fakeNetpolSource struct {
 	byNamespace map[string][]collector.NetworkPolicyInfo
 }
@@ -140,7 +140,17 @@ func (f *fakeNetpolSource) ListNetworkPolicies(_ context.Context, ns string) ([]
 }
 
 func (f *fakeNetpolSource) ListAllNetworkPolicies(_ context.Context) ([]collector.NetworkPolicyInfo, error) {
-	return nil, nil
+	var out []collector.NetworkPolicyInfo
+	for ns, infos := range f.byNamespace {
+		for i := range infos {
+			info := infos[i]
+			if info.Namespace == "" {
+				info.Namespace = ns
+			}
+			out = append(out, info)
+		}
+	}
+	return out, nil
 }
 
 // Stub all other KubeSource methods to satisfy the interface.
@@ -255,7 +265,8 @@ func TestPushCollector_NetPol_EndToEnd(t *testing.T) {
 
 	// --- 3. Tick 1: both p1 + p2 must arrive in the DB -------------------
 
-	if err := collector.CollectNetworkPolicies(ctx, src, env.apcl, clusterID, nsID, nsName); err != nil {
+	nsByName := map[string]uuid.UUID{nsName: nsID}
+	if err := collector.CollectNetworkPolicies(ctx, src, env.apcl, clusterID, nsByName); err != nil {
 		t.Fatalf("tick 1: CollectNetworkPolicies: %v", err)
 	}
 
@@ -267,7 +278,7 @@ func TestPushCollector_NetPol_EndToEnd(t *testing.T) {
 
 	src.byNamespace[nsName] = src.byNamespace[nsName][:1] // keep only p1
 
-	if err := collector.CollectNetworkPolicies(ctx, src, env.apcl, clusterID, nsID, nsName); err != nil {
+	if err := collector.CollectNetworkPolicies(ctx, src, env.apcl, clusterID, nsByName); err != nil {
 		t.Fatalf("tick 2: CollectNetworkPolicies: %v", err)
 	}
 

--- a/internal/api/network_policy_push_integration_test.go
+++ b/internal/api/network_policy_push_integration_test.go
@@ -139,6 +139,10 @@ func (f *fakeNetpolSource) ListNetworkPolicies(_ context.Context, ns string) ([]
 	return f.byNamespace[ns], nil
 }
 
+func (f *fakeNetpolSource) ListAllNetworkPolicies(_ context.Context) ([]collector.NetworkPolicyInfo, error) {
+	return nil, nil
+}
+
 // Stub all other KubeSource methods to satisfy the interface.
 
 func (f *fakeNetpolSource) ServerVersion(_ context.Context) (string, error) {

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -1177,24 +1177,19 @@ func (c *Collector) ingestPersistentVolumeClaims(ctx context.Context, namespaceI
 		slog.Int64("reconciled_deleted", reconciled), slog.String("cluster_name", c.clusterName))
 }
 
-// ingestNetworkPolicies runs one tick of NetworkPolicy reconciliation
-// for every namespace that was successfully ingested this tick. Runs in
-// both in-process (cmd/longue-vue → *store.PG direct) and push
-// (cmd/longue-vue-collector → apiclient.Store → ingest GW) modes since
-// ADR-0038. The c.netpolStore == nil guard exists for tests that inject
-// a stub store without netpol support.
+// ingestNetworkPolicies runs one tick of NetworkPolicy reconciliation for
+// the local cluster. Single cluster-wide list call (no per-namespace
+// fan-out — bugfix 2026-06-10). Runs in both in-process and push modes
+// since ADR-0038. The c.netpolStore == nil guard exists for tests that
+// inject a stub store without netpol support.
 func (c *Collector) ingestNetworkPolicies(ctx context.Context, clusterID uuid.UUID, namespaceIDsByName map[string]uuid.UUID) {
 	if c.netpolStore == nil {
 		return
 	}
-	for nsName, nsID := range namespaceIDsByName {
-		if err := CollectNetworkPolicies(ctx, c.source, c.netpolStore, clusterID, nsID, nsName); err != nil {
-			slog.Warn("collector: netpol tick failed",
-				slog.String("cluster", clusterID.String()),
-				slog.String("ns", nsName),
-				slog.Any("err", err),
-				slog.String("cluster_name", c.clusterName))
-			// per CLAUDE.md: do not return — other namespaces still need to land
-		}
+	if err := CollectNetworkPolicies(ctx, c.source, c.netpolStore, clusterID, namespaceIDsByName); err != nil {
+		slog.Warn("collector: netpol tick failed",
+			slog.String("cluster", clusterID.String()),
+			slog.Any("err", err),
+			slog.String("cluster_name", c.clusterName))
 	}
 }

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -262,14 +262,6 @@ type NetworkPolicyPeerInfo struct {
 	IPBlockExcept     []byte // JSON-encoded []string
 }
 
-// NetworkPolicyLister returns every NetworkPolicy visible to the configured
-// kubeconfig for a given namespace. Retained for back-compat; prefer
-// AllNetworkPolicyLister which makes a single cluster-wide call.
-// TODO(Task 3): remove once CollectNetworkPolicies no longer calls it.
-type NetworkPolicyLister interface {
-	ListNetworkPolicies(ctx context.Context, namespace string) ([]NetworkPolicyInfo, error)
-}
-
 // AllNetworkPolicyLister returns every NetworkPolicy across all namespaces in
 // a single cluster-wide list call — avoids the N per-namespace calls that
 // exhaust the client-go rate limiter in large clusters.
@@ -289,7 +281,6 @@ type KubeSource interface {
 	ReplicaSetOwnerLister
 	PersistentVolumeLister
 	PersistentVolumeClaimLister
-	NetworkPolicyLister
 	AllNetworkPolicyLister
 }
 

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -263,9 +263,18 @@ type NetworkPolicyPeerInfo struct {
 }
 
 // NetworkPolicyLister returns every NetworkPolicy visible to the configured
-// kubeconfig for a given namespace.
+// kubeconfig for a given namespace. Retained for back-compat; prefer
+// AllNetworkPolicyLister which makes a single cluster-wide call.
+// TODO(Task 3): remove once CollectNetworkPolicies no longer calls it.
 type NetworkPolicyLister interface {
 	ListNetworkPolicies(ctx context.Context, namespace string) ([]NetworkPolicyInfo, error)
+}
+
+// AllNetworkPolicyLister returns every NetworkPolicy across all namespaces in
+// a single cluster-wide list call — avoids the N per-namespace calls that
+// exhaust the client-go rate limiter in large clusters.
+type AllNetworkPolicyLister interface {
+	ListAllNetworkPolicies(ctx context.Context) ([]NetworkPolicyInfo, error)
 }
 
 // KubeSource is the composite contract the Collector consumes.
@@ -281,6 +290,7 @@ type KubeSource interface {
 	PersistentVolumeLister
 	PersistentVolumeClaimLister
 	NetworkPolicyLister
+	AllNetworkPolicyLister
 }
 
 // CmdbStore is the subset of api.Store the collector consumes. Exported so

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -79,10 +79,6 @@ func (f *fakeSource) ListPersistentVolumeClaims(_ context.Context) ([]PVCInfo, e
 	return f.pvcs, f.listPVCErr
 }
 
-func (f *fakeSource) ListNetworkPolicies(_ context.Context, _ string) ([]NetworkPolicyInfo, error) {
-	return f.netpols, f.listNetpolErr
-}
-
 func (f *fakeSource) ListAllNetworkPolicies(_ context.Context) ([]NetworkPolicyInfo, error) {
 	if f.listNetpolErr != nil {
 		return nil, f.listNetpolErr

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -84,7 +84,10 @@ func (f *fakeSource) ListNetworkPolicies(_ context.Context, _ string) ([]Network
 }
 
 func (f *fakeSource) ListAllNetworkPolicies(_ context.Context) ([]NetworkPolicyInfo, error) {
-	return nil, nil
+	if f.listNetpolErr != nil {
+		return nil, f.listNetpolErr
+	}
+	return f.netpols, nil
 }
 
 type recordedUpdate struct {

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -83,6 +83,10 @@ func (f *fakeSource) ListNetworkPolicies(_ context.Context, _ string) ([]Network
 	return f.netpols, f.listNetpolErr
 }
 
+func (f *fakeSource) ListAllNetworkPolicies(_ context.Context) ([]NetworkPolicyInfo, error) {
+	return nil, nil
+}
+
 type recordedUpdate struct {
 	id    uuid.UUID
 	patch api.ClusterUpdate

--- a/internal/collector/kube.go
+++ b/internal/collector/kube.go
@@ -762,6 +762,26 @@ func (k *KubeClient) listDaemonSets(ctx context.Context) ([]WorkloadInfo, error)
 	return out, nil
 }
 
+// ListAllNetworkPolicies returns every NetworkPolicy across every namespace
+// in one cluster-wide list call (mirror of ListServices/ListIngresses).
+// Replaces the per-namespace ListNetworkPolicies which fans out N calls
+// against the K8s API and exhausts client-go's rate limiter at scale.
+func (k *KubeClient) ListAllNetworkPolicies(ctx context.Context) ([]NetworkPolicyInfo, error) {
+	list, err := k.clientset.NetworkingV1().NetworkPolicies("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list netpols cluster-wide: %w", err)
+	}
+	out := make([]NetworkPolicyInfo, 0, len(list.Items))
+	for _, np := range list.Items { //nolint:gocritic // rangeValCopy: k8s NetworkPolicy is SDK-owned; indexing would couple to SDK internals
+		info, err := convertNetworkPolicy(np)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, info)
+	}
+	return out, nil
+}
+
 // ListNetworkPolicies returns every NetworkPolicy in the given namespace.
 // Selectors and the full spec are JSON-encoded so the store keeps them as
 // JSONB for later engine queries (Phase 2).

--- a/internal/collector/kube.go
+++ b/internal/collector/kube.go
@@ -690,6 +690,7 @@ func (k *KubeClient) ListWorkloads(ctx context.Context) ([]WorkloadInfo, error) 
 	return out, nil
 }
 
+//nolint:funcorder // workload helper kept adjacent to ListWorkloads; flagged because ListAllNetworkPolicies sits below
 func (k *KubeClient) listDeployments(ctx context.Context) ([]WorkloadInfo, error) {
 	deps, err := k.clientset.AppsV1().Deployments("").List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -713,6 +714,7 @@ func (k *KubeClient) listDeployments(ctx context.Context) ([]WorkloadInfo, error
 	return out, nil
 }
 
+//nolint:funcorder // workload helper kept adjacent to ListWorkloads; flagged because ListAllNetworkPolicies sits below
 func (k *KubeClient) listStatefulSets(ctx context.Context) ([]WorkloadInfo, error) {
 	sfs, err := k.clientset.AppsV1().StatefulSets("").List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -736,6 +738,7 @@ func (k *KubeClient) listStatefulSets(ctx context.Context) ([]WorkloadInfo, erro
 	return out, nil
 }
 
+//nolint:funcorder // workload helper kept adjacent to ListWorkloads; flagged because ListAllNetworkPolicies sits below
 func (k *KubeClient) listDaemonSets(ctx context.Context) ([]WorkloadInfo, error) {
 	dss, err := k.clientset.AppsV1().DaemonSets("").List(ctx, metav1.ListOptions{})
 	if err != nil {

--- a/internal/collector/kube.go
+++ b/internal/collector/kube.go
@@ -690,7 +690,6 @@ func (k *KubeClient) ListWorkloads(ctx context.Context) ([]WorkloadInfo, error) 
 	return out, nil
 }
 
-//nolint:funcorder // pre-existing helper; flagged after ListNetworkPolicies was appended below
 func (k *KubeClient) listDeployments(ctx context.Context) ([]WorkloadInfo, error) {
 	deps, err := k.clientset.AppsV1().Deployments("").List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -714,7 +713,6 @@ func (k *KubeClient) listDeployments(ctx context.Context) ([]WorkloadInfo, error
 	return out, nil
 }
 
-//nolint:funcorder // pre-existing helper; flagged after ListNetworkPolicies was appended below
 func (k *KubeClient) listStatefulSets(ctx context.Context) ([]WorkloadInfo, error) {
 	sfs, err := k.clientset.AppsV1().StatefulSets("").List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -738,7 +736,6 @@ func (k *KubeClient) listStatefulSets(ctx context.Context) ([]WorkloadInfo, erro
 	return out, nil
 }
 
-//nolint:funcorder // pre-existing helper; flagged after ListNetworkPolicies was appended below
 func (k *KubeClient) listDaemonSets(ctx context.Context) ([]WorkloadInfo, error) {
 	dss, err := k.clientset.AppsV1().DaemonSets("").List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -770,25 +767,6 @@ func (k *KubeClient) ListAllNetworkPolicies(ctx context.Context) ([]NetworkPolic
 	list, err := k.clientset.NetworkingV1().NetworkPolicies("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("list netpols cluster-wide: %w", err)
-	}
-	out := make([]NetworkPolicyInfo, 0, len(list.Items))
-	for _, np := range list.Items { //nolint:gocritic // rangeValCopy: k8s NetworkPolicy is SDK-owned; indexing would couple to SDK internals
-		info, err := convertNetworkPolicy(np)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, info)
-	}
-	return out, nil
-}
-
-// ListNetworkPolicies returns every NetworkPolicy in the given namespace.
-// Selectors and the full spec are JSON-encoded so the store keeps them as
-// JSONB for later engine queries (Phase 2).
-func (k *KubeClient) ListNetworkPolicies(ctx context.Context, namespace string) ([]NetworkPolicyInfo, error) {
-	list, err := k.clientset.NetworkingV1().NetworkPolicies(namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("list netpols in %s: %w", namespace, err)
 	}
 	out := make([]NetworkPolicyInfo, 0, len(list.Items))
 	for _, np := range list.Items { //nolint:gocritic // rangeValCopy: k8s NetworkPolicy is SDK-owned; indexing would couple to SDK internals

--- a/internal/collector/kube_netpol_test.go
+++ b/internal/collector/kube_netpol_test.go
@@ -99,3 +99,39 @@ func TestKubeSourceListNetworkPolicies_EmptyNamespace(t *testing.T) {
 		t.Fatalf("want 0 netpols, got %d", len(got))
 	}
 }
+
+// TestKubeSourceListAllNetworkPolicies_MultiNamespace asserts the cluster-wide
+// list returns NetworkPolicies from every namespace in one call, with each
+// item carrying the correct Namespace field.
+func TestKubeSourceListAllNetworkPolicies_MultiNamespace(t *testing.T) {
+	ctx := context.Background()
+	cs := fake.NewSimpleClientset(
+		&netv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "deny-all", Namespace: "team-a"},
+			Spec:       netv1.NetworkPolicySpec{PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress}},
+		},
+		&netv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "allow-dns", Namespace: "team-b"},
+			Spec:       netv1.NetworkPolicySpec{PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeEgress}},
+		},
+	)
+	src := &KubeClient{clientset: cs}
+
+	got, err := src.ListAllNetworkPolicies(ctx)
+	if err != nil {
+		t.Fatalf("ListAllNetworkPolicies: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 netpols, got %d: %+v", len(got), got)
+	}
+	nsByName := map[string]string{}
+	for _, np := range got {
+		nsByName[np.Name] = np.Namespace
+	}
+	if nsByName["deny-all"] != "team-a" {
+		t.Errorf("deny-all namespace: got %q, want team-a", nsByName["deny-all"])
+	}
+	if nsByName["allow-dns"] != "team-b" {
+		t.Errorf("allow-dns namespace: got %q, want team-b", nsByName["allow-dns"])
+	}
+}

--- a/internal/collector/kube_netpol_test.go
+++ b/internal/collector/kube_netpol_test.go
@@ -19,7 +19,7 @@ const (
 	testLabelAppWeb = "web"
 )
 
-func TestKubeSourceListNetworkPolicies_FakeClient(t *testing.T) {
+func TestKubeSourceListAllNetworkPolicies_SelectorPeer(t *testing.T) {
 	ctx := context.Background()
 	port := intstr.FromInt(8080)
 	proto := corev1.ProtocolTCP
@@ -35,7 +35,7 @@ func TestKubeSourceListNetworkPolicies_FakeClient(t *testing.T) {
 		},
 	})
 	src := &KubeClient{clientset: cs}
-	got, err := src.ListNetworkPolicies(ctx, testNSProd)
+	got, err := src.ListAllNetworkPolicies(ctx)
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
@@ -53,7 +53,7 @@ func TestKubeSourceListNetworkPolicies_FakeClient(t *testing.T) {
 	}
 }
 
-func TestKubeSourceListNetworkPolicies_IPBlock(t *testing.T) {
+func TestKubeSourceListAllNetworkPolicies_IPBlock(t *testing.T) {
 	ctx := context.Background()
 	cs := fake.NewSimpleClientset(&netv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "egress-external", Namespace: testNSProd},
@@ -68,7 +68,7 @@ func TestKubeSourceListNetworkPolicies_IPBlock(t *testing.T) {
 		},
 	})
 	src := &KubeClient{clientset: cs}
-	got, err := src.ListNetworkPolicies(ctx, testNSProd)
+	got, err := src.ListAllNetworkPolicies(ctx)
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
@@ -87,11 +87,11 @@ func TestKubeSourceListNetworkPolicies_IPBlock(t *testing.T) {
 	}
 }
 
-func TestKubeSourceListNetworkPolicies_EmptyNamespace(t *testing.T) {
+func TestKubeSourceListAllNetworkPolicies_Empty(t *testing.T) {
 	ctx := context.Background()
 	cs := fake.NewSimpleClientset()
 	src := &KubeClient{clientset: cs}
-	got, err := src.ListNetworkPolicies(ctx, testNSProd)
+	got, err := src.ListAllNetworkPolicies(ctx)
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}

--- a/internal/collector/kube_netpol_test.go
+++ b/internal/collector/kube_netpol_test.go
@@ -17,6 +17,14 @@ const (
 	testNetPolName  = "api-allow"
 	testNetPolPola  = "pol-a"
 	testLabelAppWeb = "web"
+
+	// Test namespace + netpol names shared across collector tests (extracted
+	// to satisfy goconst).
+	testNetpolNSTeamA  = "team-a"
+	testNetpolNSTeamB  = "team-b"
+	testNetpolNSGhost  = "ghost-ns"
+	testNetpolAllowDNS = "allow-dns"
+	testNetpolOrphan   = "orphan"
 )
 
 func TestKubeSourceListAllNetworkPolicies_SelectorPeer(t *testing.T) {
@@ -107,11 +115,11 @@ func TestKubeSourceListAllNetworkPolicies_MultiNamespace(t *testing.T) {
 	ctx := context.Background()
 	cs := fake.NewSimpleClientset(
 		&netv1.NetworkPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: "deny-all", Namespace: "team-a"},
+			ObjectMeta: metav1.ObjectMeta{Name: "deny-all", Namespace: testNetpolNSTeamA},
 			Spec:       netv1.NetworkPolicySpec{PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeIngress}},
 		},
 		&netv1.NetworkPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: "allow-dns", Namespace: "team-b"},
+			ObjectMeta: metav1.ObjectMeta{Name: testNetpolAllowDNS, Namespace: testNetpolNSTeamB},
 			Spec:       netv1.NetworkPolicySpec{PolicyTypes: []netv1.PolicyType{netv1.PolicyTypeEgress}},
 		},
 	)
@@ -128,10 +136,10 @@ func TestKubeSourceListAllNetworkPolicies_MultiNamespace(t *testing.T) {
 	for _, np := range got {
 		nsByName[np.Name] = np.Namespace
 	}
-	if nsByName["deny-all"] != "team-a" {
-		t.Errorf("deny-all namespace: got %q, want team-a", nsByName["deny-all"])
+	if nsByName["deny-all"] != testNetpolNSTeamA {
+		t.Errorf("deny-all namespace: got %q, want %s", nsByName["deny-all"], testNetpolNSTeamA)
 	}
-	if nsByName["allow-dns"] != "team-b" {
-		t.Errorf("allow-dns namespace: got %q, want team-b", nsByName["allow-dns"])
+	if nsByName[testNetpolAllowDNS] != testNetpolNSTeamB {
+		t.Errorf("allow-dns namespace: got %q, want %s", nsByName[testNetpolAllowDNS], testNetpolNSTeamB)
 	}
 }

--- a/internal/collector/netpol_collector.go
+++ b/internal/collector/netpol_collector.go
@@ -60,6 +60,7 @@ func CollectNetworkPolicies(
 		nsID, ok := namespaceIDsByName[info.Namespace]
 		if !ok {
 			slog.Warn("collector: netpol in unknown namespace; skipping",
+				slog.String("cluster", clusterID.String()),
 				slog.String("netpol", info.Name),
 				slog.String("namespace", info.Namespace))
 			continue
@@ -78,10 +79,21 @@ func CollectNetworkPolicies(
 		seenByNS[nsID] = append(seenByNS[nsID], info.Name)
 	}
 
-	for _, nsID := range namespaceIDsByName {
+	var sweepFailures int
+	for nsName, nsID := range namespaceIDsByName {
 		if err := st.SweepNetworkPoliciesByNamespace(ctx, nsID, seenByNS[nsID]); err != nil {
-			return fmt.Errorf("sweep netpols in ns %s: %w", nsID, err)
+			slog.Warn("collector: sweep netpols failed",
+				slog.String("cluster", clusterID.String()),
+				slog.String("namespace", nsName),
+				slog.Any("err", err))
+			sweepFailures++
+			// per CLAUDE.md reconcile contract: other namespaces still need
+			// their sweep — don't let one failure block the rest
+			continue
 		}
+	}
+	if sweepFailures > 0 {
+		return fmt.Errorf("sweep netpols: %d namespace(s) failed", sweepFailures)
 	}
 	return nil
 }

--- a/internal/collector/netpol_collector.go
+++ b/internal/collector/netpol_collector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"github.com/google/uuid"
 
@@ -24,17 +25,45 @@ type NetPolStore interface {
 	SweepNetworkPoliciesByNamespace(ctx context.Context, nsID uuid.UUID, seen []string) error
 }
 
-// CollectNetworkPolicies runs one tick of NetworkPolicy reconciliation
-// for a single (cluster, namespace). MUST only be called after the kube
-// list call succeeds — transient API errors must never wipe the store
-// (CLAUDE.md reconcile contract).
-func CollectNetworkPolicies(ctx context.Context, src KubeSource, st NetPolStore, clusterID, nsID uuid.UUID, nsName string) error {
-	infos, err := src.ListNetworkPolicies(ctx, nsName)
+// CollectNetworkPolicies runs one tick of NetworkPolicy reconciliation for
+// the local cluster. Issues ONE cluster-wide list call (replaces the
+// per-namespace fan-out that exhausted client-go's rate limiter on
+// large clusters — bugfix 2026-06-10). Groups results by namespace,
+// upserts each, and sweeps every known namespace (per the reconcile
+// contract — even empty ones, to clean up stale rows). Netpols in unknown
+// namespaces (created between ingestNamespaces and this call) are skipped
+// and picked up on the next tick — same pattern as ingestServices.
+//
+// MUST only be called after the kube list call succeeds — transient API
+// errors must never wipe the store (CLAUDE.md reconcile contract).
+func CollectNetworkPolicies(
+	ctx context.Context,
+	src KubeSource,
+	st NetPolStore,
+	clusterID uuid.UUID,
+	namespaceIDsByName map[string]uuid.UUID,
+) error {
+	infos, err := src.ListAllNetworkPolicies(ctx)
 	if err != nil {
-		return fmt.Errorf("list netpols in %s: %w", nsName, err)
+		return fmt.Errorf("list netpols cluster-wide: %w", err)
 	}
-	seen := make([]string, 0, len(infos))
+
+	// Pre-seed seen map for every known namespace so the sweep below runs
+	// even on namespaces with zero netpols (cleans up stale rows after a
+	// NetworkPolicy is deleted from K8s).
+	seenByNS := make(map[uuid.UUID][]string, len(namespaceIDsByName))
+	for _, nsID := range namespaceIDsByName {
+		seenByNS[nsID] = make([]string, 0)
+	}
+
 	for _, info := range infos { //nolint:gocritic // rangeValCopy: NetworkPolicyInfo has slices; shallow copy is safe here
+		nsID, ok := namespaceIDsByName[info.Namespace]
+		if !ok {
+			slog.Warn("collector: netpol in unknown namespace; skipping",
+				slog.String("netpol", info.Name),
+				slog.String("namespace", info.Namespace))
+			continue
+		}
 		rules := flattenNetPolRules(info)
 		if _, err := st.UpsertNetworkPolicy(ctx, store.NetworkPolicy{
 			ClusterID:   clusterID,
@@ -44,12 +73,15 @@ func CollectNetworkPolicies(ctx context.Context, src KubeSource, st NetPolStore,
 			PolicyTypes: info.PolicyTypes,
 			SpecRaw:     info.SpecRaw,
 		}, rules); err != nil {
-			return fmt.Errorf("upsert netpol %q: %w", info.Name, err)
+			return fmt.Errorf("upsert netpol %s/%s: %w", info.Namespace, info.Name, err)
 		}
-		seen = append(seen, info.Name)
+		seenByNS[nsID] = append(seenByNS[nsID], info.Name)
 	}
-	if err := st.SweepNetworkPoliciesByNamespace(ctx, nsID, seen); err != nil {
-		return fmt.Errorf("sweep: %w", err)
+
+	for _, nsID := range namespaceIDsByName {
+		if err := st.SweepNetworkPoliciesByNamespace(ctx, nsID, seenByNS[nsID]); err != nil {
+			return fmt.Errorf("sweep netpols in ns %s: %w", nsID, err)
+		}
 	}
 	return nil
 }

--- a/internal/collector/netpol_collector.go
+++ b/internal/collector/netpol_collector.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -10,6 +11,12 @@ import (
 
 	"github.com/sthalbert/longue-vue/internal/store"
 )
+
+// errNetpolSweepFailed is a sentinel returned by CollectNetworkPolicies
+// when one or more per-namespace sweeps failed — individual failures are
+// already logged with full context inside the loop; this error gives the
+// caller a single signal for the tick outcome.
+var errNetpolSweepFailed = errors.New("sweep netpols: one or more namespaces failed")
 
 const (
 	peerKindSelector = "selector"
@@ -93,7 +100,7 @@ func CollectNetworkPolicies(
 		}
 	}
 	if sweepFailures > 0 {
-		return fmt.Errorf("sweep netpols: %d namespace(s) failed", sweepFailures)
+		return fmt.Errorf("%w (%d)", errNetpolSweepFailed, sweepFailures)
 	}
 	return nil
 }

--- a/internal/collector/netpol_collector_test.go
+++ b/internal/collector/netpol_collector_test.go
@@ -63,7 +63,6 @@ func (f *fakeNetPolStore) sweepNamesForNS(nsID uuid.UUID) (names []string, found
 	return nil, false
 }
 
-
 func TestCollectNetworkPolicies_HappyPath(t *testing.T) {
 	ctx := t.Context()
 	clusterID, nsA, nsB := uuid.New(), uuid.New(), uuid.New()

--- a/internal/collector/netpol_collector_test.go
+++ b/internal/collector/netpol_collector_test.go
@@ -69,13 +69,13 @@ func TestCollectNetworkPolicies_HappyPath(t *testing.T) {
 	clusterID, nsA, nsB := uuid.New(), uuid.New(), uuid.New()
 	src := &fakeSource{
 		netpols: []NetworkPolicyInfo{
-			{Name: "deny-all", Namespace: "team-a", PodSelector: []byte(`{}`), SpecRaw: []byte(`{}`)},
-			{Name: "deny-egress", Namespace: "team-a", PodSelector: []byte(`{}`), SpecRaw: []byte(`{}`)},
-			{Name: "allow-dns", Namespace: "team-b", PodSelector: []byte(`{}`), SpecRaw: []byte(`{}`)},
+			{Name: "deny-all", Namespace: testNetpolNSTeamA, PodSelector: []byte(`{}`), SpecRaw: []byte(`{}`)},
+			{Name: "deny-egress", Namespace: testNetpolNSTeamA, PodSelector: []byte(`{}`), SpecRaw: []byte(`{}`)},
+			{Name: testNetpolAllowDNS, Namespace: testNetpolNSTeamB, PodSelector: []byte(`{}`), SpecRaw: []byte(`{}`)},
 		},
 	}
 	st := newFakeNetPolStore()
-	nsByName := map[string]uuid.UUID{"team-a": nsA, "team-b": nsB}
+	nsByName := map[string]uuid.UUID{testNetpolNSTeamA: nsA, testNetpolNSTeamB: nsB}
 
 	if err := CollectNetworkPolicies(ctx, src, st, clusterID, nsByName); err != nil {
 		t.Fatalf("CollectNetworkPolicies: %v", err)
@@ -89,7 +89,7 @@ func TestCollectNetworkPolicies_HappyPath(t *testing.T) {
 	if got, ok := st.sweepNamesForNS(nsA); !ok || len(got) != 2 {
 		t.Errorf("nsA sweep seen: got %v (ok=%v), want 2 entries", got, ok)
 	}
-	if got, ok := st.sweepNamesForNS(nsB); !ok || len(got) != 1 || got[0] != "allow-dns" {
+	if got, ok := st.sweepNamesForNS(nsB); !ok || len(got) != 1 || got[0] != testNetpolAllowDNS {
 		t.Errorf("nsB sweep seen: got %v (ok=%v), want [allow-dns]", got, ok)
 	}
 }
@@ -99,12 +99,12 @@ func TestCollectNetworkPolicies_UnknownNamespaceSkipped(t *testing.T) {
 	clusterID, nsA := uuid.New(), uuid.New()
 	src := &fakeSource{
 		netpols: []NetworkPolicyInfo{
-			{Name: "good", Namespace: "team-a", PodSelector: []byte(`{}`), SpecRaw: []byte(`{}`)},
-			{Name: "orphan", Namespace: "ghost-ns", PodSelector: []byte(`{}`), SpecRaw: []byte(`{}`)},
+			{Name: "good", Namespace: testNetpolNSTeamA, PodSelector: []byte(`{}`), SpecRaw: []byte(`{}`)},
+			{Name: testNetpolOrphan, Namespace: testNetpolNSGhost, PodSelector: []byte(`{}`), SpecRaw: []byte(`{}`)},
 		},
 	}
 	st := newFakeNetPolStore()
-	nsByName := map[string]uuid.UUID{"team-a": nsA}
+	nsByName := map[string]uuid.UUID{testNetpolNSTeamA: nsA}
 
 	if err := CollectNetworkPolicies(ctx, src, st, clusterID, nsByName); err != nil {
 		t.Fatalf("CollectNetworkPolicies: %v", err)
@@ -122,11 +122,11 @@ func TestCollectNetworkPolicies_EmptyNamespaceSweeps(t *testing.T) {
 	clusterID, nsA, nsB := uuid.New(), uuid.New(), uuid.New()
 	src := &fakeSource{
 		netpols: []NetworkPolicyInfo{
-			{Name: "only-one", Namespace: "team-a", PodSelector: []byte(`{}`), SpecRaw: []byte(`{}`)},
+			{Name: "only-one", Namespace: testNetpolNSTeamA, PodSelector: []byte(`{}`), SpecRaw: []byte(`{}`)},
 		},
 	}
 	st := newFakeNetPolStore()
-	nsByName := map[string]uuid.UUID{"team-a": nsA, "team-b": nsB}
+	nsByName := map[string]uuid.UUID{testNetpolNSTeamA: nsA, testNetpolNSTeamB: nsB}
 
 	if err := CollectNetworkPolicies(ctx, src, st, clusterID, nsByName); err != nil {
 		t.Fatalf("CollectNetworkPolicies: %v", err)

--- a/internal/collector/netpol_collector_test.go
+++ b/internal/collector/netpol_collector_test.go
@@ -63,18 +63,6 @@ func (f *fakeNetPolStore) sweepNamesForNS(nsID uuid.UUID) (names []string, found
 	return nil, false
 }
 
-// sweepCountForNS returns how many sweep calls were recorded for nsID.
-func (f *fakeNetPolStore) sweepCountForNS(nsID uuid.UUID) int {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	n := 0
-	for _, s := range f.sweeps {
-		if s.nsID == nsID {
-			n++
-		}
-	}
-	return n
-}
 
 func TestCollectNetworkPolicies_HappyPath(t *testing.T) {
 	ctx := t.Context()

--- a/internal/collector/netpol_collector_test.go
+++ b/internal/collector/netpol_collector_test.go
@@ -49,113 +49,110 @@ func (f *fakeNetPolStore) SweepNetworkPoliciesByNamespace(_ context.Context, nsI
 	return nil
 }
 
-func TestCollectNetworkPolicies_SinglePolicy(t *testing.T) {
-	ctx := context.Background()
-	clusterID := uuid.New()
-	nsID := uuid.New()
+// sweepNamesForNS returns the names from the most-recent sweep for nsID, and
+// whether any sweep for that namespace was recorded at all. Helps assertions
+// stay independent of sweep ordering.
+func (f *fakeNetPolStore) sweepNamesForNS(nsID uuid.UUID) (names []string, found bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i := len(f.sweeps) - 1; i >= 0; i-- {
+		if f.sweeps[i].nsID == nsID {
+			return f.sweeps[i].names, true
+		}
+	}
+	return nil, false
+}
 
+// sweepCountForNS returns how many sweep calls were recorded for nsID.
+func (f *fakeNetPolStore) sweepCountForNS(nsID uuid.UUID) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, s := range f.sweeps {
+		if s.nsID == nsID {
+			n++
+		}
+	}
+	return n
+}
+
+func TestCollectNetworkPolicies_HappyPath(t *testing.T) {
+	ctx := t.Context()
+	clusterID, nsA, nsB := uuid.New(), uuid.New(), uuid.New()
 	src := &fakeSource{
 		netpols: []NetworkPolicyInfo{
-			{
-				Name:        testNetPolName,
-				Namespace:   testNSProd,
-				PolicyTypes: []string{"Ingress"},
-				Ingress: []NetworkPolicyRuleInfo{
-					{
-						Peers: []NetworkPolicyPeerInfo{{Kind: peerKindSelector}},
-						Ports: []byte(`[{"port":8080}]`),
-					},
-				},
-			},
+			{Name: "deny-all", Namespace: "team-a", PodSelector: []byte(`{}`), SpecRaw: []byte(`{}`)},
+			{Name: "deny-egress", Namespace: "team-a", PodSelector: []byte(`{}`), SpecRaw: []byte(`{}`)},
+			{Name: "allow-dns", Namespace: "team-b", PodSelector: []byte(`{}`), SpecRaw: []byte(`{}`)},
 		},
 	}
 	st := newFakeNetPolStore()
+	nsByName := map[string]uuid.UUID{"team-a": nsA, "team-b": nsB}
 
-	if err := CollectNetworkPolicies(ctx, src, st, clusterID, nsID, testNSProd); err != nil {
+	if err := CollectNetworkPolicies(ctx, src, st, clusterID, nsByName); err != nil {
 		t.Fatalf("CollectNetworkPolicies: %v", err)
 	}
+	if len(st.upserts) != 3 {
+		t.Errorf("upserts: got %d, want 3", len(st.upserts))
+	}
+	if len(st.sweeps) != 2 {
+		t.Errorf("sweeps: got %d, want 2 (one per known ns)", len(st.sweeps))
+	}
+	if got, ok := st.sweepNamesForNS(nsA); !ok || len(got) != 2 {
+		t.Errorf("nsA sweep seen: got %v (ok=%v), want 2 entries", got, ok)
+	}
+	if got, ok := st.sweepNamesForNS(nsB); !ok || len(got) != 1 || got[0] != "allow-dns" {
+		t.Errorf("nsB sweep seen: got %v (ok=%v), want [allow-dns]", got, ok)
+	}
+}
 
+func TestCollectNetworkPolicies_UnknownNamespaceSkipped(t *testing.T) {
+	ctx := t.Context()
+	clusterID, nsA := uuid.New(), uuid.New()
+	src := &fakeSource{
+		netpols: []NetworkPolicyInfo{
+			{Name: "good", Namespace: "team-a", PodSelector: []byte(`{}`), SpecRaw: []byte(`{}`)},
+			{Name: "orphan", Namespace: "ghost-ns", PodSelector: []byte(`{}`), SpecRaw: []byte(`{}`)},
+		},
+	}
+	st := newFakeNetPolStore()
+	nsByName := map[string]uuid.UUID{"team-a": nsA}
+
+	if err := CollectNetworkPolicies(ctx, src, st, clusterID, nsByName); err != nil {
+		t.Fatalf("CollectNetworkPolicies: %v", err)
+	}
 	if len(st.upserts) != 1 {
-		t.Fatalf("want 1 upsert, got %d", len(st.upserts))
+		t.Errorf("upserts: got %d, want 1 (orphan should be skipped)", len(st.upserts))
 	}
-	if st.upserts[0].Name != testNetPolName {
-		t.Fatalf("upserted name: %q", st.upserts[0].Name)
-	}
-	if len(st.replaces) != 1 {
-		t.Fatalf("want 1 replace call, got %d", len(st.replaces))
-	}
-	if len(st.sweeps) != 1 {
-		t.Fatalf("want 1 sweep call, got %d", len(st.sweeps))
-	}
-	if len(st.sweeps[0].names) != 1 || st.sweeps[0].names[0] != testNetPolName {
-		t.Fatalf("sweep names: %v", st.sweeps[0].names)
+	if got, ok := st.sweepNamesForNS(nsA); !ok || len(got) != 1 || got[0] != "good" {
+		t.Errorf("nsA sweep seen: got %v (ok=%v), want [good]", got, ok)
 	}
 }
 
-func TestCollectNetworkPolicies_SweepDropsGone(t *testing.T) {
-	ctx := context.Background()
-	clusterID := uuid.New()
-	nsID := uuid.New()
-
-	// Round 1: two policies.
+func TestCollectNetworkPolicies_EmptyNamespaceSweeps(t *testing.T) {
+	ctx := t.Context()
+	clusterID, nsA, nsB := uuid.New(), uuid.New(), uuid.New()
 	src := &fakeSource{
 		netpols: []NetworkPolicyInfo{
-			{Name: testNetPolPola, Namespace: testNSProd},
-			{Name: "pol-b", Namespace: testNSProd},
+			{Name: "only-one", Namespace: "team-a", PodSelector: []byte(`{}`), SpecRaw: []byte(`{}`)},
 		},
 	}
 	st := newFakeNetPolStore()
+	nsByName := map[string]uuid.UUID{"team-a": nsA, "team-b": nsB}
 
-	if err := CollectNetworkPolicies(ctx, src, st, clusterID, nsID, testNSProd); err != nil {
-		t.Fatalf("round 1: %v", err)
-	}
-	if len(st.upserts) != 2 {
-		t.Fatalf("round 1: want 2 upserts, got %d", len(st.upserts))
-	}
-	sweep1 := st.sweeps[0].names
-	if len(sweep1) != 2 {
-		t.Fatalf("round 1 sweep names: %v", sweep1)
-	}
-
-	// Round 2: only pol-a remains.
-	src.netpols = []NetworkPolicyInfo{
-		{Name: testNetPolPola, Namespace: testNSProd},
-	}
-
-	if err := CollectNetworkPolicies(ctx, src, st, clusterID, nsID, testNSProd); err != nil {
-		t.Fatalf("round 2: %v", err)
-	}
-	sweep2 := st.sweeps[1].names
-	if len(sweep2) != 1 || sweep2[0] != testNetPolPola {
-		t.Fatalf("round 2 sweep should contain only pol-a, got %v", sweep2)
-	}
-}
-
-func TestCollectNetworkPolicies_EmptyNamespace(t *testing.T) {
-	ctx := context.Background()
-	clusterID := uuid.New()
-	nsID := uuid.New()
-
-	src := &fakeSource{netpols: nil}
-	st := newFakeNetPolStore()
-
-	if err := CollectNetworkPolicies(ctx, src, st, clusterID, nsID, testNSProd); err != nil {
+	if err := CollectNetworkPolicies(ctx, src, st, clusterID, nsByName); err != nil {
 		t.Fatalf("CollectNetworkPolicies: %v", err)
 	}
-
-	if len(st.upserts) != 0 {
-		t.Fatalf("want 0 upserts, got %d", len(st.upserts))
+	if len(st.sweeps) != 2 {
+		t.Errorf("sweeps: got %d, want 2 (every known ns gets a sweep)", len(st.sweeps))
 	}
-	if len(st.sweeps) != 1 {
-		t.Fatalf("want 1 sweep, got %d", len(st.sweeps))
-	}
-	if len(st.sweeps[0].names) != 0 {
-		t.Fatalf("want empty sweep names, got %v", st.sweeps[0].names)
+	if got, ok := st.sweepNamesForNS(nsB); !ok || len(got) != 0 {
+		t.Errorf("nsB sweep: got (%v, ok=%v), want ([], ok=true)", got, ok)
 	}
 }
 
 func TestCollectNetworkPolicies_IPBlockPeer(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	clusterID := uuid.New()
 	nsID := uuid.New()
 
@@ -178,8 +175,9 @@ func TestCollectNetworkPolicies_IPBlockPeer(t *testing.T) {
 		},
 	}
 	st := newFakeNetPolStore()
+	nsByName := map[string]uuid.UUID{testNSProd: nsID}
 
-	if err := CollectNetworkPolicies(ctx, src, st, clusterID, nsID, testNSProd); err != nil {
+	if err := CollectNetworkPolicies(ctx, src, st, clusterID, nsByName); err != nil {
 		t.Fatalf("CollectNetworkPolicies: %v", err)
 	}
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -901,6 +901,10 @@ func (f *fakeKubeSource) ListNetworkPolicies(_ context.Context, _ string) ([]col
 	return nil, nil
 }
 
+func (f *fakeKubeSource) ListAllNetworkPolicies(_ context.Context) ([]collector.NetworkPolicyInfo, error) {
+	return nil, nil
+}
+
 // notifyingStore wraps a CmdbStore and closes tickDone after the first
 // successful UpsertPersistentVolumeClaim, which is the last write in a tick.
 type notifyingStore struct {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -897,10 +897,6 @@ func (f *fakeKubeSource) ListPersistentVolumeClaims(_ context.Context) ([]collec
 	return f.pvcs, nil
 }
 
-func (f *fakeKubeSource) ListNetworkPolicies(_ context.Context, _ string) ([]collector.NetworkPolicyInfo, error) {
-	return nil, nil
-}
-
 func (f *fakeKubeSource) ListAllNetworkPolicies(_ context.Context) ([]collector.NetworkPolicyInfo, error) {
 	return nil, nil
 }


### PR DESCRIPTION
  ## Summary

  Fix the 68-per-tick `netpol tick failed` storm on preprod-main (`longue-vue-collector:1.4.0`). The collector was issuing one `client-go NetworkPolicies(ns).List()` call **per namespace** (68 calls/tick on preprod) instead of one cluster-wide `NetworkPolicies("").List()` like Services/Ingresses/PVCs already do. client-go's rate limiter timed out every call
  → 0 NetworkPolicies ingested.

  After this PR: **1 K8s API call per tick**, all NetworkPolicies ingested, log spam gone. Targets the 1.4.1 patch release.

  ## Why the "iterates over tenants" interpretation was a misread

  Each of the 68 errors logged the local push collector's cluster UUID via `slog`. 68 identical UUIDs in the log stream read as "many tenants" — they were 68 namespaces in the **same** cluster, each hitting the rate limiter independently because the per-namespace fan-out had no aggregate budget. No multi-cluster or tenant iteration was ever happening.

  ## Architecture
  
  Before:                              After:
  ingestNetworkPolicies                ingestNetworkPolicies
    for ns in 68:                        CollectNetworkPolicies(nsByName)
      CollectNetworkPolicies(ns)          src.ListAllNetworkPolicies(ctx)  ← 1 call
        src.ListNetworkPolicies(ns)        // group by Namespace
          ← K8s API call (rate limited!)   for each known ns:
                                             sweep

  `KubeSource.ListNetworkPolicies(ctx, ns)` deleted entirely; replaced by `ListAllNetworkPolicies(ctx)` matching the existing `ListServices`/`ListIngresses`/`ListPersistentVolumeClaims` pattern. `NetworkPolicyInfo.Namespace` was already populated by `convertNetworkPolicy` — no struct change needed.

  ## Behavior preserved

  - Upsert set on a known cluster state is **identical** before/after
  - Sweep set is identical (every known namespace gets one, including empty ones for stale-row cleanup)
  - Reconcile contract upheld: list failure → no writes, no sweeps (transient errors never wipe the store)
  - Unknown-namespace skip mirrors `ingestServices` pattern (`if !ok { log + continue }`)
  - Sweep error semantics **strengthened**: per-namespace failures now `log + continue` (other namespaces still get swept) instead of aborting the tick — aligns with `reconcilePerNamespace`

  ## Files changed (~150 LOC net negative)

  | Layer | Change |
  |---|---|
  | Interface | `KubeSource.ListNetworkPolicies(ctx, ns)` → `ListAllNetworkPolicies(ctx)` |
  | K8s client | `KubeClient.ListAllNetworkPolicies` — `NetworkPolicies("").List(ctx, ...)` |
  | Collector | `CollectNetworkPolicies(ctx, src, st, clusterID, namespaceIDsByName)` — one list, group, per-NS sweep |
  | Caller | `(*Collector).ingestNetworkPolicies` — single call, no for-loop |
  | Tests | 7 unit tests + integration test updated, all 4 fake `KubeSource` impls migrated |
  | Compile-time | `var _ collector.NetPolStore = (*apiclient.Store)(nil)` assertion still enforces ADR-0038 push path |

  ## Test plan

  - [x] `go test ./internal/collector/... ./internal/api/... ./internal/integration/...` — all green
  - [x] New unit tests cover happy path (multi-NS), unknown-namespace skip, empty-namespace sweep, IPBlock peer conversion, selector peer conversion
  - [x] Integration test (`TestPushCollector_NetPol_EndToEnd`) green — 2-tick add-then-delete scenario through real PG + apiclient
  - [x] `make check` — fmt/vet/build/test/ui-test all green
  - [x] `golangci-lint run --new-from-rev=origin/main` — 0 new issues
  - [x] `govulncheck` — 0 affecting vulns
  - [x] `gosec` — 0 issues on touched code
  - [x] `commitlint` on all 6 commits — all pass conventional format
  - [x] **Manual**: deploy `longue-vue-collector:1.4.1` candidate on preprod-main → confirm 1 `ingested netpols` log line per tick, `SELECT count(*) FROM network_policies WHERE cluster_id = ...` > 0

  ## Out of scope

  - **Per-tick context timeout** (pre-existing 1.3.0 issue affecting services/pvcs/ingresses too — they each consume budget from the shared `c.fetchTimeout`). After this fix, netpol consumes 1× the budget instead of 68× so the pressure is dramatically reduced; a separate cleanup can address the shared-timeout architecture.
  - **Metrics on `CollectNetworkPolicies`** — it's package-level (shared with push collector per ADR-0038) and doesn't capture `c.clusterName` for `metrics.Mark*` calls today. The bug would have been instantly visible if `longue_vue_collector_errors_total{resource="networkpolicies",op="list"}` existed; tracked as follow-up.

  ## Release

  - `cmd/longue-vue-collector` → **1.4.1 patch**
  - No chart changes (RBAC already grants cluster-wide list per ADR-0034)
  - No ADR — follows established Services/Ingresses/PVCs pattern