### PR TITLE
feat(chart): expose longue-vue via Gateway API (HTTPRoute + Envoy Gateway SecurityPolicy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,26 @@ jobs:
             --set postgresql.enabled=false \
             --set externalDatabase.url="postgres://longue_vue:test@pg:5432/longue_vue" > /dev/null
 
+      - name: Template renders cleanly (HTTPRoute exposure)
+        run: |
+          helm template longue-vue charts/longue-vue \
+            --set postgresql.enabled=false \
+            --set externalDatabase.url="postgres://longue_vue:test@pg:5432/longue_vue" \
+            --set httpRoute.enabled=true \
+            --set httpRoute.parentRefs[0].name=shared-gw \
+            --set httpRoute.parentRefs[0].namespace=envoy-gateway-system \
+            --set httpRoute.hostnames[0]=longue-vue.example.com > /dev/null
+
+      - name: Template renders cleanly (HTTPRoute + SecurityPolicy)
+        run: |
+          helm template longue-vue charts/longue-vue \
+            --set postgresql.enabled=false \
+            --set externalDatabase.url="postgres://longue_vue:test@pg:5432/longue_vue" \
+            --set httpRoute.enabled=true \
+            --set httpRoute.parentRefs[0].name=shared-gw \
+            --set securityPolicy.enabled=true \
+            --set securityPolicy.cors.allowOrigins[0]="https://longue-vue.example.com" > /dev/null
+
   docker:
     name: docker build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,23 @@ jobs:
             --set securityPolicy.enabled=true \
             --set securityPolicy.cors.allowOrigins[0]="https://longue-vue.example.com" > /dev/null
 
+      - name: Template guards fire on misconfiguration
+        run: |
+          set -e
+          if helm template longue-vue charts/longue-vue \
+            --set postgresql.enabled=false \
+            --set externalDatabase.url="postgres://longue_vue:test@pg:5432/longue_vue" \
+            --set httpRoute.enabled=true > /dev/null 2>&1; then
+            echo "FAIL: expected render error for httpRoute.enabled with empty parentRefs"; exit 1
+          fi
+          if helm template longue-vue charts/longue-vue \
+            --set postgresql.enabled=false \
+            --set externalDatabase.url="postgres://longue_vue:test@pg:5432/longue_vue" \
+            --set securityPolicy.enabled=true > /dev/null 2>&1; then
+            echo "FAIL: expected render error for securityPolicy without httpRoute"; exit 1
+          fi
+          echo "guards fired as expected"
+
   docker:
     name: docker build
     runs-on: ubuntu-latest

--- a/charts/longue-vue/templates/NOTES.txt
+++ b/charts/longue-vue/templates/NOTES.txt
@@ -1,7 +1,14 @@
 longue-vue has been installed.
 
 1. Get the application URL:
-{{- if .Values.ingress.enabled }}
+{{- if .Values.httpRoute.enabled }}
+  (Requires Gateway API CRDs + an Envoy Gateway already installed; Helm does not install them.)
+{{- range $host := .Values.httpRoute.hostnames }}
+  https://{{ $host }}
+{{- else }}
+  (HTTPRoute enabled with no hostnames — reachable via the Gateway's address.)
+{{- end }}
+{{- else if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}
 {{- end }}
@@ -26,3 +33,9 @@ longue-vue has been installed.
      -d '{"name":"my-cluster"}'
 
 Documentation: https://github.com/sthalbert/longue-vue/tree/main/docs
+
+{{- if .Values.ingress.enabled }}
+
+WARNING: `ingress.enabled` is DEPRECATED and will be removed in the next major
+chart version. Migrate to `httpRoute` (Gateway API). See ADR-0039.
+{{- end }}

--- a/charts/longue-vue/templates/httproute.yaml
+++ b/charts/longue-vue/templates/httproute.yaml
@@ -7,16 +7,18 @@ metadata:
   labels:
     {{- include "longue-vue.labels" . | nindent 4 }}
 spec:
+  {{- with .Values.httpRoute.parentRefs }}
   parentRefs:
-    {{- range .Values.httpRoute.parentRefs }}
-    - name: {{ .name }}
+    {{- range . }}
+    - name: {{ required "httpRoute.parentRefs[].name is required when httpRoute.enabled" .name | quote }}
       {{- with .namespace }}
-      namespace: {{ . }}
+      namespace: {{ . | quote }}
       {{- end }}
       {{- with .sectionName }}
-      sectionName: {{ . }}
+      sectionName: {{ . | quote }}
       {{- end }}
     {{- end }}
+  {{- end }}
   {{- with .Values.httpRoute.hostnames }}
   hostnames:
     {{- range . }}

--- a/charts/longue-vue/templates/httproute.yaml
+++ b/charts/longue-vue/templates/httproute.yaml
@@ -7,10 +7,12 @@ metadata:
   labels:
     {{- include "longue-vue.labels" . | nindent 4 }}
 spec:
-  {{- with .Values.httpRoute.parentRefs }}
+  {{- if not .Values.httpRoute.parentRefs }}
+  {{- fail "httpRoute.parentRefs must list at least one Gateway when httpRoute.enabled=true" }}
+  {{- end }}
   parentRefs:
-    {{- range . }}
-    - name: {{ required "httpRoute.parentRefs[].name is required when httpRoute.enabled" .name | quote }}
+    {{- range .Values.httpRoute.parentRefs }}
+    - name: {{ required "httpRoute.parentRefs[].name is required" .name | quote }}
       {{- with .namespace }}
       namespace: {{ . | quote }}
       {{- end }}
@@ -18,7 +20,6 @@ spec:
       sectionName: {{ . | quote }}
       {{- end }}
     {{- end }}
-  {{- end }}
   {{- with .Values.httpRoute.hostnames }}
   hostnames:
     {{- range . }}

--- a/charts/longue-vue/templates/httproute.yaml
+++ b/charts/longue-vue/templates/httproute.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "longue-vue.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "longue-vue.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    {{- range .Values.httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .sectionName }}
+      sectionName: {{ . }}
+      {{- end }}
+    {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "longue-vue.fullname" . }}
+          port: {{ .Values.service.port }}
+    {{- /*
+    Optional: expose MCP SSE at the edge (off by default — parity with the old Ingress).
+    Uncomment and ensure mcp.enabled + mcp.transport=sse so the Service exposes the mcp port.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /mcp
+      backendRefs:
+        - name: {{ include "longue-vue.fullname" . }}
+          port: {{ .Values.service.mcpPort }}
+    */}}
+{{- end }}

--- a/charts/longue-vue/templates/securitypolicy.yaml
+++ b/charts/longue-vue/templates/securitypolicy.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.securityPolicy.enabled }}
+{{- if not .Values.httpRoute.enabled }}
+{{- fail "securityPolicy.enabled requires httpRoute.enabled=true (the policy targets the chart's HTTPRoute)" }}
+{{- end }}
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
@@ -7,10 +10,10 @@ metadata:
   labels:
     {{- include "longue-vue.labels" . | nindent 4 }}
 spec:
-  targetRef:
-    group: gateway.networking.k8s.io
-    kind: HTTPRoute
-    name: {{ include "longue-vue.fullname" . }}
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ include "longue-vue.fullname" . }}
   {{- with .Values.securityPolicy.cors }}
   cors:
     {{- toYaml . | nindent 4 }}

--- a/charts/longue-vue/templates/securitypolicy.yaml
+++ b/charts/longue-vue/templates/securitypolicy.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.securityPolicy.enabled }}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ include "longue-vue.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "longue-vue.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: {{ include "longue-vue.fullname" . }}
+  {{- with .Values.securityPolicy.cors }}
+  cors:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.securityPolicy.authorization }}
+  authorization:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/longue-vue/values.yaml
+++ b/charts/longue-vue/values.yaml
@@ -261,7 +261,9 @@ flowMatrix:
     # Prometheus ruleSelector).
     labels: {}
 
-# -- Ingress (expose longue-vue outside the cluster).
+# -- DEPRECATED: legacy Ingress exposure. Removed in the next major chart version.
+#    Migrate to `httpRoute` above. Under Gateway API, TLS terminates on the Gateway
+#    listener (operator-owned), so `ingress.tls` has no Gateway-path equivalent here.
 ingress:
   enabled: false
   className: ""

--- a/charts/longue-vue/values.yaml
+++ b/charts/longue-vue/values.yaml
@@ -282,11 +282,11 @@ ingress:
 #    TLS terminates on the Gateway listener, not here.
 httpRoute:
   enabled: false
-  # parentRefs: the shared Gateway(s) this route attaches to.
-  parentRefs:
-    - name: ""          # REQUIRED when enabled — shared Gateway name
-      namespace: ""     # Gateway namespace (defaults to release namespace if empty)
-      sectionName: ""   # optional Gateway listener section (e.g. the HTTPS listener)
+  # parentRefs: the shared Gateway(s) this route attaches to (REQUIRED when enabled).
+  parentRefs: []
+  #  - name: shared-gateway       # name of the Gateway to attach to
+  #    namespace: gateway-system  # omit to default to the release namespace
+  #    sectionName: https         # omit to attach to all listeners
   hostnames: []
   #  - longue-vue.example.com
 

--- a/charts/longue-vue/values.yaml
+++ b/charts/longue-vue/values.yaml
@@ -297,8 +297,8 @@ httpRoute:
 #    SecurityPolicy for overlapping settings on this route.
 securityPolicy:
   enabled: false
-  cors: {}              # e.g. allowOrigins: ["https://longue-vue.example.com"]
-  authorization: {}     # e.g. defaultAction: Deny + rules with client CIDR principals
+  cors: {}              # rendered verbatim under spec.cors — see Envoy Gateway SecurityPolicy CORS schema
+  authorization: {}     # rendered verbatim under spec.authorization — e.g. defaultAction: Deny + rules with client CIDR principals
 
 # -- Node selector, tolerations, affinity.
 nodeSelector: {}

--- a/charts/longue-vue/values.yaml
+++ b/charts/longue-vue/values.yaml
@@ -297,6 +297,8 @@ httpRoute:
 #    longue-vue does its own session/PAT/OIDC auth. Use for edge CORS / IP allowlist.
 #    NOTE: a route-level policy REPLACES (does not merge with) any Gateway-level
 #    SecurityPolicy for overlapping settings on this route.
+#    When enabled, set at least one policy field (cors / authorization / or another
+#    Envoy Gateway SecurityPolicy field) — an empty policy is rejected by the webhook.
 securityPolicy:
   enabled: false
   cors: {}              # rendered verbatim under spec.cors — see Envoy Gateway SecurityPolicy CORS schema

--- a/charts/longue-vue/values.yaml
+++ b/charts/longue-vue/values.yaml
@@ -290,6 +290,16 @@ httpRoute:
   hostnames: []
   #  - longue-vue.example.com
 
+# -- Optional Envoy Gateway SecurityPolicy attached route-level to the HTTPRoute
+#    above (targetRef -> our HTTPRoute, never the shared Gateway). Off by default;
+#    longue-vue does its own session/PAT/OIDC auth. Use for edge CORS / IP allowlist.
+#    NOTE: a route-level policy REPLACES (does not merge with) any Gateway-level
+#    SecurityPolicy for overlapping settings on this route.
+securityPolicy:
+  enabled: false
+  cors: {}              # e.g. allowOrigins: ["https://longue-vue.example.com"]
+  authorization: {}     # e.g. defaultAction: Deny + rules with client CIDR principals
+
 # -- Node selector, tolerations, affinity.
 nodeSelector: {}
 tolerations: []

--- a/charts/longue-vue/values.yaml
+++ b/charts/longue-vue/values.yaml
@@ -276,6 +276,20 @@ ingress:
   #    hosts:
   #      - longue-vue.example.com
 
+# -- HTTPRoute exposure via an existing (operator-owned) Gateway API Gateway.
+#    Replaces the deprecated `ingress` block. Requires Gateway API CRDs and an
+#    Envoy Gateway (or compatible) Gateway already present in the cluster.
+#    TLS terminates on the Gateway listener, not here.
+httpRoute:
+  enabled: false
+  # parentRefs: the shared Gateway(s) this route attaches to.
+  parentRefs:
+    - name: ""          # REQUIRED when enabled — shared Gateway name
+      namespace: ""     # Gateway namespace (defaults to release namespace if empty)
+      sectionName: ""   # optional Gateway listener section (e.g. the HTTPS listener)
+  hostnames: []
+  #  - longue-vue.example.com
+
 # -- Node selector, tolerations, affinity.
 nodeSelector: {}
 tolerations: []

--- a/docs/adr/0039-gateway-api-chart-exposure.md
+++ b/docs/adr/0039-gateway-api-chart-exposure.md
@@ -1,0 +1,82 @@
+# 39. Gateway API chart exposure (HTTPRoute + Envoy Gateway SecurityPolicy)
+
+Date: 2026-06-10
+
+Status: Accepted
+
+## Context
+
+`ingress-nginx` is heading to end-of-life and the project is standardising on
+Gateway API. The `longue-vue` Helm chart previously exposed the daemon's
+Service with a `networking.k8s.io/v1 Ingress` (`templates/ingress.yaml`,
+toggled by `ingress.enabled`). We need a Gateway API equivalent for the
+chart's *self-exposure*.
+
+This ADR covers only how longue-vue exposes itself via its Helm chart. How the
+CMDB *collects and models* Gateway API resources from monitored clusters is a
+separate, later effort and is out of scope here.
+
+## Decision
+
+- The chart ships an **`HTTPRoute`** (`gateway.networking.k8s.io/v1`,
+  `templates/httproute.yaml`, gated on `httpRoute.enabled`) that attaches to an
+  **existing, operator-owned shared Gateway** via `parentRefs`. The chart never
+  templates a `Gateway` — the shared Gateway typically fronts multiple tenants
+  and owns listener/TLS configuration. `httpRoute.parentRefs[].name` is
+  `required` when the route is enabled, so a forgotten Gateway name fails the
+  render loudly instead of producing an invalid null reference.
+- TLS termination therefore lives on the **Gateway listener** (operator-owned),
+  not in the chart. The HTTPRoute binds to a specific listener via
+  `parentRefs[].sectionName`. There is no Gateway-path equivalent of
+  `ingress.tls`.
+- An optional **Envoy Gateway `SecurityPolicy`** (`gateway.envoyproxy.io/v1alpha1`,
+  `templates/securitypolicy.yaml`, gated on `securityPolicy.enabled`, default
+  off) attaches **route-level** via `targetRef` to our own HTTPRoute — never to
+  the shared Gateway, which would affect every tenant on it. It is a scaffold
+  for edge CORS / IP-allowlist (`authorization`); longue-vue keeps doing its own
+  session/PAT/OIDC auth, so no edge auth is enabled by default.
+- A route-level `SecurityPolicy` **replaces, not merges with**, any
+  Gateway-level policy for overlapping settings on this route. Operators with a
+  Gateway-level policy should know their route-level policy overrides it for
+  this route.
+- MCP is **not** exposed at the edge by default (parity with the old Ingress,
+  which only routed `http`); the HTTPRoute template documents an opt-in MCP rule.
+- The legacy `ingress.yaml` is **deprecated for one release** (kept behind its
+  toggle, flagged in `values.yaml` and `NOTES.txt`) and is removed in the next
+  major chart version.
+
+## Consequences
+
+- Gateway API CRDs and an Envoy Gateway (or compatible Gateway) must be
+  installed in-cluster; Helm does not install them. `NOTES.txt` states this when
+  `httpRoute.enabled` is set.
+- Operators move exposure-TLS configuration from `ingress.tls` to the shared
+  Gateway listener.
+- `gatewayClassName` and `SecurityPolicy` are Envoy-Gateway-specific. Other
+  Gateway API implementations render the `HTTPRoute` fine but ignore the
+  `SecurityPolicy`; those operators apply equivalent edge policy by their own
+  means.
+- CI renders the chart with `httpRoute.enabled=true` and with
+  `securityPolicy.enabled=true` (`helm template`, no cluster needed) so both new
+  templates stay covered.
+
+## Alternatives considered
+
+- **Chart templates its own Gateway.** Rejected: the Gateway is shared
+  infrastructure owned by the cluster operator, fronts multiple tenants, and
+  owns listener/TLS config the chart should not assume. Shipping only the
+  HTTPRoute matches Gateway API's role separation (operator owns Gateway, app
+  owns Route).
+- **SecurityPolicy attached to the Gateway.** Rejected: a Gateway-level policy
+  applies to every route on the shared Gateway, not just longue-vue's. Route-level
+  attachment keeps the policy self-contained.
+- **Hard-remove the Ingress immediately.** Rejected in favour of a one-release
+  deprecation so existing installs have an upgrade path.
+
+## References
+
+- ADR-0016, ADR-0017 — public/ingest listeners and TLS posture. Unaffected;
+  this ADR concerns only public self-exposure of the daemon Service via the chart.
+- ADR-0018 — one Helm chart per binary.
+- Gateway API: https://gateway-api.sigs.k8s.io/
+- Envoy Gateway SecurityPolicy: https://gateway.envoyproxy.io/docs/api/extension_types/#securitypolicy

--- a/docs/adr/0039-gateway-api-chart-exposure.md
+++ b/docs/adr/0039-gateway-api-chart-exposure.md
@@ -31,7 +31,7 @@ separate, later effort and is out of scope here.
   `ingress.tls`.
 - An optional **Envoy Gateway `SecurityPolicy`** (`gateway.envoyproxy.io/v1alpha1`,
   `templates/securitypolicy.yaml`, gated on `securityPolicy.enabled`, default
-  off) attaches **route-level** via `targetRef` to our own HTTPRoute — never to
+  off) attaches **route-level** via `targetRefs` to our own HTTPRoute — never to
   the shared Gateway, which would affect every tenant on it. It is a scaffold
   for edge CORS / IP-allowlist (`authorization`); longue-vue keeps doing its own
   session/PAT/OIDC auth, so no edge auth is enabled by default.
@@ -52,10 +52,9 @@ separate, later effort and is out of scope here.
   `httpRoute.enabled` is set.
 - Operators move exposure-TLS configuration from `ingress.tls` to the shared
   Gateway listener.
-- `gatewayClassName` and `SecurityPolicy` are Envoy-Gateway-specific. Other
-  Gateway API implementations render the `HTTPRoute` fine but ignore the
-  `SecurityPolicy`; those operators apply equivalent edge policy by their own
-  means.
+- `SecurityPolicy` is Envoy-Gateway-specific. Other Gateway API implementations
+  render the `HTTPRoute` fine but ignore the `SecurityPolicy`; those operators
+  apply equivalent edge policy by their own means.
 - CI renders the chart with `httpRoute.enabled=true` and with
   `securityPolicy.enabled=true` (`helm template`, no cluster needed) so both new
   templates stay covered.


### PR DESCRIPTION
## Summary

Migrates the `longue-vue` Helm chart's self-exposure from a Kubernetes `Ingress` to **Gateway API**, since `ingress-nginx` is heading to EOL. (Sub-project A — chart self-exposure; the CMDB-side migration of how the collector models Gateway API resources is a separate future effort.)

- **New `HTTPRoute`** (`templates/httproute.yaml`, gated on `httpRoute.enabled`) attaching to an existing, operator-owned shared Gateway via `parentRefs` — the chart never templates a `Gateway`. `parentRefs[].name` is `required` when enabled, so a forgotten Gateway name fails the render loudly.
- **Optional `SecurityPolicy`** (Envoy Gateway `gateway.envoyproxy.io/v1alpha1`, `templates/securitypolicy.yaml`, off by default) attaching **route-level** via `targetRefs` to our own HTTPRoute — a scaffold for edge CORS / IP-allowlist. longue-vue keeps doing its own session/PAT/OIDC auth, so no edge auth by default. Fails loudly if enabled without `httpRoute`.
- **`Ingress` deprecated for one release** — kept behind its toggle, flagged in `values.yaml` + `NOTES.txt`, removed next major. TLS termination moves to the operator-owned Gateway listener (no Gateway-path equivalent of `ingress.tls`).
- **NOTES.txt** surfaces the HTTPRoute URL + a Gateway-API-CRD prerequisite note, and warns when the deprecated Ingress is enabled.
- **CI** renders both new templates (`helm template`, no cluster needed) and asserts the misconfiguration guards fire.
- **ADR-0039** records the decision and rationale.

Chart version / CHANGELOG are intentionally left to release-please (chart is a `helm` release-type package; commits are conventional).

## Test Plan

- [x] `helm lint` — default + external-DB
- [x] `helm template` — default, external-DB, `httpRoute.enabled`, `httpRoute`+`securityPolicy`
- [x] Negative guards fire: `httpRoute.enabled` with empty `parentRefs`; `securityPolicy.enabled` without `httpRoute`
- [x] Full local CI sweep: vet/build, swagger-sync, codegen drift, golangci-lint (0 issues), UI tests (333 passed), `go test -race` (27 pkgs, 0 failures/races). Docker job not run locally (no buildx; orthogonal to this chart-only change).
- [x] CI green on PR

Fixes #224