### PR TITLE
feat(ui): add OS Images inventory page (ADR-0040)

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -31,6 +31,7 @@ import EolDashboard from './pages/EolDashboard';
 import Flows from './pages/Flows';
 import VirtualMachines from './pages/VirtualMachines';
 import VirtualMachineDetail from './pages/VirtualMachineDetail';
+import OSImages from './pages/OSImages';
 import Applications from './pages/Applications';
 import ApplicationDetail from './pages/ApplicationDetail';
 import Images from './pages/Images';
@@ -161,6 +162,7 @@ function Chrome({ me, children }: { me: api.Me; children: React.ReactNode }) {
           <div className="sidebar-divider" />
           <span className="sidebar-section-label">Cloud Infrastructure</span>
           {link('/virtual-machines', 'Virtual Machines', VirtualMachineIcon)}
+          {link('/os-images', 'OS Images', ContainerImageIcon)}
           <div className="sidebar-divider" />
           <span className="sidebar-section-label">Tools</span>
           {link('/search/image', 'Search', SearchIcon)}
@@ -261,6 +263,7 @@ export default function App() {
 
       <Route path="/virtual-machines" element={authed(<VirtualMachines />)} />
       <Route path="/virtual-machines/:id" element={authed(<VirtualMachineDetail />)} />
+      <Route path="/os-images" element={authed(<OSImages />)} />
 
       {/* ADR-0029: applications sit alongside Kubernetes + VMs as a
           first-class business-systems view. Routes added now so

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1406,6 +1406,20 @@ export function refreshImageVersions() {
   });
 }
 
+export interface OSImage {
+  image_name: string;
+  image_ids: string[];
+  vm_count: number;
+  node_count: number;
+}
+
+// listOSImages returns the deduplicated inventory of OS images in service
+// (cloud VMs ∪ cluster nodes), keyed by image name (ADR-0040). The endpoint
+// is not paginated — it returns the full set; the page sorts/filters client-side.
+export function listOSImages() {
+  return request<{ images: OSImage[]; generated_at: string }>('/v1/os-images');
+}
+
 // --- Image registries (admin) -----------------------------------------------
 
 export interface ImageRegistry {

--- a/ui/src/pages/OSImages.test.tsx
+++ b/ui/src/pages/OSImages.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { screen, waitFor } from '@testing-library/react';
+import OSImages from './OSImages';
+import { renderWithRouter } from '../test/render';
+import { server } from '../test/server';
+import { fixtureOSImage } from '../test/fixtures';
+
+describe('OSImages list', () => {
+  it('renders the heading', () => {
+    renderWithRouter(<OSImages />, { initialPath: '/os-images' });
+    expect(screen.getByRole('heading', { name: /os images/i })).toBeInTheDocument();
+  });
+
+  it('renders an image row once data arrives', async () => {
+    renderWithRouter(<OSImages />, { initialPath: '/os-images' });
+    await waitFor(() =>
+      expect(screen.getByText(fixtureOSImage.image_name)).toBeInTheDocument(),
+    );
+  });
+
+  it('renders error state on 500', async () => {
+    server.use(
+      http.get('/v1/os-images', () => new HttpResponse(null, { status: 500 })),
+    );
+    renderWithRouter(<OSImages />, { initialPath: '/os-images' });
+    await waitFor(() =>
+      expect(screen.getByText(/failed to load/i)).toBeInTheDocument(),
+    );
+  });
+});

--- a/ui/src/pages/OSImages.tsx
+++ b/ui/src/pages/OSImages.tsx
@@ -1,0 +1,162 @@
+import { useState } from 'react';
+import * as api from '../api';
+import { useResource, useDebouncedValue } from '../hooks';
+import { AsyncView, Dash } from '../components';
+
+// OSImages is the read-only inventory of OS images (OMI) in service across
+// cloud VMs and Kubernetes cluster nodes, served by GET /v1/os-images
+// (ADR-0040). The endpoint returns the full set unpaginated; this page
+// sorts and filters client-side.
+
+type SortKey = 'image_name' | 'vm_count' | 'node_count' | 'total';
+type SortDir = 'asc' | 'desc';
+
+function total(img: api.OSImage): number {
+  return img.vm_count + img.node_count;
+}
+
+function formatTs(ts?: string | null): string {
+  if (!ts) return '';
+  try {
+    return new Date(ts).toLocaleString();
+  } catch {
+    return ts;
+  }
+}
+
+export default function OSImages() {
+  const [searchInput, setSearchInput] = useState('');
+  const [sortKey, setSortKey] = useState<SortKey>('image_name');
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
+  const debouncedSearch = useDebouncedValue(searchInput, 300);
+
+  // Fetch once on mount; search + sort are applied client-side below.
+  const listState = useResource(() => api.listOSImages(), []);
+
+  const toggleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir(key === 'image_name' ? 'asc' : 'desc');
+    }
+  };
+
+  const arrow = (key: SortKey) =>
+    sortKey === key ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '';
+
+  return (
+    <>
+      <h2>OS Images</h2>
+      <p className="muted" style={{ marginBottom: '1rem' }}>
+        Images OS en service — VMs et nodes de clusters (ADR-0040).
+      </p>
+
+      <div className="vm-search" style={{ marginBottom: '0.75rem' }}>
+        <label>
+          <span>Image</span>
+          <input
+            type="search"
+            value={searchInput}
+            placeholder="e.g. master-PLATFORM-k8s"
+            onChange={(e) => setSearchInput(e.target.value)}
+          />
+        </label>
+      </div>
+
+      <AsyncView state={listState}>
+        {(data) => {
+          const all = data.images;
+          const totalVMs = all.reduce((acc, i) => acc + i.vm_count, 0);
+          const totalNodes = all.reduce((acc, i) => acc + i.node_count, 0);
+
+          const q = debouncedSearch.trim().toLowerCase();
+          const filtered = q
+            ? all.filter((i) => i.image_name.toLowerCase().includes(q))
+            : all;
+          const sorted = [...filtered].sort((a, b) => {
+            let cmp = 0;
+            if (sortKey === 'image_name') cmp = a.image_name.localeCompare(b.image_name);
+            else if (sortKey === 'vm_count') cmp = a.vm_count - b.vm_count;
+            else if (sortKey === 'node_count') cmp = a.node_count - b.node_count;
+            else cmp = total(a) - total(b);
+            return sortDir === 'asc' ? cmp : -cmp;
+          });
+
+          return (
+            <>
+              <div className="eol-summary" style={{ marginBottom: '1rem' }}>
+                <div className="eol-summary-card">
+                  <span className="eol-summary-count">{all.length}</span>
+                  <span className="eol-summary-label">Images</span>
+                </div>
+                <div className="eol-summary-card">
+                  <span className="eol-summary-count">{totalVMs}</span>
+                  <span className="eol-summary-label">VMs</span>
+                </div>
+                <div className="eol-summary-card">
+                  <span className="eol-summary-count">{totalNodes}</span>
+                  <span className="eol-summary-label">Nodes</span>
+                </div>
+              </div>
+
+              {sorted.length === 0 ? (
+                <p className="muted empty">Aucune image OS en service.</p>
+              ) : (
+                <table className="entities">
+                  <thead>
+                    <tr>
+                      <th className="sortable" onClick={() => toggleSort('image_name')}>
+                        Image{arrow('image_name')}
+                      </th>
+                      <th className="sortable" onClick={() => toggleSort('vm_count')}>
+                        VMs{arrow('vm_count')}
+                      </th>
+                      <th className="sortable" onClick={() => toggleSort('node_count')}>
+                        Nodes{arrow('node_count')}
+                      </th>
+                      <th className="sortable" onClick={() => toggleSort('total')}>
+                        Total{arrow('total')}
+                      </th>
+                      <th>Image IDs</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sorted.map((img) => (
+                      <tr key={img.image_name}>
+                        <td>
+                          <strong>{img.image_name}</strong>
+                        </td>
+                        <td>{img.vm_count}</td>
+                        <td>{img.node_count}</td>
+                        <td>{total(img)}</td>
+                        <td>
+                          {img.image_ids.length ? (
+                            img.image_ids.map((id) => (
+                              <span key={id} className="pill">
+                                {id}
+                              </span>
+                            ))
+                          ) : (
+                            <Dash />
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+
+              <p
+                className="muted"
+                style={{ marginTop: '0.75rem', fontSize: 'var(--fs-sm)' }}
+              >
+                Généré à {formatTs(data.generated_at) || '—'}
+              </p>
+            </>
+          );
+        }}
+      </AsyncView>
+    </>
+  );
+}

--- a/ui/src/test/fixtures.ts
+++ b/ui/src/test/fixtures.ts
@@ -1,7 +1,7 @@
 import type {
   ApiToken, Application, ApplicationBlock, ApplicationMember, AuditEvent,
   AuthConfig, Cluster, CloudAccount, Container, Ingress, ImpactGraph, Me,
-  Namespace, Node, NodeCondition, NodeTaint, PagedResponse, PersistentVolume,
+  Namespace, Node, NodeCondition, NodeTaint, OSImage, PagedResponse, PersistentVolume,
   PersistentVolumeClaim, Pod, Service, Session, Settings, User,
   VirtualMachine, VMApplication, Workload,
 } from '../api';
@@ -432,3 +432,10 @@ export const fixtureVirtualMachineMember: ApplicationMember = {
 export function paged<T>(items: T[]): PagedResponse<T> {
   return { items, next_cursor: null };
 }
+
+export const fixtureOSImage: OSImage = {
+  image_name: 'master-PLATFORM-k8s-1-32-k8s_1_32_snc-2025.10.13',
+  image_ids: ['ami-0abc123'],
+  vm_count: 4,
+  node_count: 12,
+};

--- a/ui/src/test/handlers.ts
+++ b/ui/src/test/handlers.ts
@@ -2,7 +2,7 @@ import { http, HttpResponse } from 'msw';
 import {
   fixtureApplication, fixtureApplicationBlock, fixtureAuditEvent,
   fixtureAuthConfig, fixtureCloudAccount, fixtureCluster, fixtureImpactGraph,
-  fixtureIngress, fixtureMe, fixtureNamespace, fixtureNode, fixturePV,
+  fixtureIngress, fixtureMe, fixtureNamespace, fixtureNode, fixtureOSImage, fixturePV,
   fixturePVC, fixturePod, fixtureService, fixtureSession, fixtureSettings,
   fixtureToken, fixtureUser, fixtureVirtualMachine, fixtureWorkload, paged,
 } from './fixtures';
@@ -105,6 +105,11 @@ export const handlers = [
   http.post('/v1/applications', () => HttpResponse.json(fixtureApplication)),
   http.patch('/v1/applications/:id', () => HttpResponse.json(fixtureApplication)),
   http.delete('/v1/applications/:id', () => new HttpResponse(null, { status: 204 })),
+
+  // --- OS images ---
+  http.get('/v1/os-images', () =>
+    HttpResponse.json({ images: [fixtureOSImage], generated_at: '2026-06-20T10:00:00Z' }),
+  ),
 
   // --- network rules ---
   http.get('/v1/workloads/:id/network-rules', () =>


### PR DESCRIPTION
  ## Summary

  Adds a read-only **OS Images** inventory page to the SPA, under **Virtual Machines** in the **Cloud Infrastructure** sidebar section (route `/os-images`). It surfaces the existing `GET /v1/os-images` endpoint (ADR-0040): the deduplicated set of OS images in service across cloud VMs and Kubernetes cluster nodes.

  ## What

  - **`api.ts`**: `OSImage` type + `listOSImages()` (`GET /v1/os-images` → `{ images, generated_at }`, unpaginated).
  - **`pages/OSImages.tsx`**: page with a heading + `generated_at`, 3 summary cards (Images / Σ VMs / Σ nodes), a debounced name search, and a sortable table (Image, VMs, Nodes, Total, Image IDs). Fetches once; search + sort are client-side. Loading/error/empty via `AsyncView`.
  - **`App.tsx`**: sidebar entry "OS Images" under "Virtual Machines" + auth-gated route `/os-images`.

  ## Notes

  - **UI-only** — no backend changes (endpoint already shipped in ADR-0040), **no new CSS** (reuses `AsyncView`/`Dash`, `useResource`/`useDebouncedValue`, and existing classes).
  - The frontend `OSImage` type is byte-for-byte consistent with the backend Go struct + OpenAPI schema.

  ## Testing
  
  - `OSImages.test.tsx`: heading renders, image row appears after data, error state on 500.
  - `make ui-check` (tsc) clean; `make ui-test` — 341 tests pass.