### PR TITLE
docs: fix accuracy drift found by documentation audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Guidance for Claude Code working in this repo. For deep design rationale, read `
 ## Listeners (ADR-0016, ADR-0017)
 
 - Public `:8080` — humans + machines. TLS via `LONGUE_VUE_PUBLIC_LISTEN_TLS_{CERT,KEY}` (mtime hot reload).
-- Ingest mTLS-only `:8443` (opt-in via `LONGUE_VUE_INGEST_LISTEN_ADDR`) — exposes the 18 push-collector writes + `POST /v1/auth/verify`. Allowlist in `internal/ingestgw/allowlist.go` must stay in sync with `internal/api/ingest_mux.go`.
+- Ingest mTLS-only `:8443` (opt-in via `LONGUE_VUE_INGEST_LISTEN_ADDR`) — exposes the 22 push-collector writes + `POST /v1/auth/verify`. Allowlist in `internal/ingestgw/allowlist.go` must stay in sync with `internal/api/ingest_mux.go`.
 - `LONGUE_VUE_TRUSTED_PROXIES` (CIDRs, empty by default) gates trust in `X-Forwarded-For` / `-Proto`. Used by rate-limiter, audit IP, secure-cookie decision, HSTS — see `internal/httputil/`.
 - `LONGUE_VUE_REQUIRE_HTTPS=true` startup guard: refuse boot unless native TLS is on **or** trusted-proxy + `SecureAlways` cookie posture is set.
 - `/healthz`, `/readyz`, `/metrics` are unauthenticated.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -888,7 +888,7 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
 
 ## MCP server (alternative query interface)
 
-longue-vue also exposes a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server with 22 read-only tools that mirror the REST query surface. The MCP interface is designed for AI agents and supports SSE and stdio transports. It is **not** part of the REST API -- see [MCP Server](mcp-server.md) for setup, tool catalogue, and authentication details.
+longue-vue also exposes a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server with 28 read-only tools that mirror the REST query surface. The MCP interface is designed for AI agents and supports SSE and stdio transports. It is **not** part of the REST API -- see [MCP Server](mcp-server.md) for setup, tool catalogue, and authentication details.
 
 ## References
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,7 +57,7 @@ The main daemon, built from `cmd/longue-vue/main.go`. It combines several subsys
 - **PostgreSQL store** -- cursor-paginated CRUD with merge-patch updates. Implemented in `internal/store/`.
 - **EOL enricher** -- background goroutine that annotates clusters, nodes, and platform VMs with lifecycle status from [endoflife.date](https://endoflife.date). Implemented in `internal/eol/`. Toggled at runtime via the `eol_enabled` setting. See [ADR-0012](adr/adr-0012-eol-enrichment-via-endoflife-date.md) and [EOL Enrichment](eol-enrichment.md).
 - **Impact analysis** -- on-the-fly FK traversal producing a dependency graph for any CMDB entity. Serves `GET /v1/impact/{entity_type}/{id}`. Implemented in `internal/impact/`. See [ADR-0013](adr/adr-0013-impact-analysis-graph.md) and [Impact Analysis](impact-analysis.md).
-- **MCP server** -- Model Context Protocol server exposing 22 read-only CMDB tools for AI agents, over SSE or stdio transports. Implemented in `internal/mcp/`. Toggled at runtime via the `mcp_enabled` setting. See [ADR-0014](adr/adr-0014-mcp-server.md) and [MCP Server](mcp-server.md).
+- **MCP server** -- Model Context Protocol server exposing 28 read-only CMDB tools for AI agents, over SSE or stdio transports. Implemented in `internal/mcp/`. Toggled at runtime via the `mcp_enabled` setting. See [ADR-0014](adr/adr-0014-mcp-server.md) and [MCP Server](mcp-server.md).
 - **Ingest listener** -- optional second mTLS-only listener (`:8443`) for push-mode collectors transiting through a DMZ ingest gateway. Registered via `api.NewIngestMux`. Disabled unless `LONGUE_VUE_INGEST_LISTEN_ADDR` is set. See [ADR-0016](adr/adr-0016-dmz-ingest-gateway.md).
 - **Metrics** -- Prometheus counters and gauges at `/metrics`. Implemented in `internal/metrics/`.
 - **Embedded UI** -- the React SPA built into the binary via `//go:embed` and served at `/ui/*`.
@@ -81,7 +81,7 @@ A standalone push-mode binary (`cmd/longue-vue-vm-collector/`) that catalogues n
 
 ### longue-vue-ingest-gw
 
-A stateless DMZ reverse-proxy binary (`cmd/longue-vue-ingest-gw/`) deployed between remote collectors and longue-vue's trusted zone. It enforces a hardcoded 18-route write-only allowlist, verifies bearer PATs against longue-vue via `POST /v1/auth/verify` (with an LRU cache), and forwards approved requests over mTLS to longue-vue's ingest listener. No database, no replay buffer. See [ADR-0016](adr/adr-0016-dmz-ingest-gateway.md) and [How to deploy the DMZ ingest gateway](how-to-deploy-dmz-ingest-gateway.md).
+A stateless DMZ reverse-proxy binary (`cmd/longue-vue-ingest-gw/`) deployed between remote collectors and longue-vue's trusted zone. It enforces a hardcoded 22-route write-only allowlist, verifies bearer PATs against longue-vue via `POST /v1/auth/verify` (with an LRU cache), and forwards approved requests over mTLS to longue-vue's ingest listener. No database, no replay buffer. See [ADR-0016](adr/adr-0016-dmz-ingest-gateway.md) and [How to deploy the DMZ ingest gateway](how-to-deploy-dmz-ingest-gateway.md).
 
 ## Pull collector
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,7 +67,7 @@ The embedded pull-mode collector is disabled by default.
 |----------|----------|---------|-------------|
 | `LONGUE_VUE_COLLECTOR_ENABLED` | no | `false` | Enable the polling collector. Set to `true` to start ingesting data from Kubernetes. |
 | `LONGUE_VUE_COLLECTOR_INTERVAL` | no | `5m` | Time between polling ticks. Accepts Go duration syntax (`30s`, `5m`). |
-| `LONGUE_VUE_COLLECTOR_FETCH_TIMEOUT` | no | `20s` | Per-tick timeout for Kubernetes API calls. |
+| `LONGUE_VUE_COLLECTOR_FETCH_TIMEOUT` | no | `10s` | Per-tick timeout for Kubernetes API calls. |
 | `LONGUE_VUE_COLLECTOR_RECONCILE` | no | `true` | Delete rows from the CMDB that no longer appear in the live Kubernetes listing. Required for ANSSI cartography fidelity. Set to `false` for append-only behavior. |
 
 #### Single-cluster mode

--- a/docs/how-to-deploy-dmz-ingest-gateway.md
+++ b/docs/how-to-deploy-dmz-ingest-gateway.md
@@ -20,7 +20,7 @@ longue-vue-collector  ──HTTPS──► Envoy/WAF ──► longue-vue-ingest
                                            verify cache)
 ```
 
-`longue-vue-ingest-gw` is a stateless reverse proxy. It enforces a hardcoded 18-route write-only allowlist, verifies every bearer token against longue-vue via a `POST /v1/auth/verify` call (with a 60 s in-memory cache), and forwards approved requests to longue-vue's mTLS-only ingest listener. longue-vue's existing public listener (`:8080`) is unchanged and never directly reachable from the DMZ.
+`longue-vue-ingest-gw` is a stateless reverse proxy. It enforces a hardcoded 22-route write-only allowlist, verifies every bearer token against longue-vue via a `POST /v1/auth/verify` call (with a 60 s in-memory cache), and forwards approved requests to longue-vue's mTLS-only ingest listener. longue-vue's existing public listener (`:8080`) is unchanged and never directly reachable from the DMZ.
 
 ## Prerequisites
 
@@ -457,7 +457,7 @@ kubectl -n <DMZ_NAMESPACE> describe certificate longue-vue-ingest-gw-mtls
 
 ### Read or admin endpoints return 404 from the gateway
 
-Expected. The gateway enforces a strict 18-route write-only allowlist. `GET /v1/clusters`, admin endpoints, audit endpoints, and any other read paths are all `404` at the gateway by design — they are only reachable on longue-vue's `:8080` listener from inside the trusted zone.
+Expected. The gateway enforces a strict 22-route write-only allowlist. `GET /v1/clusters`, admin endpoints, audit endpoints, and any other read paths are all `404` at the gateway by design — they are only reachable on longue-vue's `:8080` listener from inside the trusted zone.
 
 ---
 
@@ -466,7 +466,7 @@ Expected. The gateway enforces a strict 18-route write-only allowlist. `GET /v1/
 - The gateway is **not** an auth authority. longue-vue re-validates every forwarded bearer token with full argon2id on every request. The gateway's 60 s verify cache exists only to reduce verify-call cardinality — it does not change longue-vue's authorization decisions.
 - Token revocation propagates within 60 s worst case. For immediate revocation, delete the token in longue-vue's admin UI; longue-vue will return 401 on the next forwarded request and the gateway will evict the cache entry.
 - The gateway never buffers or spools requests. If longue-vue is unreachable, collectors receive 503 and retry with backoff. No inventory data is lost — the next successful collector tick reconciles the gap.
-- The ingest listener on longue-vue registers only 19 routes (the 18 allowed writes + `POST /v1/auth/verify`). Any other path returns 404 on this listener even if the route exists on `:8080`.
+- The ingest listener on longue-vue registers only 21 routes (the 20 allowed writes + `POST /v1/auth/verify`). Any other path returns 404 on this listener even if the route exists on `:8080`.
 
 ## References
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -52,7 +52,7 @@ For the **stdio** transport (local agent on the same machine), set `LONGUE_VUE_M
 
 ## Available tools
 
-All tools are read-only. List tools return up to 1000 items (silently truncated beyond that). There are 25 tools total.
+All tools are read-only. List tools return up to 1000 items (silently truncated beyond that). There are 28 tools total.
 
 ### Kubernetes inventory
 

--- a/docs/vm-applications.md
+++ b/docs/vm-applications.md
@@ -97,7 +97,7 @@ The VM list page (`/ui/virtual-machines`) exposes a toolbar of filters. Filters 
 | Cloud account | Exact UUID | Admin only — viewers and editors see a UUID prefix fallback. |
 | Region | Exact | Populated from accounts and ingested VMs. |
 | Role | Exact | Client-side split on comma-joined role strings. |
-| Power state | Exact | One of `running`, `stopped`, `stopped`, `pending`, `terminated`, `error`, `unknown`. |
+| Power state | Exact | One of `pending`, `running`, `stopping`, `stopped`, `terminating`, `terminated`. |
 | Application | Exact (normalized product) | Populated from `GET /v1/virtual-machines/applications/distinct`. |
 | App version | Exact | Enabled only after an Application is selected; shows versions for that product. Selecting a different product resets the version filter. |
 


### PR DESCRIPTION
Correct factual drift between docs and implemented code:
- ingest allowlist count 18 -> 22 (CLAUDE.md, architecture.md, DMZ guide)
- ingest listener route count 19 -> 21 (20 writes + verify)
- MCP tool count 22/25 -> 28 (architecture.md, api-reference.md, mcp-server.md)
- vm power_state filter enum deduplicated and aligned to canonical set
- COLLECTOR_FETCH_TIMEOUT default 20s -> 10s
