### PR TITLE
feat(ui): uniform search & server-side sort on all main list pages (phase 2)

### DIFF
--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import {
-  ApiError, getCluster, getMe, listClusters, login, logout,
+  ApiError, getCluster, getMe, listClusters, listNodes, listVirtualMachines, listApplications, login, logout,
   updateCluster, updateUser,
 } from './api';
 import { server } from './test/server';
@@ -128,5 +128,57 @@ describe('ApiError', () => {
     expect(e.status).toBe(403);
     expect(e.name).toBe('ApiError');
     expect(e.message).toBe('forbidden');
+  });
+});
+
+describe('list helpers forward uniform search/sort params', () => {
+  it('listClusters serializes name/sort/order', async () => {
+    let search = '';
+    server.use(
+      http.get('/v1/clusters', ({ request }) => {
+        search = new URL(request.url).search;
+        return HttpResponse.json({ items: [], next_cursor: null });
+      }),
+    );
+    await listClusters({ limit: 20, name: 'prod-*', sort: 'name', order: 'desc' });
+    const p = new URLSearchParams(search);
+    expect(p.get('name')).toBe('prod-*');
+    expect(p.get('sort')).toBe('name');
+    expect(p.get('order')).toBe('desc');
+    expect(p.get('limit')).toBe('20');
+  });
+
+  it('listNodes omits empty controls', async () => {
+    let search = '';
+    server.use(
+      http.get('/v1/nodes', ({ request }) => {
+        search = new URL(request.url).search;
+        return HttpResponse.json({ items: [], next_cursor: null });
+      }),
+    );
+    await listNodes({ limit: 20 });
+    const p = new URLSearchParams(search);
+    expect(p.has('name')).toBe(false);
+    expect(p.has('sort')).toBe(false);
+    expect(p.has('order')).toBe(false);
+  });
+
+  it('listVirtualMachines and listApplications forward sort/order', async () => {
+    const seen: Record<string, string> = {};
+    server.use(
+      http.get('/v1/virtual-machines', ({ request }) => {
+        seen.vm = new URL(request.url).search;
+        return HttpResponse.json({ items: [], next_cursor: null });
+      }),
+      http.get('/v1/applications', ({ request }) => {
+        seen.app = new URL(request.url).search;
+        return HttpResponse.json({ items: [], next_cursor: null });
+      }),
+    );
+    await listVirtualMachines({ sort: 'last_seen_at', order: 'desc' });
+    await listApplications({ sort: 'name' });
+    expect(new URLSearchParams(seen.vm).get('sort')).toBe('last_seen_at');
+    expect(new URLSearchParams(seen.vm).get('order')).toBe('desc');
+    expect(new URLSearchParams(seen.app).get('sort')).toBe('name');
   });
 });

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -311,6 +311,17 @@ export interface PagedResponse<T> {
   next_cursor?: string | null;
 }
 
+// ListControlParams are the uniform list controls every paginated list
+// endpoint accepts since ADR-0042: `name` is a case-insensitive
+// substring (or anchored glob when it contains `*`), `sort` must be one
+// of the entity's allowlisted keys, `order` defaults to asc and is
+// ignored without `sort`.
+export interface ListControlParams {
+  name?: string;
+  sort?: string;
+  order?: 'asc' | 'desc';
+}
+
 export type Layer =
   | 'ecosystem'
   | 'business'
@@ -688,7 +699,7 @@ export interface PersistentVolumeClaim {
 
 // Endpoints ---------------------------------------------------------------
 
-export function listClusters(filter?: { cursor?: string; limit?: number }) {
+export function listClusters(filter?: { cursor?: string; limit?: number } & ListControlParams) {
   return request<PagedResponse<Cluster>>('/v1/clusters' + query({ limit: 200, ...filter }));
 }
 export function getCluster(id: string) {
@@ -698,14 +709,14 @@ export function deleteCluster(id: string) {
   return request<void>(`/v1/clusters/${id}`, { method: 'DELETE' });
 }
 
-export function listNodes(filter?: { cluster_id?: string; cursor?: string; limit?: number }) {
+export function listNodes(filter?: { cluster_id?: string; cursor?: string; limit?: number } & ListControlParams) {
   return request<PagedResponse<Node>>('/v1/nodes' + query({ limit: 200, ...filter }));
 }
 export function getNode(id: string) {
   return request<Node>(`/v1/nodes/${id}`);
 }
 
-export function listNamespaces(filter?: { cluster_id?: string; cursor?: string; limit?: number }) {
+export function listNamespaces(filter?: { cluster_id?: string; cursor?: string; limit?: number } & ListControlParams) {
   return request<PagedResponse<Namespace>>('/v1/namespaces' + query({ limit: 200, ...filter }));
 }
 export function getNamespace(id: string) {
@@ -719,7 +730,7 @@ export function listWorkloads(filter?: {
   cursor?: string;
   limit?: number;
   include?: 'containers_versions';
-}) {
+} & ListControlParams) {
   return request<PagedResponse<Workload>>('/v1/workloads' + query({ limit: 200, ...filter }));
 }
 export function getWorkload(id: string) {
@@ -733,28 +744,28 @@ export function listPods(filter?: {
   image?: string;
   cursor?: string;
   limit?: number;
-}) {
+} & ListControlParams) {
   return request<PagedResponse<Pod>>('/v1/pods' + query({ limit: 200, ...filter }));
 }
 export function getPod(id: string) {
   return request<Pod>(`/v1/pods/${id}`);
 }
 
-export function listServices(filter?: { namespace_id?: string; cursor?: string; limit?: number }) {
+export function listServices(filter?: { namespace_id?: string; cursor?: string; limit?: number } & ListControlParams) {
   return request<PagedResponse<Service>>('/v1/services' + query({ limit: 200, ...filter }));
 }
 export function getService(id: string) {
   return request<Service>(`/v1/services/${id}`);
 }
 
-export function listIngresses(filter?: { namespace_id?: string; cursor?: string; limit?: number }) {
+export function listIngresses(filter?: { namespace_id?: string; cursor?: string; limit?: number } & ListControlParams) {
   return request<PagedResponse<Ingress>>('/v1/ingresses' + query({ limit: 200, ...filter }));
 }
 export function getIngress(id: string) {
   return request<Ingress>(`/v1/ingresses/${id}`);
 }
 
-export function listPersistentVolumes(filter?: { cluster_id?: string; cursor?: string; limit?: number }) {
+export function listPersistentVolumes(filter?: { cluster_id?: string; cursor?: string; limit?: number } & ListControlParams) {
   return request<PagedResponse<PersistentVolume>>(
     '/v1/persistentvolumes' + query({ limit: 200, ...filter }),
   );
@@ -763,7 +774,7 @@ export function getPersistentVolume(id: string) {
   return request<PersistentVolume>(`/v1/persistentvolumes/${id}`);
 }
 
-export function listPersistentVolumeClaims(filter?: { namespace_id?: string; cursor?: string; limit?: number }) {
+export function listPersistentVolumeClaims(filter?: { namespace_id?: string; cursor?: string; limit?: number } & ListControlParams) {
   return request<PagedResponse<PersistentVolumeClaim>>(
     '/v1/persistentvolumeclaims' + query({ limit: 200, ...filter }),
   );
@@ -1042,6 +1053,8 @@ export interface VirtualMachineListFilter {
   image?: string;
   application?: string;
   application_version?: string;
+  sort?: string;
+  order?: 'asc' | 'desc';
   cursor?: string;
   limit?: number;
 }
@@ -1082,6 +1095,8 @@ export function listVirtualMachines(filter: VirtualMachineListFilter = {}) {
         image: filter.image,
         application: filter.application,
         application_version: filter.application_version,
+        sort: filter.sort,
+        order: filter.order,
       }),
   );
 }
@@ -1224,6 +1239,8 @@ export interface ApplicationListFilter {
   // ADR-0029 Phase 4.
   has_dict?: boolean;
   dict_min?: number;
+  sort?: string;
+  order?: 'asc' | 'desc';
   cursor?: string;
   limit?: number;
 }
@@ -1231,6 +1248,8 @@ export interface ApplicationListFilter {
 export interface ApplicationBlockListFilter {
   name?: string;
   owner?: string;
+  sort?: string;
+  order?: 'asc' | 'desc';
   cursor?: string;
   limit?: number;
 }
@@ -1242,6 +1261,8 @@ export function listApplicationBlocks(filter: ApplicationBlockListFilter = {}) {
         limit: filter.limit ?? 200,
         name: filter.name,
         owner: filter.owner,
+        sort: filter.sort,
+        order: filter.order,
         cursor: filter.cursor,
       }),
   );
@@ -1280,6 +1301,8 @@ export function listApplications(filter: ApplicationListFilter = {}) {
         criticality: filter.criticality,
         has_dict: filter.has_dict !== undefined ? String(filter.has_dict) : undefined,
         dict_min: filter.dict_min,
+        sort: filter.sort,
+        order: filter.order,
         cursor: filter.cursor,
       }),
   );

--- a/ui/src/components/EntityListPage.test.tsx
+++ b/ui/src/components/EntityListPage.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithRouter } from '../test/render';
+import { EntityListPage } from './EntityListPage';
+
+type Row = { id: string; name: string };
+
+function makeFetch(calls: Array<{ params: unknown; cursor?: string; limit: number }>) {
+  return async (
+    params: { name?: string; sort?: string; order?: string },
+    cursor: string | undefined,
+    limit: number,
+  ) => {
+    calls.push({ params, cursor, limit });
+    return {
+      items: [
+        { id: '1', name: 'alpha' },
+        { id: '2', name: 'beta' },
+      ] as Row[],
+      next_cursor: null,
+    };
+  };
+}
+
+function renderPage(calls: Array<{ params: unknown; cursor?: string; limit: number }>) {
+  return renderWithRouter(
+    <EntityListPage<Row>
+      title="Widgets"
+      icon={null}
+      storageKey="test.widgets"
+      emptyMessage="none"
+      fetchPage={makeFetch(calls)}
+      rowKey={(r) => r.id}
+      columns={[
+        { key: 'name', label: 'Name', sortKey: 'name', render: (r) => r.name },
+        { key: 'computed', label: 'Computed', render: () => 'x' },
+      ]}
+    />,
+  );
+}
+
+describe('EntityListPage', () => {
+  it('renders rows, sortable and plain headers', async () => {
+    const calls: Array<{ params: unknown; cursor?: string; limit: number }> = [];
+    renderPage(calls);
+    await screen.findByText('alpha');
+    const headers = screen.getAllByRole('columnheader');
+    expect(headers[0].className).toContain('sortable');
+    expect(headers[1].className).not.toContain('sortable');
+  });
+
+  it('clicking a sortable header refetches with sort params', async () => {
+    const calls: Array<{ params: { sort?: string; order?: string }; cursor?: string; limit: number }> = [];
+    renderPage(calls);
+    await screen.findByText('alpha');
+    fireEvent.click(screen.getByRole('columnheader', { name: /^Name/ }));
+    await waitFor(() =>
+      expect(calls.at(-1)?.params).toMatchObject({ sort: 'name', order: 'asc' }),
+    );
+  });
+
+  it('typing in the search box refetches with name after debounce', async () => {
+    const calls: Array<{ params: { name?: string }; cursor?: string; limit: number }> = [];
+    renderPage(calls);
+    await screen.findByText('alpha');
+    fireEvent.change(screen.getByPlaceholderText(/Filter by name/), { target: { value: 'alp' } });
+    await waitFor(() => expect(calls.at(-1)?.params).toMatchObject({ name: 'alp' }), {
+      timeout: 2000,
+    });
+  });
+});

--- a/ui/src/components/EntityListPage.tsx
+++ b/ui/src/components/EntityListPage.tsx
@@ -1,0 +1,109 @@
+// EntityListPage factors the top-level list-page pattern shared by the
+// nine Lists.tsx pages (ADR-0042 phase 2): heading, uniform SearchInput,
+// Paginator, loading/error/empty tri-state, and an `entities` table whose
+// sortable headers drive server-side sorting through URL-synced controls.
+// Columns without a sortKey (computed/lookup columns) render plain <th>.
+import * as api from '../api';
+import { usePagedList, useListControls } from '../hooks';
+import { Empty, Paginator } from '../components';
+import { useEntityTable } from './column_filters';
+import { SearchInput } from './SearchInput';
+import { SortHeader } from './SortHeader';
+
+export interface EntityColumn<T> {
+  key: string;
+  label: React.ReactNode;
+  // Server sort key from the entity's ADR-0042 allowlist. Omitted for
+  // computed/lookup columns — those render with no click affordance.
+  sortKey?: string;
+  render: (item: T) => React.ReactNode;
+}
+
+export interface EntityListPageProps<T> {
+  title: string;
+  icon: React.ReactNode;
+  storageKey: string;
+  emptyMessage: string;
+  fetchPage: (
+    params: api.ListControlParams,
+    cursor: string | undefined,
+    limit: number,
+  ) => Promise<api.PagedResponse<T>>;
+  columns: EntityColumn<T>[];
+  rowKey: (item: T) => string;
+}
+
+export function EntityListPage<T>({
+  title,
+  icon,
+  storageKey,
+  emptyMessage,
+  fetchPage,
+  columns,
+  rowKey,
+}: EntityListPageProps<T>) {
+  const controls = useListControls();
+  const list = usePagedList<T>(
+    (cursor, limit) => fetchPage(controls.params, cursor, limit),
+    controls.deps,
+  );
+  const tableRef = useEntityTable(storageKey);
+
+  return (
+    <>
+      <h2>
+        {icon} {title}
+      </h2>
+      <div className="vm-filters">
+        <SearchInput value={controls.nameInput} onChange={controls.setNameInput} />
+      </div>
+      <Paginator
+        pageSize={list.pageSize}
+        hasPrev={list.hasPrev}
+        hasNext={list.hasNext}
+        onPrev={list.prev}
+        onNext={list.next}
+        onPageSize={list.setPageSize}
+      />
+      {list.loading ? (
+        <p className="loading">Loading…</p>
+      ) : list.error ? (
+        <div className="error">Failed to load: {list.error}</div>
+      ) : list.items.length === 0 ? (
+        <Empty message={emptyMessage} />
+      ) : (
+        <div className="table-wrap">
+          <table className="entities" ref={tableRef}>
+            <thead>
+              <tr>
+                {columns.map((c) =>
+                  c.sortKey ? (
+                    <SortHeader
+                      key={c.key}
+                      label={c.label}
+                      sortKey={c.sortKey}
+                      activeKey={controls.sort}
+                      asc={controls.order === 'asc'}
+                      onToggle={controls.toggleSort}
+                    />
+                  ) : (
+                    <th key={c.key}>{c.label}</th>
+                  ),
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {list.items.map((item) => (
+                <tr key={rowKey(item)}>
+                  {columns.map((c) => (
+                    <td key={c.key}>{c.render(item)}</td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </>
+  );
+}

--- a/ui/src/components/SearchInput.test.tsx
+++ b/ui/src/components/SearchInput.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SearchInput } from './SearchInput';
+
+describe('SearchInput', () => {
+  it('renders the glob hint and forwards changes', () => {
+    const onChange = vi.fn();
+    render(<SearchInput value="" onChange={onChange} />);
+    const input = screen.getByPlaceholderText('Filter by name… (* = wildcard)');
+    expect(input).toHaveAttribute('title', expect.stringContaining('du* = starts with'));
+    fireEvent.change(input, { target: { value: 'prod-*' } });
+    expect(onChange).toHaveBeenCalledWith('prod-*');
+  });
+});

--- a/ui/src/components/SearchInput.tsx
+++ b/ui/src/components/SearchInput.tsx
@@ -1,0 +1,27 @@
+// SearchInput is the uniform list search box (ADR-0042 phase 2).
+// Debouncing lives in useListControls — this component is presentation
+// only. The tooltip documents the `*` glob convention the server applies.
+export function SearchInput({
+  value,
+  onChange,
+  placeholder = 'Filter by name… (* = wildcard)',
+  label = 'Name',
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  label?: string;
+}) {
+  return (
+    <label className="list-search">
+      <span>{label}</span>
+      <input
+        type="search"
+        value={value}
+        placeholder={placeholder}
+        title="Plain text matches anywhere in the name. Use * to anchor: du* = starts with, *du = ends with."
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </label>
+  );
+}

--- a/ui/src/components/SortHeader.test.tsx
+++ b/ui/src/components/SortHeader.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SortHeader } from './SortHeader';
+
+function renderTh(ui: React.ReactElement) {
+  // th needs table ancestry to render without DOM nesting warnings.
+  return render(<table><thead><tr>{ui}</tr></thead></table>);
+}
+
+describe('SortHeader', () => {
+  it('shows no arrow when inactive and calls onToggle with its key', () => {
+    const onToggle = vi.fn();
+    renderTh(
+      <SortHeader label="Name" sortKey="name" activeKey="" asc onToggle={onToggle} />,
+    );
+    const th = screen.getByRole('columnheader');
+    expect(th.textContent).toBe('Name');
+    fireEvent.click(th);
+    expect(onToggle).toHaveBeenCalledWith('name');
+  });
+
+  it('shows ▲ when active asc and ▼ when active desc', () => {
+    const { rerender } = renderTh(
+      <SortHeader label="Name" sortKey="name" activeKey="name" asc onToggle={() => {}} />,
+    );
+    expect(screen.getByRole('columnheader').textContent).toBe('Name ▲');
+    rerender(
+      <table><thead><tr>
+        <SortHeader label="Name" sortKey="name" activeKey="name" asc={false} onToggle={() => {}} />
+      </tr></thead></table>,
+    );
+    expect(screen.getByRole('columnheader').textContent).toBe('Name ▼');
+  });
+});

--- a/ui/src/components/SortHeader.tsx
+++ b/ui/src/components/SortHeader.tsx
@@ -1,0 +1,26 @@
+// SortHeader is the one clickable column header shared by every sortable
+// table (ADR-0042 phase 2). The parent owns the sort state — server-side
+// pages keep it in the URL (useListControls), client-side tables keep it
+// in local state — and this component only renders the header + arrow.
+// Non-sortable columns must render a plain <th> instead (no affordance).
+export function SortHeader({
+  label,
+  sortKey,
+  activeKey,
+  asc,
+  onToggle,
+}: {
+  label: React.ReactNode;
+  sortKey: string;
+  activeKey: string;
+  asc: boolean;
+  onToggle: (key: string) => void;
+}) {
+  const arrow = activeKey === sortKey ? (asc ? ' ▲' : ' ▼') : '';
+  return (
+    <th className="sortable" onClick={() => onToggle(sortKey)}>
+      {label}
+      {arrow}
+    </th>
+  );
+}

--- a/ui/src/hooks.test.tsx
+++ b/ui/src/hooks.test.tsx
@@ -3,7 +3,7 @@ import { act, render, renderHook, screen, waitFor } from '@testing-library/react
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { type ReactNode, useState } from 'react';
 import { ApiError } from './api';
-import { useDebouncedValue, useResource, useResources, usePageSize, PAGE_SIZE_OPTIONS, usePagedList } from './hooks';
+import { useDebouncedValue, useResource, useResources, usePageSize, PAGE_SIZE_OPTIONS, usePagedList, useListControls } from './hooks';
 import type { PagedResponse } from './api';
 
 afterEach(() => vi.useRealTimers());
@@ -260,5 +260,52 @@ describe('useDebouncedValue', () => {
       vi.advanceTimersByTime(100);
     });
     expect(screen.getByTestId('value').textContent).toBe('b');
+  });
+});
+
+function wrapper(initial = '/clusters') {
+  return ({ children }: { children: React.ReactNode }) => (
+    <MemoryRouter initialEntries={[initial]}>{children}</MemoryRouter>
+  );
+}
+
+describe('useListControls', () => {
+  it('reads initial state from the URL', () => {
+    const { result } = renderHook(() => useListControls(), {
+      wrapper: wrapper('/clusters?name=prod&sort=name&order=desc'),
+    });
+    expect(result.current.name).toBe('prod');
+    expect(result.current.nameInput).toBe('prod');
+    expect(result.current.sort).toBe('name');
+    expect(result.current.order).toBe('desc');
+    expect(result.current.params).toEqual({ name: 'prod', sort: 'name', order: 'desc' });
+  });
+
+  it('debounces typed input into the URL-synced name', async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useListControls(), { wrapper: wrapper() });
+    act(() => result.current.setNameInput('web'));
+    expect(result.current.name).toBe('');           // not yet applied
+    act(() => { vi.advanceTimersByTime(300); });
+    vi.useRealTimers();
+    await waitFor(() => expect(result.current.name).toBe('web'));
+    expect(result.current.deps).toEqual(['web', '', 'asc']);
+  });
+
+  it('toggleSort cycles asc → desc on the same key and resets to asc on a new key', async () => {
+    const { result } = renderHook(() => useListControls(), { wrapper: wrapper() });
+    act(() => result.current.toggleSort('name'));
+    await waitFor(() => expect(result.current.sort).toBe('name'));
+    expect(result.current.order).toBe('asc');
+    act(() => result.current.toggleSort('name'));
+    await waitFor(() => expect(result.current.order).toBe('desc'));
+    act(() => result.current.toggleSort('region'));
+    await waitFor(() => expect(result.current.sort).toBe('region'));
+    expect(result.current.order).toBe('asc');
+  });
+
+  it('omits sort/order from params when no sort is active', () => {
+    const { result } = renderHook(() => useListControls(), { wrapper: wrapper() });
+    expect(result.current.params).toEqual({ name: undefined, sort: undefined, order: undefined });
   });
 });

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -251,12 +251,13 @@ export function useListControls(): ListControls {
   }, [urlName]);
 
   const toggleSort = (key: string) => {
+    // replace: sort clicks shouldn't pile up in browser history.
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);
       next.set('sort', key);
       next.set('order', sort === key && order === 'asc' ? 'desc' : 'asc');
       return next;
-    });
+    }, { replace: true });
   };
 
   return {

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ApiError } from './api';
-import type { PagedResponse } from './api';
+import type { ListControlParams, PagedResponse } from './api';
 
 // useDebouncedValue delays propagation of a fast-changing value (typed
 // search input) until it has been stable for `delayMs`. Used by list
@@ -200,5 +200,77 @@ export function usePagedList<T>(
       if (nextCursor) setStack((s) => [...s, nextCursor]);
     },
     prev: () => setStack((s) => s.slice(0, -1)),
+  };
+}
+
+export type ListControls = {
+  nameInput: string;
+  setNameInput: (v: string) => void;
+  name: string;
+  sort: string;
+  order: 'asc' | 'desc';
+  toggleSort: (key: string) => void;
+  params: ListControlParams;
+  deps: unknown[];
+};
+
+// useListControls owns the uniform list controls (ADR-0042 phase 2): a
+// debounced free-text name filter and a sort key/direction, all mirrored
+// into the URL query string so any list view is a shareable link. The URL
+// is the source of truth; typing debounces 300 ms before landing there.
+// Cursors deliberately never reach the URL — a shared link opens page 1.
+export function useListControls(): ListControls {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const urlName = searchParams.get('name') ?? '';
+  const sort = searchParams.get('sort') ?? '';
+  const order: 'asc' | 'desc' = searchParams.get('order') === 'desc' ? 'desc' : 'asc';
+
+  const [nameInput, setNameInput] = useState(urlName);
+  const debouncedName = useDebouncedValue(nameInput.trim(), 300);
+
+  // Debounced input → URL. replace:true so typing doesn't spam history.
+  useEffect(() => {
+    if (debouncedName === urlName) return;
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (debouncedName) next.set('name', debouncedName);
+        else next.delete('name');
+        return next;
+      },
+      { replace: true },
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedName]);
+
+  // External URL change (back/forward, shared link, block-pill link) →
+  // input. Guarded so our own debounced write doesn't loop.
+  useEffect(() => {
+    if (urlName !== debouncedName) setNameInput(urlName);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlName]);
+
+  const toggleSort = (key: string) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.set('sort', key);
+      next.set('order', sort === key && order === 'asc' ? 'desc' : 'asc');
+      return next;
+    });
+  };
+
+  return {
+    nameInput,
+    setNameInput,
+    name: urlName,
+    sort,
+    order,
+    toggleSort,
+    params: {
+      name: urlName || undefined,
+      sort: sort || undefined,
+      order: sort ? order : undefined,
+    },
+    deps: [urlName, sort, order],
   };
 }

--- a/ui/src/pages/Applications.test.tsx
+++ b/ui/src/pages/Applications.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Applications from './Applications';
 import { renderWithRouter } from '../test/render';
@@ -87,30 +87,63 @@ describe('Applications list', () => {
     renderWithRouter(<Applications />, { initialPath: '/applications' });
     await waitFor(() => expect(screen.getByRole('link', { name: /billing/ })).toBeInTheDocument());
 
-    await user.type(screen.getByPlaceholderText('prefix or substring'), 'bill');
+    await user.type(screen.getByPlaceholderText('Filter by name… (* = wildcard)'), 'bill');
     await waitFor(() => expect(seen).toContain('bill'));
   });
 
-  it('"Load more" calls the fetcher with the previous cursor', async () => {
-    const cursors: (string | null)[] = [];
-    let call = 0;
+  it('renders the Paginator (no Load-more button)', async () => {
+    server.use(
+      http.get('/v1/applications', () =>
+        HttpResponse.json({ items: [billing], next_cursor: 'C1' }),
+      ),
+    );
+    renderWithRouter(<Applications />, { initialPath: '/applications' });
+    await waitFor(() =>
+      expect(screen.getByRole('link', { name: /billing/ })).toBeInTheDocument(),
+    );
+    // Standard Paginator "Next" button should be present.
+    expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument();
+    // Old "Load more" button must NOT be present.
+    expect(screen.queryByRole('button', { name: /load more/i })).toBeNull();
+  });
+
+  it('Owner column header sends sort=owner&order=asc', async () => {
+    const captured: string[] = [];
     server.use(
       http.get('/v1/applications', ({ request }) => {
-        cursors.push(new URL(request.url).searchParams.get('cursor'));
-        call += 1;
-        if (call === 1) {
-          return HttpResponse.json({ items: [billing], next_cursor: 'CURSOR123' });
-        }
-        return HttpResponse.json({ items: [ledger], next_cursor: null });
+        captured.push(new URL(request.url).search);
+        return HttpResponse.json(paged([billing]));
       }),
     );
-    const user = userEvent.setup();
     renderWithRouter(<Applications />, { initialPath: '/applications' });
-    await waitFor(() => expect(screen.getByRole('link', { name: /billing/ })).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByRole('link', { name: /billing/ })).toBeInTheDocument(),
+    );
+    const ownerHeader = screen.getByRole('columnheader', { name: /^Owner/ });
+    expect(ownerHeader.className).toContain('sortable');
+    fireEvent.click(ownerHeader);
+    await waitFor(() => {
+      const last = captured.at(-1) ?? '';
+      expect(last).toContain('sort=owner');
+      expect(last).toContain('order=asc');
+    });
+  });
 
-    await user.click(screen.getByRole('button', { name: /load more/i }));
-    await waitFor(() => expect(cursors).toContain('CURSOR123'));
-    await waitFor(() => expect(screen.getByRole('link', { name: /^Ledger$/ })).toBeInTheDocument());
+  it('URL application_block_name is sent to the API', async () => {
+    const captured: string[] = [];
+    server.use(
+      http.get('/v1/applications', ({ request }) => {
+        captured.push(new URL(request.url).search);
+        return HttpResponse.json(paged([billing]));
+      }),
+    );
+    renderWithRouter(<Applications />, {
+      initialPath: '/applications?application_block_name=facturation',
+    });
+    await waitFor(() => {
+      const last = captured.at(-1) ?? '';
+      expect(last).toContain('application_block_name=facturation');
+    });
   });
 
   it('renders the empty state', async () => {

--- a/ui/src/pages/Applications.tsx
+++ b/ui/src/pages/Applications.tsx
@@ -1,14 +1,16 @@
-import { useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
 import * as api from '../api';
-import { useResource, useDebouncedValue } from '../hooks';
-import { AsyncView, Dash } from '../components';
+import { usePagedList, useListControls, useDebouncedValue } from '../hooks';
+import { Dash, Paginator } from '../components';
+import { SortHeader } from '../components/SortHeader';
+import { SearchInput } from '../components/SearchInput';
 
 // Applications is the top-level list page for the ADR-0029 first-class
 // Application entity. It mirrors the VirtualMachines page shape: a
 // toolbar of filters above a table. The default view groups rows by
 // application_block_name (with an "Unblocked" group last); a toggle
-// flips to a flat alphabetical sort. Cursor pagination via "Load more".
+// flips to a flat alphabetical sort. Standard Paginator replaces "Load more".
 
 // dictMax returns the maximum DICT axis value across the four axes, or
 // null when none are recorded. The list badge renders "DICT max: N".
@@ -34,56 +36,75 @@ function memberSummary(c: api.ApplicationMemberCounts): string {
 const UNBLOCKED = '__unblocked__';
 
 export default function Applications() {
-  // Typed filter inputs — debounced before they reach the fetcher so a
-  // fast typist doesn't fan out a request per keystroke.
-  const [nameInput, setNameInput] = useState('');
-  const [blockInput, setBlockInput] = useState('');
-  const [criticalityInput, setCriticalityInput] = useState('');
-  const [hasDict, setHasDict] = useState<'any' | 'yes' | 'no'>('any');
-  const [dictMin, setDictMin] = useState<number>(0);
+  const controls = useListControls();
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const setParam = (key: string, value: string) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (value) next.set(key, value);
+        else next.delete(key);
+        return next;
+      },
+      { replace: true },
+    );
+  };
+
+  // Read filter values from URL:
+  const block = searchParams.get('application_block_name') ?? '';
+  const criticality = searchParams.get('criticality') ?? '';
+  const hasDictParam = searchParams.get('has_dict') ?? '';
+  const dictMinParam = searchParams.get('dict_min') ?? '';
+
+  const hasDict: 'any' | 'yes' | 'no' =
+    hasDictParam === 'yes' ? 'yes' : hasDictParam === 'no' ? 'no' : 'any';
+  const dictMin = dictMinParam ? Math.max(0, Math.min(4, Number(dictMinParam))) : 0;
+
+  // Debounced text inputs for block and criticality (VM-page pattern).
+  const [blockInput, setBlockInput] = useState(block);
+  const [criticalityInput, setCriticalityInput] = useState(criticality);
+
+  const debouncedBlock = useDebouncedValue(blockInput.trim(), 300);
+  const debouncedCriticality = useDebouncedValue(criticalityInput.trim(), 300);
+
+  // Debounced input → URL (guarded to avoid loops).
+  useEffect(() => {
+    if (debouncedBlock !== block) setParam('application_block_name', debouncedBlock);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedBlock]);
+
+  useEffect(() => {
+    if (debouncedCriticality !== criticality) setParam('criticality', debouncedCriticality);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedCriticality]);
+
+  // External URL change (back/forward, block-pill link) → input.
+  useEffect(() => {
+    if (block !== debouncedBlock) setBlockInput(block);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [block]);
+
+  useEffect(() => {
+    if (criticality !== debouncedCriticality) setCriticalityInput(criticality);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [criticality]);
+
+  // Display preference — not a filter, stays local.
   const [grouped, setGrouped] = useState(true);
 
-  // Accumulated pages — "Load more" appends rather than replacing so the
-  // operator keeps scroll context. Reset whenever a filter changes.
-  const [extraPages, setExtraPages] = useState<api.Application[]>([]);
-  const [moreCursor, setMoreCursor] = useState<string | null>(null);
-  const [loadingMore, setLoadingMore] = useState(false);
-
-  const name = useDebouncedValue(nameInput.trim(), 250);
-  const block = useDebouncedValue(blockInput.trim(), 250);
-  const criticality = useDebouncedValue(criticalityInput.trim(), 250);
-
   const filter: api.ApplicationListFilter = {
-    limit: 50,
-    name: name || undefined,
     application_block_name: block || undefined,
     criticality: criticality || undefined,
     has_dict: hasDict === 'any' ? undefined : hasDict === 'yes',
     dict_min: dictMin > 0 ? dictMin : undefined,
   };
 
-  const state = useResource(
-    async () => {
-      // A fresh filter resets any accumulated "Load more" pages.
-      setExtraPages([]);
-      const page = await api.listApplications(filter);
-      setMoreCursor(page.next_cursor ?? null);
-      return page;
-    },
-    [name, block, criticality, hasDict, dictMin],
+  const list = usePagedList<api.Application>(
+    (cursor, limit) =>
+      api.listApplications({ ...filter, ...controls.params, cursor, limit }),
+    [block, criticality, hasDict, dictMin, ...controls.deps],
   );
-
-  const loadMore = async () => {
-    if (!moreCursor) return;
-    setLoadingMore(true);
-    try {
-      const page = await api.listApplications({ ...filter, cursor: moreCursor });
-      setExtraPages((prev) => [...prev, ...page.items]);
-      setMoreCursor(page.next_cursor ?? null);
-    } finally {
-      setLoadingMore(false);
-    }
-  };
 
   return (
     <>
@@ -93,15 +114,7 @@ export default function Applications() {
       </p>
 
       <div className="vm-filters">
-        <label>
-          <span>Name</span>
-          <input
-            type="search"
-            value={nameInput}
-            placeholder="prefix or substring"
-            onChange={(e) => setNameInput(e.target.value)}
-          />
-        </label>
+        <SearchInput value={controls.nameInput} onChange={controls.setNameInput} />
         <label>
           <span>Application block</span>
           <input
@@ -124,7 +137,7 @@ export default function Applications() {
           <span>Has DICT</span>
           <select
             value={hasDict}
-            onChange={(e) => setHasDict(e.target.value as 'any' | 'yes' | 'no')}
+            onChange={(e) => setParam('has_dict', e.target.value === 'any' ? '' : e.target.value)}
           >
             <option value="any">Any</option>
             <option value="yes">Yes</option>
@@ -133,7 +146,12 @@ export default function Applications() {
         </label>
         <label>
           <span>DICT min</span>
-          <select value={dictMin} onChange={(e) => setDictMin(Number(e.target.value))}>
+          <select
+            value={dictMin}
+            onChange={(e) =>
+              setParam('dict_min', e.target.value === '0' ? '' : e.target.value)
+            }
+          >
             {[0, 1, 2, 3, 4].map((n) => (
               <option key={n} value={n}>
                 {n}
@@ -148,45 +166,52 @@ export default function Applications() {
         </label>
       </div>
 
-      <AsyncView state={state}>
-        {(firstPage) => {
-          const all = [...firstPage.items, ...extraPages];
-          if (all.length === 0) {
-            return (
-              <p className="muted empty">
-                No applications yet — create one from a workload or VM detail page.
-              </p>
-            );
-          }
-          return (
-            <>
-              {grouped ? (
-                <GroupedTable apps={all} />
-              ) : (
-                <FlatTable
-                  apps={[...all].sort((a, b) =>
-                    (a.display_name || a.name).toLowerCase().localeCompare(
-                      (b.display_name || b.name).toLowerCase(),
-                    ),
-                  )}
-                />
-              )}
-              {moreCursor && (
-                <div style={{ marginTop: '0.75rem' }}>
-                  <button type="button" onClick={loadMore} disabled={loadingMore}>
-                    {loadingMore ? 'Loading...' : 'Load more'}
-                  </button>
-                </div>
-              )}
-            </>
-          );
-        }}
-      </AsyncView>
+      <Paginator
+        pageSize={list.pageSize}
+        hasPrev={list.hasPrev}
+        hasNext={list.hasNext}
+        onPrev={list.prev}
+        onNext={list.next}
+        onPageSize={list.setPageSize}
+      />
+      {list.loading ? (
+        <p className="loading">Loading…</p>
+      ) : list.error ? (
+        <div className="error">Failed to load: {list.error}</div>
+      ) : list.items.length === 0 ? (
+        <p className="muted empty">
+          No applications yet — create one from a workload or VM detail page.
+        </p>
+      ) : grouped ? (
+        <GroupedTable
+          apps={list.items}
+          sort={controls.sort}
+          asc={controls.order === 'asc'}
+          onToggle={controls.toggleSort}
+        />
+      ) : (
+        <FlatTable
+          apps={list.items}
+          sort={controls.sort}
+          asc={controls.order === 'asc'}
+          onToggle={controls.toggleSort}
+        />
+      )}
     </>
   );
 }
 
-function GroupedTable({ apps }: { apps: api.Application[] }) {
+function GroupedTable({
+  apps,
+  sort,
+  asc,
+  onToggle,
+}: {
+  apps: api.Application[];
+  sort: string;
+  asc: boolean;
+  onToggle: (k: string) => void;
+}) {
   // Group case-insensitively on the block name; unblocked apps land in a
   // dedicated bucket keyed by UNBLOCKED so it can sort last.
   const groups = useMemo(() => {
@@ -214,23 +239,51 @@ function GroupedTable({ apps }: { apps: api.Application[] }) {
           <summary>
             {g.label} <span className="muted">({g.apps.length})</span>
           </summary>
-          <FlatTable apps={g.apps} />
+          <FlatTable apps={g.apps} sort={sort} asc={asc} onToggle={onToggle} />
         </details>
       ))}
     </>
   );
 }
 
-function FlatTable({ apps }: { apps: api.Application[] }) {
+function FlatTable({
+  apps,
+  sort,
+  asc,
+  onToggle,
+}: {
+  apps: api.Application[];
+  sort: string;
+  asc: boolean;
+  onToggle: (k: string) => void;
+}) {
   return (
     <div className="table-wrap">
       <table className="entities">
         <thead>
           <tr>
-            <th>Name</th>
+            <SortHeader
+              label="Name"
+              sortKey="name"
+              activeKey={sort}
+              asc={asc}
+              onToggle={onToggle}
+            />
             <th>Block</th>
-            <th>Owner</th>
-            <th>Criticality</th>
+            <SortHeader
+              label="Owner"
+              sortKey="owner"
+              activeKey={sort}
+              asc={asc}
+              onToggle={onToggle}
+            />
+            <SortHeader
+              label="Criticality"
+              sortKey="criticality"
+              activeKey={sort}
+              asc={asc}
+              onToggle={onToggle}
+            />
             <th>DICT</th>
             <th>Members</th>
             <th>Runbook</th>

--- a/ui/src/pages/EolDashboard.tsx
+++ b/ui/src/pages/EolDashboard.tsx
@@ -7,6 +7,7 @@ import { useEntityTable } from '../components/column_filters';
 import { EolIcon } from '../icons';
 import { ExtractButton } from '../components/ExtractButton';
 import { TruncationBanner } from '../components/TruncationBanner';
+import { SortHeader } from '../components/SortHeader';
 
 // --- EOL annotation parsing -----------------------------------------------
 
@@ -189,7 +190,7 @@ function countStatuses(rows: EolRow[]): StatusCounts {
   return counts;
 }
 
-// --- Sortable column header -----------------------------------------------
+// --- Sort logic ----------------------------------------------------------
 
 type SortKey = 'status' | 'product' | 'entity' | 'cluster' | 'application' | 'eolDate';
 
@@ -218,26 +219,6 @@ function compareRows(a: EolRow, b: EolRow, key: SortKey, asc: boolean): number {
   return asc ? cmp : -cmp;
 }
 
-function SortHeader({
-  label,
-  sortKey,
-  currentKey,
-  asc,
-  onClick,
-}: {
-  label: string;
-  sortKey: SortKey;
-  currentKey: SortKey;
-  asc: boolean;
-  onClick: (key: SortKey) => void;
-}) {
-  const arrow = currentKey === sortKey ? (asc ? ' \u25b2' : ' \u25bc') : '';
-  return (
-    <th className="sortable" onClick={() => onClick(sortKey)}>
-      {label}{arrow}
-    </th>
-  );
-}
 
 // --- Page component -------------------------------------------------------
 
@@ -257,11 +238,12 @@ export default function EolDashboard() {
   const [sortAsc, setSortAsc] = useState(true);
   const [truncated, setTruncated] = useState(false);
 
-  const handleSort = (key: SortKey) => {
-    if (key === sortKey) {
+  const handleSort = (key: string) => {
+    const k = key as SortKey;
+    if (k === sortKey) {
       setSortAsc(!sortAsc);
     } else {
-      setSortKey(key);
+      setSortKey(k);
       setSortAsc(true);
     }
   };
@@ -353,7 +335,7 @@ function EolTable({
   sortKey: SortKey;
   sortAsc: boolean;
   onCardClick: (status: EolStatus) => void;
-  onSort: (key: SortKey) => void;
+  onSort: (key: string) => void;
 }) {
   const allRows = useMemo(
     () => buildRows(clusters, nodes, vms, appNameById),
@@ -450,15 +432,15 @@ function EolTable({
       <table className="entities eol-table" ref={tableRef}>
         <thead>
           <tr>
-            <SortHeader label="Status" sortKey="status" currentKey={sortKey} asc={sortAsc} onClick={onSort} />
-            <SortHeader label="Product" sortKey="product" currentKey={sortKey} asc={sortAsc} onClick={onSort} />
+            <SortHeader label="Status" sortKey="status" activeKey={sortKey} asc={sortAsc} onToggle={onSort} />
+            <SortHeader label="Product" sortKey="product" activeKey={sortKey} asc={sortAsc} onToggle={onSort} />
             <th>Version</th>
             <th>Patch</th>
-            <SortHeader label="Entity" sortKey="entity" currentKey={sortKey} asc={sortAsc} onClick={onSort} />
-            <SortHeader label="Application" sortKey="application" currentKey={sortKey} asc={sortAsc} onClick={onSort} />
-            <SortHeader label="Cluster" sortKey="cluster" currentKey={sortKey} asc={sortAsc} onClick={onSort} />
+            <SortHeader label="Entity" sortKey="entity" activeKey={sortKey} asc={sortAsc} onToggle={onSort} />
+            <SortHeader label="Application" sortKey="application" activeKey={sortKey} asc={sortAsc} onToggle={onSort} />
+            <SortHeader label="Cluster" sortKey="cluster" activeKey={sortKey} asc={sortAsc} onToggle={onSort} />
             <th>Latest Available</th>
-            <SortHeader label="EOL Date" sortKey="eolDate" currentKey={sortKey} asc={sortAsc} onClick={onSort} />
+            <SortHeader label="EOL Date" sortKey="eolDate" activeKey={sortKey} asc={sortAsc} onToggle={onSort} />
             <th>Checked</th>
           </tr>
         </thead>

--- a/ui/src/pages/Lists.test.tsx
+++ b/ui/src/pages/Lists.test.tsx
@@ -288,6 +288,26 @@ describe('PersistentVolumes list', () => {
       expect(screen.getByText(/failed to load/i)).toBeInTheDocument(),
     );
   });
+
+  it('Capacity column header is sortable and clicking it sends sort=capacity&order=asc', async () => {
+    const captured: string[] = [];
+    server.use(
+      http.get('/v1/persistentvolumes', ({ request }) => {
+        captured.push(new URL(request.url).search);
+        return HttpResponse.json({ items: [fixturePV], next_cursor: null });
+      }),
+    );
+    renderWithRouter(<PersistentVolumes />, { initialPath: '/persistent-volumes' });
+    await waitFor(() => expect(screen.getByText(fixturePV.name)).toBeInTheDocument());
+    const capacityHeader = screen.getByRole('columnheader', { name: /^Capacity/ });
+    expect(capacityHeader.className).toContain('sortable');
+    fireEvent.click(capacityHeader);
+    await waitFor(() => {
+      const last = captured.at(-1) ?? '';
+      expect(last).toContain('sort=capacity');
+      expect(last).toContain('order=asc');
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/ui/src/pages/Lists.test.tsx
+++ b/ui/src/pages/Lists.test.tsx
@@ -184,6 +184,26 @@ describe('Pods list', () => {
       expect(screen.getByText(/failed to load/i)).toBeInTheDocument(),
     );
   });
+
+  it('Node column header is sortable and clicking it sends sort=node_name&order=asc', async () => {
+    const captured: string[] = [];
+    server.use(
+      http.get('/v1/pods', ({ request }) => {
+        captured.push(new URL(request.url).search);
+        return HttpResponse.json({ items: [fixturePod], next_cursor: null });
+      }),
+    );
+    renderWithRouter(<Pods />, { initialPath: '/pods' });
+    await waitFor(() => expect(screen.getByText(fixturePod.name)).toBeInTheDocument());
+    const nodeHeader = screen.getByRole('columnheader', { name: /^Node/ });
+    expect(nodeHeader.className).toContain('sortable');
+    fireEvent.click(nodeHeader);
+    await waitFor(() => {
+      const last = captured.at(-1) ?? '';
+      expect(last).toContain('sort=node_name');
+      expect(last).toContain('order=asc');
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/ui/src/pages/Lists.test.tsx
+++ b/ui/src/pages/Lists.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
 import {
   Clusters,
   Ingresses,
@@ -51,6 +51,26 @@ describe('Clusters list', () => {
     await waitFor(() =>
       expect(screen.getByText(/failed to load/i)).toBeInTheDocument(),
     );
+  });
+
+  it('Name column header is sortable and clicking it sends sort=name&order=asc', async () => {
+    const captured: string[] = [];
+    server.use(
+      http.get('/v1/clusters', ({ request }) => {
+        captured.push(new URL(request.url).search);
+        return HttpResponse.json({ items: [fixtureCluster], next_cursor: null });
+      }),
+    );
+    renderWithRouter(<Clusters />, { initialPath: '/clusters' });
+    await waitFor(() => expect(screen.getByText(fixtureCluster.display_name!)).toBeInTheDocument());
+    const nameHeader = screen.getByRole('columnheader', { name: /^Name/ });
+    expect(nameHeader.className).toContain('sortable');
+    fireEvent.click(nameHeader);
+    await waitFor(() => {
+      const last = captured.at(-1) ?? '';
+      expect(last).toContain('sort=name');
+      expect(last).toContain('order=asc');
+    });
   });
 });
 

--- a/ui/src/pages/Lists.tsx
+++ b/ui/src/pages/Lists.tsx
@@ -1,14 +1,12 @@
-// One-file home for every top-level list page. All of them use the same
-// pattern — usePagedList(listFn) → Paginator → table with a few columns →
-// id links through to the detail page. Kept together so adding a new kind
-// means editing one file.
+// One-file home for every top-level list page. All of them use EntityListPage
+// with per-entity column configs — sortable headers, search input, and
+// pagination come for free. Adding a new kind means adding one config here.
 
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import * as api from '../api';
-import { useResource, usePagedList } from '../hooks';
-import { Dash, IdLink, LayerPill, LoadBalancerAddresses, Empty, NamespaceLink, Paginator } from '../components';
-import { useEntityTable } from '../components/column_filters';
+import { useResource } from '../hooks';
+import { Dash, IdLink, LayerPill, LoadBalancerAddresses, NamespaceLink } from '../components';
 import { EntityListPage } from '../components/EntityListPage';
 import {
   ClusterIcon, NodeIcon, NamespaceIcon, WorkloadIcon, PodIcon,
@@ -291,282 +289,189 @@ export function Pods() {
 }
 
 export function Services() {
-  const list = usePagedList<api.Service>(
-    (cursor, limit) => api.listServices({ cursor, limit }),
-    [],
-  );
-  const tableRef = useEntityTable('lists.services');
   return (
-    <>
-      <h2><ServiceIcon size={20} /> Services</h2>
-      <Paginator
-        pageSize={list.pageSize}
-        hasPrev={list.hasPrev}
-        hasNext={list.hasNext}
-        onPrev={list.prev}
-        onNext={list.next}
-        onPageSize={list.setPageSize}
-      />
-      {list.loading ? (
-        <p className="loading">Loading…</p>
-      ) : list.error ? (
-        <div className="error">Failed to load: {list.error}</div>
-      ) : list.items.length === 0 ? (
-        <Empty message="No services found. Kubernetes Services are collected automatically." />
-      ) : (
-        <div className="table-wrap">
-          <table className="entities" ref={tableRef}>
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Namespace</th>
-                <th>Type</th>
-                <th>ClusterIP</th>
-                <th>Ports</th>
-                <th>Load balancer</th>
-              </tr>
-            </thead>
-            <tbody>
-              {list.items.map((s) => (
-                <tr key={s.id}>
-                  <td>
-                    <Link to={`/services/${s.id}`}>
-                      <strong>{s.name}</strong>
-                    </Link>
-                  </td>
-                  <td>
-                    <NamespaceLink
-                      namespaceId={s.namespace_id}
-                      namespaceName={s.namespace_name}
-                      clusterId={s.cluster_id}
-                      clusterName={s.cluster_name}
-                    />
-                  </td>
-                  <td><span className="pill">{s.type || 'ClusterIP'}</span></td>
-                  <td>{s.cluster_ip ? <code>{s.cluster_ip}</code> : <Dash />}</td>
-                  <td>
-                    {s.ports?.length ? (
-                      <code>{s.ports.map((p) => `${p.port}/${p.protocol || 'TCP'}`).join(', ')}</code>
-                    ) : (
-                      <Dash />
-                    )}
-                  </td>
-                  <td><LoadBalancerAddresses entries={s.load_balancer} /></td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </>
+    <EntityListPage<api.Service>
+      title="Services"
+      icon={<ServiceIcon size={20} />}
+      storageKey="lists.services"
+      emptyMessage="No services found. Kubernetes Services are collected automatically."
+      fetchPage={(params, cursor, limit) => api.listServices({ ...params, cursor, limit })}
+      rowKey={(s) => s.id}
+      columns={[
+        {
+          key: 'name',
+          label: 'Name',
+          sortKey: 'name',
+          render: (s) => (
+            <Link to={`/services/${s.id}`}>
+              <strong>{s.name}</strong>
+            </Link>
+          ),
+        },
+        {
+          key: 'namespace',
+          label: 'Namespace',
+          render: (s) => (
+            <NamespaceLink
+              namespaceId={s.namespace_id}
+              namespaceName={s.namespace_name}
+              clusterId={s.cluster_id}
+              clusterName={s.cluster_name}
+            />
+          ),
+        },
+        { key: 'type', label: 'Type', sortKey: 'type', render: (s) => <span className="pill">{s.type || 'ClusterIP'}</span> },
+        { key: 'cluster_ip', label: 'ClusterIP', sortKey: 'cluster_ip', render: (s) => s.cluster_ip ? <code>{s.cluster_ip}</code> : <Dash /> },
+        {
+          key: 'ports',
+          label: 'Ports',
+          render: (s) => (
+            s.ports?.length ? (
+              <code>{s.ports.map((p) => `${p.port}/${p.protocol || 'TCP'}`).join(', ')}</code>
+            ) : (
+              <Dash />
+            )
+          ),
+        },
+        { key: 'load_balancer', label: 'Load balancer', render: (s) => <LoadBalancerAddresses entries={s.load_balancer} /> },
+      ]}
+    />
   );
 }
 
 export function Ingresses() {
-  const list = usePagedList<api.Ingress>(
-    (cursor, limit) => api.listIngresses({ cursor, limit }),
-    [],
-  );
-  const tableRef = useEntityTable('lists.ingresses');
   return (
-    <>
-      <h2><IngressIcon size={20} /> Ingresses</h2>
-      <Paginator
-        pageSize={list.pageSize}
-        hasPrev={list.hasPrev}
-        hasNext={list.hasNext}
-        onPrev={list.prev}
-        onNext={list.next}
-        onPageSize={list.setPageSize}
-      />
-      {list.loading ? (
-        <p className="loading">Loading…</p>
-      ) : list.error ? (
-        <div className="error">Failed to load: {list.error}</div>
-      ) : list.items.length === 0 ? (
-        <Empty message="No ingresses found. Ingress resources are collected from all namespaces." />
-      ) : (
-        <div className="table-wrap">
-          <table className="entities" ref={tableRef}>
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Namespace</th>
-                <th>Class</th>
-                <th>Hosts</th>
-                <th>Load balancer</th>
-              </tr>
-            </thead>
-            <tbody>
-              {list.items.map((i) => (
-                <tr key={i.id}>
-                  <td>
-                    <Link to={`/ingresses/${i.id}`}>
-                      <strong>{i.name}</strong>
-                    </Link>
-                  </td>
-                  <td>
-                    <NamespaceLink
-                      namespaceId={i.namespace_id}
-                      namespaceName={i.namespace_name}
-                      clusterId={i.cluster_id}
-                      clusterName={i.cluster_name}
-                    />
-                  </td>
-                  <td>{i.ingress_class_name || <Dash />}</td>
-                  <td>
-                    {i.rules?.length ? (
-                      <code>{i.rules.map((r) => r.host).filter(Boolean).join(', ')}</code>
-                    ) : (
-                      <Dash />
-                    )}
-                  </td>
-                  <td><LoadBalancerAddresses entries={i.load_balancer} /></td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </>
+    <EntityListPage<api.Ingress>
+      title="Ingresses"
+      icon={<IngressIcon size={20} />}
+      storageKey="lists.ingresses"
+      emptyMessage="No ingresses found. Ingress resources are collected from all namespaces."
+      fetchPage={(params, cursor, limit) => api.listIngresses({ ...params, cursor, limit })}
+      rowKey={(i) => i.id}
+      columns={[
+        {
+          key: 'name',
+          label: 'Name',
+          sortKey: 'name',
+          render: (i) => (
+            <Link to={`/ingresses/${i.id}`}>
+              <strong>{i.name}</strong>
+            </Link>
+          ),
+        },
+        {
+          key: 'namespace',
+          label: 'Namespace',
+          render: (i) => (
+            <NamespaceLink
+              namespaceId={i.namespace_id}
+              namespaceName={i.namespace_name}
+              clusterId={i.cluster_id}
+              clusterName={i.cluster_name}
+            />
+          ),
+        },
+        { key: 'class', label: 'Class', sortKey: 'ingress_class_name', render: (i) => i.ingress_class_name || <Dash /> },
+        {
+          key: 'hosts',
+          label: 'Hosts',
+          render: (i) => (
+            i.rules?.length ? (
+              <code>{i.rules.map((r) => r.host).filter(Boolean).join(', ')}</code>
+            ) : (
+              <Dash />
+            )
+          ),
+        },
+        { key: 'load_balancer', label: 'Load balancer', render: (i) => <LoadBalancerAddresses entries={i.load_balancer} /> },
+      ]}
+    />
   );
 }
 
 export function PersistentVolumes() {
-  const list = usePagedList<api.PersistentVolume>(
-    (cursor, limit) => api.listPersistentVolumes({ cursor, limit }),
-    [],
-  );
-  const clusters = useResource(() => fetchAllClusters(), []);
-  const clustersById =
-    clusters.status === 'ready'
-      ? new Map(clusters.data.map((c) => [c.id, c]))
-      : new Map<string, api.Cluster>();
-  const tableRef = useEntityTable('lists.persistent_volumes');
+  const clustersState = useResource(() => fetchAllClusters(), []);
+  const clustersById = useMemo(() => {
+    if (clustersState.status !== 'ready') return new Map<string, api.Cluster>();
+    return new Map(clustersState.data.map((c) => [c.id, c]));
+  }, [clustersState]);
   return (
-    <>
-      <h2><VolumeIcon size={20} /> Persistent Volumes</h2>
-      <Paginator
-        pageSize={list.pageSize}
-        hasPrev={list.hasPrev}
-        hasNext={list.hasNext}
-        onPrev={list.prev}
-        onNext={list.next}
-        onPageSize={list.setPageSize}
-      />
-      {list.loading ? (
-        <p className="loading">Loading…</p>
-      ) : list.error ? (
-        <div className="error">Failed to load: {list.error}</div>
-      ) : list.items.length === 0 ? (
-        <Empty message="No persistent volumes found. PVs are collected cluster-wide by the collector." />
-      ) : (
-        <div className="table-wrap">
-          <table className="entities" ref={tableRef}>
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Cluster</th>
-                <th>Capacity</th>
-                <th>Storage class</th>
-                <th>CSI driver</th>
-                <th>Phase</th>
-              </tr>
-            </thead>
-            <tbody>
-              {list.items.map((pv) => {
-                const cluster = clustersById.get(pv.cluster_id);
-                return (
-                  <tr key={pv.id}>
-                    <td>
-                      <Link to={`/persistentvolumes/${pv.id}`}>
-                        <strong>{pv.name}</strong>
-                      </Link>
-                    </td>
-                    <td>
-                      {cluster ? (
-                        <Link to={`/clusters/${cluster.id}`}>{cluster.name}</Link>
-                      ) : (
-                        <IdLink to={`/clusters/${pv.cluster_id}`} id={pv.cluster_id} />
-                      )}
-                    </td>
-                    <td>{pv.capacity ? <code>{pv.capacity}</code> : <Dash />}</td>
-                    <td>{pv.storage_class_name || <Dash />}</td>
-                    <td>{pv.csi_driver ? <code>{pv.csi_driver}</code> : <Dash />}</td>
-                    <td>{pv.phase || <Dash />}</td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </>
+    <EntityListPage<api.PersistentVolume>
+      title="Persistent Volumes"
+      icon={<VolumeIcon size={20} />}
+      storageKey="lists.persistent_volumes"
+      emptyMessage="No persistent volumes found. PVs are collected cluster-wide by the collector."
+      fetchPage={(params, cursor, limit) => api.listPersistentVolumes({ ...params, cursor, limit })}
+      rowKey={(pv) => pv.id}
+      columns={[
+        {
+          key: 'name',
+          label: 'Name',
+          sortKey: 'name',
+          render: (pv) => (
+            <Link to={`/persistentvolumes/${pv.id}`}>
+              <strong>{pv.name}</strong>
+            </Link>
+          ),
+        },
+        {
+          key: 'cluster',
+          label: 'Cluster',
+          render: (pv) => {
+            const cluster = clustersById.get(pv.cluster_id);
+            return cluster ? (
+              <Link to={`/clusters/${cluster.id}`}>{cluster.name}</Link>
+            ) : (
+              <IdLink to={`/clusters/${pv.cluster_id}`} id={pv.cluster_id} />
+            );
+          },
+        },
+        { key: 'capacity', label: 'Capacity', sortKey: 'capacity', render: (pv) => pv.capacity ? <code>{pv.capacity}</code> : <Dash /> },
+        { key: 'storage_class', label: 'Storage class', sortKey: 'storage_class_name', render: (pv) => pv.storage_class_name || <Dash /> },
+        { key: 'csi_driver', label: 'CSI driver', sortKey: 'csi_driver', render: (pv) => pv.csi_driver ? <code>{pv.csi_driver}</code> : <Dash /> },
+        { key: 'phase', label: 'Phase', sortKey: 'phase', render: (pv) => pv.phase || <Dash /> },
+      ]}
+    />
   );
 }
 
 export function PersistentVolumeClaims() {
-  const list = usePagedList<api.PersistentVolumeClaim>(
-    (cursor, limit) => api.listPersistentVolumeClaims({ cursor, limit }),
-    [],
-  );
-  const tableRef = useEntityTable('lists.persistent_volume_claims');
   return (
-    <>
-      <h2><VolumeIcon size={20} /> Persistent Volume Claims</h2>
-      <Paginator
-        pageSize={list.pageSize}
-        hasPrev={list.hasPrev}
-        hasNext={list.hasNext}
-        onPrev={list.prev}
-        onNext={list.next}
-        onPageSize={list.setPageSize}
-      />
-      {list.loading ? (
-        <p className="loading">Loading…</p>
-      ) : list.error ? (
-        <div className="error">Failed to load: {list.error}</div>
-      ) : list.items.length === 0 ? (
-        <Empty message="No persistent volume claims found. PVCs are collected from all namespaces." />
-      ) : (
-        <div className="table-wrap">
-          <table className="entities" ref={tableRef}>
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Namespace</th>
-                <th>Phase</th>
-                <th>Requested</th>
-                <th>Storage class</th>
-                <th>Bound PV</th>
-              </tr>
-            </thead>
-            <tbody>
-              {list.items.map((pvc) => (
-                <tr key={pvc.id}>
-                  <td>
-                    <Link to={`/persistentvolumeclaims/${pvc.id}`}>
-                      <strong>{pvc.name}</strong>
-                    </Link>
-                  </td>
-                  <td>
-                    <NamespaceLink
-                      namespaceId={pvc.namespace_id}
-                      namespaceName={pvc.namespace_name}
-                      clusterId={pvc.cluster_id}
-                      clusterName={pvc.cluster_name}
-                    />
-                  </td>
-                  <td>{pvc.phase || <Dash />}</td>
-                  <td>{pvc.requested_storage ? <code>{pvc.requested_storage}</code> : <Dash />}</td>
-                  <td>{pvc.storage_class_name || <Dash />}</td>
-                  <td>{pvc.volume_name ? <code>{pvc.volume_name}</code> : <Dash />}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </>
+    <EntityListPage<api.PersistentVolumeClaim>
+      title="Persistent Volume Claims"
+      icon={<VolumeIcon size={20} />}
+      storageKey="lists.persistent_volume_claims"
+      emptyMessage="No persistent volume claims found. PVCs are collected from all namespaces."
+      fetchPage={(params, cursor, limit) => api.listPersistentVolumeClaims({ ...params, cursor, limit })}
+      rowKey={(pvc) => pvc.id}
+      columns={[
+        {
+          key: 'name',
+          label: 'Name',
+          sortKey: 'name',
+          render: (pvc) => (
+            <Link to={`/persistentvolumeclaims/${pvc.id}`}>
+              <strong>{pvc.name}</strong>
+            </Link>
+          ),
+        },
+        {
+          key: 'namespace',
+          label: 'Namespace',
+          render: (pvc) => (
+            <NamespaceLink
+              namespaceId={pvc.namespace_id}
+              namespaceName={pvc.namespace_name}
+              clusterId={pvc.cluster_id}
+              clusterName={pvc.cluster_name}
+            />
+          ),
+        },
+        { key: 'phase', label: 'Phase', sortKey: 'phase', render: (pvc) => pvc.phase || <Dash /> },
+        { key: 'requested', label: 'Requested', sortKey: 'requested_storage', render: (pvc) => pvc.requested_storage ? <code>{pvc.requested_storage}</code> : <Dash /> },
+        { key: 'storage_class', label: 'Storage class', sortKey: 'storage_class_name', render: (pvc) => pvc.storage_class_name || <Dash /> },
+        { key: 'bound_pv', label: 'Bound PV', render: (pvc) => pvc.volume_name ? <code>{pvc.volume_name}</code> : <Dash /> },
+      ]}
+    />
   );
 }

--- a/ui/src/pages/Lists.tsx
+++ b/ui/src/pages/Lists.tsx
@@ -3,6 +3,7 @@
 // id links through to the detail page. Kept together so adding a new kind
 // means editing one file.
 
+import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import * as api from '../api';
 import { useResource, usePagedList } from '../hooks';
@@ -71,85 +72,59 @@ async function fetchAllClusters(): Promise<api.Cluster[]> {
 }
 
 export function Nodes() {
-  const list = usePagedList<api.Node>(
-    (cursor, limit) => api.listNodes({ cursor, limit }),
-    [],
-  );
-  const clusters = useResource(() => fetchAllClusters(), []);
-  const clustersById =
-    clusters.status === 'ready'
-      ? new Map(clusters.data.map((c) => [c.id, c]))
-      : new Map<string, api.Cluster>();
-  const tableRef = useEntityTable('lists.nodes');
+  const clustersState = useResource(() => fetchAllClusters(), []);
+  const clustersById = useMemo(() => {
+    if (clustersState.status !== 'ready') return new Map<string, api.Cluster>();
+    return new Map(clustersState.data.map((c) => [c.id, c]));
+  }, [clustersState]);
   return (
-    <>
-      <h2><NodeIcon size={20} /> Nodes</h2>
-      <Paginator
-        pageSize={list.pageSize}
-        hasPrev={list.hasPrev}
-        hasNext={list.hasNext}
-        onPrev={list.prev}
-        onNext={list.next}
-        onPageSize={list.setPageSize}
-      />
-      {list.loading ? (
-        <p className="loading">Loading…</p>
-      ) : list.error ? (
-        <div className="error">Failed to load: {list.error}</div>
-      ) : list.items.length === 0 ? (
-        <Empty message="No nodes found. Ensure a collector is running and connected to a cluster." />
-      ) : (
-        <div className="table-wrap">
-          <table className="entities" ref={tableRef}>
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Cluster</th>
-                <th>Role</th>
-                <th>Zone</th>
-                <th>Instance type</th>
-                <th>CPU / Mem</th>
-                <th>Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              {list.items.map((n) => {
-                const cluster = clustersById.get(n.cluster_id);
-                return (
-                  <tr key={n.id}>
-                    <td>
-                      <Link to={`/nodes/${n.id}`}>
-                        <strong>{n.display_name || n.name}</strong>
-                      </Link>
-                    </td>
-                    <td>
-                      {cluster ? (
-                        <Link to={`/clusters/${cluster.id}`}>{cluster.name}</Link>
-                      ) : (
-                        <IdLink to={`/clusters/${n.cluster_id}`} id={n.cluster_id} />
-                      )}
-                    </td>
-                    <td>{n.role ? <span className="pill">{n.role}</span> : <Dash />}</td>
-                    <td>{n.zone ? <code>{n.zone}</code> : <Dash />}</td>
-                    <td>{n.instance_type ? <code>{n.instance_type}</code> : <Dash />}</td>
-                    <td>
-                      {n.capacity_cpu || n.capacity_memory ? (
-                        <code>{n.capacity_cpu || '?'} / {n.capacity_memory || '?'}</code>
-                      ) : (
-                        <Dash />
-                      )}
-                    </td>
-                    <td>
-                      <NodeStatusBadge ready={n.ready} unschedulable={n.unschedulable} />
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </>
+    <EntityListPage<api.Node>
+      title="Nodes"
+      icon={<NodeIcon size={20} />}
+      storageKey="lists.nodes"
+      emptyMessage="No nodes found. Ensure a collector is running and connected to a cluster."
+      fetchPage={(params, cursor, limit) => api.listNodes({ ...params, cursor, limit })}
+      rowKey={(n) => n.id}
+      columns={[
+        {
+          key: 'name',
+          label: 'Name',
+          sortKey: 'name',
+          render: (n) => (
+            <Link to={`/nodes/${n.id}`}>
+              <strong>{n.display_name || n.name}</strong>
+            </Link>
+          ),
+        },
+        {
+          key: 'cluster',
+          label: 'Cluster',
+          render: (n) => {
+            const cluster = clustersById.get(n.cluster_id);
+            return cluster ? (
+              <Link to={`/clusters/${cluster.id}`}>{cluster.name}</Link>
+            ) : (
+              <IdLink to={`/clusters/${n.cluster_id}`} id={n.cluster_id} />
+            );
+          },
+        },
+        { key: 'role', label: 'Role', sortKey: 'role', render: (n) => n.role ? <span className="pill">{n.role}</span> : <Dash /> },
+        { key: 'zone', label: 'Zone', sortKey: 'zone', render: (n) => n.zone ? <code>{n.zone}</code> : <Dash /> },
+        { key: 'instance_type', label: 'Instance type', sortKey: 'instance_type', render: (n) => n.instance_type ? <code>{n.instance_type}</code> : <Dash /> },
+        {
+          key: 'cpu_mem',
+          label: 'CPU / Mem',
+          render: (n) => (
+            n.capacity_cpu || n.capacity_memory ? (
+              <code>{n.capacity_cpu || '?'} / {n.capacity_memory || '?'}</code>
+            ) : (
+              <Dash />
+            )
+          ),
+        },
+        { key: 'status', label: 'Status', render: (n) => <NodeStatusBadge ready={n.ready} unschedulable={n.unschedulable} /> },
+      ]}
+    />
   );
 }
 
@@ -169,207 +144,149 @@ function NodeStatusBadge({
 }
 
 export function Namespaces() {
-  const list = usePagedList<api.Namespace>(
-    (cursor, limit) => api.listNamespaces({ cursor, limit }),
-    [],
-  );
-  const tableRef = useEntityTable('lists.namespaces');
   return (
-    <>
-      <h2><NamespaceIcon size={20} /> Namespaces</h2>
-      <Paginator
-        pageSize={list.pageSize}
-        hasPrev={list.hasPrev}
-        hasNext={list.hasNext}
-        onPrev={list.prev}
-        onNext={list.next}
-        onPageSize={list.setPageSize}
-      />
-      {list.loading ? (
-        <p className="loading">Loading…</p>
-      ) : list.error ? (
-        <div className="error">Failed to load: {list.error}</div>
-      ) : list.items.length === 0 ? (
-        <Empty message="No namespaces found. They are collected automatically from your clusters." />
-      ) : (
-        <div className="table-wrap">
-          <table className="entities" ref={tableRef}>
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Cluster</th>
-                <th>Phase</th>
-              </tr>
-            </thead>
-            <tbody>
-              {list.items.map((n) => (
-                <tr key={n.id}>
-                  <td>
-                    <Link to={`/namespaces/${n.id}`}>
-                      <strong>{n.name}</strong>
-                    </Link>
-                  </td>
-                  <td>
-                    <Link to={`/clusters/${n.cluster_id}`}>
-                      {n.cluster_name ?? <span title="cluster row missing">(orphan)</span>}
-                    </Link>
-                  </td>
-                  <td>{n.phase || <Dash />}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </>
+    <EntityListPage<api.Namespace>
+      title="Namespaces"
+      icon={<NamespaceIcon size={20} />}
+      storageKey="lists.namespaces"
+      emptyMessage="No namespaces found. They are collected automatically from your clusters."
+      fetchPage={(params, cursor, limit) => api.listNamespaces({ ...params, cursor, limit })}
+      rowKey={(n) => n.id}
+      columns={[
+        {
+          key: 'name',
+          label: 'Name',
+          sortKey: 'name',
+          render: (n) => (
+            <Link to={`/namespaces/${n.id}`}>
+              <strong>{n.name}</strong>
+            </Link>
+          ),
+        },
+        {
+          key: 'cluster',
+          label: 'Cluster',
+          render: (n) => (
+            <Link to={`/clusters/${n.cluster_id}`}>
+              {n.cluster_name ?? <span title="cluster row missing">(orphan)</span>}
+            </Link>
+          ),
+        },
+        { key: 'phase', label: 'Phase', sortKey: 'phase', render: (n) => n.phase || <Dash /> },
+      ]}
+    />
   );
 }
 
 export function Workloads() {
-  const list = usePagedList<api.Workload>(
-    (cursor, limit) => api.listWorkloads({ cursor, limit }),
-    [],
-  );
-  const tableRef = useEntityTable('lists.workloads');
-
   return (
-    <>
-      <h2><WorkloadIcon size={20} /> Workloads</h2>
-      <Paginator
-        pageSize={list.pageSize}
-        hasPrev={list.hasPrev}
-        hasNext={list.hasNext}
-        onPrev={list.prev}
-        onNext={list.next}
-        onPageSize={list.setPageSize}
-      />
-      {list.loading ? (
-        <p className="loading">Loading…</p>
-      ) : list.error ? (
-        <div className="error">Failed to load: {list.error}</div>
-      ) : list.items.length === 0 ? (
-        <Empty message="No workloads found. Deployments, StatefulSets and DaemonSets will appear here once collected." />
-      ) : (
-        <div className="table-wrap">
-          <table className="entities" ref={tableRef}>
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Kind</th>
-                <th>Namespace</th>
-                <th>Replicas</th>
-                <th>Containers</th>
-              </tr>
-            </thead>
-            <tbody>
-              {list.items.map((w) => (
-                <tr key={w.id}>
-                  <td>
-                    <Link to={`/workloads/${w.id}`}>
-                      <strong>{w.name}</strong>
-                    </Link>
-                  </td>
-                  <td><span className="pill">{w.kind}</span></td>
-                  <td>
-                    <NamespaceLink
-                      namespaceId={w.namespace_id}
-                      namespaceName={w.namespace_name}
-                      clusterId={w.cluster_id}
-                      clusterName={w.cluster_name}
-                    />
-                  </td>
-                  <td>
-                    {w.ready_replicas ?? '?'}
-                    <span className="muted">/{w.replicas ?? '?'}</span>
-                  </td>
-                  <td>
-                    {w.containers?.length ? (
-                      <code>{w.containers.map((c) => c.image).join(', ')}</code>
-                    ) : (
-                      <Dash />
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </>
+    <EntityListPage<api.Workload>
+      title="Workloads"
+      icon={<WorkloadIcon size={20} />}
+      storageKey="lists.workloads"
+      emptyMessage="No workloads found. Deployments, StatefulSets and DaemonSets will appear here once collected."
+      fetchPage={(params, cursor, limit) => api.listWorkloads({ ...params, cursor, limit })}
+      rowKey={(w) => w.id}
+      columns={[
+        {
+          key: 'name',
+          label: 'Name',
+          sortKey: 'name',
+          render: (w) => (
+            <Link to={`/workloads/${w.id}`}>
+              <strong>{w.name}</strong>
+            </Link>
+          ),
+        },
+        { key: 'kind', label: 'Kind', sortKey: 'kind', render: (w) => <span className="pill">{w.kind}</span> },
+        {
+          key: 'namespace',
+          label: 'Namespace',
+          render: (w) => (
+            <NamespaceLink
+              namespaceId={w.namespace_id}
+              namespaceName={w.namespace_name}
+              clusterId={w.cluster_id}
+              clusterName={w.cluster_name}
+            />
+          ),
+        },
+        {
+          key: 'replicas',
+          label: 'Replicas',
+          render: (w) => (
+            <>
+              {w.ready_replicas ?? '?'}
+              <span className="muted">/{w.replicas ?? '?'}</span>
+            </>
+          ),
+        },
+        {
+          key: 'containers',
+          label: 'Containers',
+          render: (w) => (
+            w.containers?.length ? (
+              <code>{w.containers.map((c) => c.image).join(', ')}</code>
+            ) : (
+              <Dash />
+            )
+          ),
+        },
+      ]}
+    />
   );
 }
 
 export function Pods() {
-  const list = usePagedList<api.Pod>(
-    (cursor, limit) => api.listPods({ cursor, limit }),
-    [],
-  );
-  const tableRef = useEntityTable('lists.pods');
   return (
-    <>
-      <h2><PodIcon size={20} /> Pods</h2>
-      <Paginator
-        pageSize={list.pageSize}
-        hasPrev={list.hasPrev}
-        hasNext={list.hasNext}
-        onPrev={list.prev}
-        onNext={list.next}
-        onPageSize={list.setPageSize}
-      />
-      {list.loading ? (
-        <p className="loading">Loading…</p>
-      ) : list.error ? (
-        <div className="error">Failed to load: {list.error}</div>
-      ) : list.items.length === 0 ? (
-        <Empty message="No pods found. Pods are collected from all connected clusters." />
-      ) : (
-        <div className="table-wrap">
-          <table className="entities" ref={tableRef}>
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Namespace</th>
-                <th>Phase</th>
-                <th>Node</th>
-                <th>Pod IP</th>
-                <th>Workload</th>
-              </tr>
-            </thead>
-            <tbody>
-              {list.items.map((p) => (
-                <tr key={p.id}>
-                  <td>
-                    <Link to={`/pods/${p.id}`}>
-                      <strong>{p.name}</strong>
-                    </Link>
-                  </td>
-                  <td>
-                    <NamespaceLink
-                      namespaceId={p.namespace_id}
-                      namespaceName={p.namespace_name}
-                      clusterId={p.cluster_id}
-                      clusterName={p.cluster_name}
-                    />
-                  </td>
-                  <td>{p.phase || <Dash />}</td>
-                  <td>{p.node_name ? <code>{p.node_name}</code> : <Dash />}</td>
-                  <td>{p.pod_ip ? <code>{p.pod_ip}</code> : <Dash />}</td>
-                  <td>
-                    {p.workload_id ? (
-                      <Link to={`/workloads/${p.workload_id}`}>
-                        {p.workload_name ?? <IdLink to={`/workloads/${p.workload_id}`} id={p.workload_id} />}
-                      </Link>
-                    ) : (
-                      <Dash />
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </>
+    <EntityListPage<api.Pod>
+      title="Pods"
+      icon={<PodIcon size={20} />}
+      storageKey="lists.pods"
+      emptyMessage="No pods found. Pods are collected from all connected clusters."
+      fetchPage={(params, cursor, limit) => api.listPods({ ...params, cursor, limit })}
+      rowKey={(p) => p.id}
+      columns={[
+        {
+          key: 'name',
+          label: 'Name',
+          sortKey: 'name',
+          render: (p) => (
+            <Link to={`/pods/${p.id}`}>
+              <strong>{p.name}</strong>
+            </Link>
+          ),
+        },
+        {
+          key: 'namespace',
+          label: 'Namespace',
+          render: (p) => (
+            <NamespaceLink
+              namespaceId={p.namespace_id}
+              namespaceName={p.namespace_name}
+              clusterId={p.cluster_id}
+              clusterName={p.cluster_name}
+            />
+          ),
+        },
+        { key: 'phase', label: 'Phase', sortKey: 'phase', render: (p) => p.phase || <Dash /> },
+        { key: 'node', label: 'Node', sortKey: 'node_name', render: (p) => p.node_name ? <code>{p.node_name}</code> : <Dash /> },
+        { key: 'pod_ip', label: 'Pod IP', sortKey: 'pod_ip', render: (p) => p.pod_ip ? <code>{p.pod_ip}</code> : <Dash /> },
+        {
+          key: 'workload',
+          label: 'Workload',
+          render: (p) => (
+            p.workload_id ? (
+              <Link to={`/workloads/${p.workload_id}`}>
+                {p.workload_name ?? <IdLink to={`/workloads/${p.workload_id}`} id={p.workload_id} />}
+              </Link>
+            ) : (
+              <Dash />
+            )
+          ),
+        },
+      ]}
+    />
   );
 }
 

--- a/ui/src/pages/Lists.tsx
+++ b/ui/src/pages/Lists.tsx
@@ -8,72 +8,51 @@ import * as api from '../api';
 import { useResource, usePagedList } from '../hooks';
 import { Dash, IdLink, LayerPill, LoadBalancerAddresses, Empty, NamespaceLink, Paginator } from '../components';
 import { useEntityTable } from '../components/column_filters';
+import { EntityListPage } from '../components/EntityListPage';
 import {
   ClusterIcon, NodeIcon, NamespaceIcon, WorkloadIcon, PodIcon,
   ServiceIcon, IngressIcon, VolumeIcon,
 } from '../icons';
 
 export function Clusters() {
-  const list = usePagedList<api.Cluster>(
-    (cursor, limit) => api.listClusters({ cursor, limit }),
-    [],
-  );
-  const tableRef = useEntityTable('lists.clusters');
   return (
-    <>
-      <h2><ClusterIcon size={20} /> Clusters</h2>
-      <Paginator
-        pageSize={list.pageSize}
-        hasPrev={list.hasPrev}
-        hasNext={list.hasNext}
-        onPrev={list.prev}
-        onNext={list.next}
-        onPageSize={list.setPageSize}
-      />
-      {list.loading ? (
-        <p className="loading">Loading…</p>
-      ) : list.error ? (
-        <div className="error">Failed to load: {list.error}</div>
-      ) : list.items.length === 0 ? (
-        <Empty message="No clusters yet. Connect a collector to start populating your inventory." />
-      ) : (
-        <div className="table-wrap">
-          <table className="entities" ref={tableRef}>
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Environment</th>
-                <th>Provider</th>
-                <th>Region</th>
-                <th>K8s version</th>
-                <th>Layer</th>
-              </tr>
-            </thead>
-            <tbody>
-              {list.items.map((c) => (
-                <tr key={c.id}>
-                  <td>
-                    <Link to={`/clusters/${c.id}`}>
-                      <strong>{c.display_name || c.name}</strong>
-                    </Link>
-                    {c.display_name && (
-                      <div className="muted" style={{ fontSize: '0.8rem' }}>
-                        {c.name}
-                      </div>
-                    )}
-                  </td>
-                  <td>{c.environment || <Dash />}</td>
-                  <td>{c.provider || <Dash />}</td>
-                  <td>{c.region || <Dash />}</td>
-                  <td>{c.kubernetes_version ? <code>{c.kubernetes_version}</code> : <Dash />}</td>
-                  <td><LayerPill layer={c.layer} /></td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </>
+    <EntityListPage<api.Cluster>
+      title="Clusters"
+      icon={<ClusterIcon size={20} />}
+      storageKey="lists.clusters"
+      emptyMessage="No clusters yet. Connect a collector to start populating your inventory."
+      fetchPage={(params, cursor, limit) => api.listClusters({ ...params, cursor, limit })}
+      rowKey={(c) => c.id}
+      columns={[
+        {
+          key: 'name',
+          label: 'Name',
+          sortKey: 'name',
+          render: (c) => (
+            <>
+              <Link to={`/clusters/${c.id}`}>
+                <strong>{c.display_name || c.name}</strong>
+              </Link>
+              {c.display_name && (
+                <div className="muted" style={{ fontSize: '0.8rem' }}>
+                  {c.name}
+                </div>
+              )}
+            </>
+          ),
+        },
+        { key: 'environment', label: 'Environment', sortKey: 'environment', render: (c) => c.environment || <Dash /> },
+        { key: 'provider', label: 'Provider', sortKey: 'provider', render: (c) => c.provider || <Dash /> },
+        { key: 'region', label: 'Region', sortKey: 'region', render: (c) => c.region || <Dash /> },
+        {
+          key: 'k8s_version',
+          label: 'K8s version',
+          sortKey: 'kubernetes_version',
+          render: (c) => (c.kubernetes_version ? <code>{c.kubernetes_version}</code> : <Dash />),
+        },
+        { key: 'layer', label: 'Layer', render: (c) => <LayerPill layer={c.layer} /> },
+      ]}
+    />
   );
 }
 

--- a/ui/src/pages/VirtualMachines.test.tsx
+++ b/ui/src/pages/VirtualMachines.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
 import VirtualMachines from './VirtualMachines';
 import { renderWithRouter } from '../test/render';
 import { server } from '../test/server';
@@ -26,6 +26,51 @@ describe('VirtualMachines list', () => {
     renderWithRouter(<VirtualMachines />, { initialPath: '/virtual-machines' });
     await waitFor(() =>
       expect(screen.getByText(/failed to load/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('Name column header is sortable and clicking it sends sort=name&order=asc', async () => {
+    const captured: string[] = [];
+    server.use(
+      http.get('/v1/virtual-machines', ({ request }) => {
+        captured.push(new URL(request.url).search);
+        return HttpResponse.json({ items: [fixtureVirtualMachine], next_cursor: null });
+      }),
+    );
+    renderWithRouter(<VirtualMachines />, { initialPath: '/virtual-machines' });
+    await waitFor(() =>
+      expect(screen.getByText(fixtureVirtualMachine.name)).toBeInTheDocument(),
+    );
+    const nameHeader = screen.getByRole('columnheader', { name: /^Name/ });
+    expect(nameHeader.className).toContain('sortable');
+    fireEvent.click(nameHeader);
+    await waitFor(() => {
+      const last = captured.at(-1) ?? '';
+      expect(last).toContain('sort=name');
+      expect(last).toContain('order=asc');
+    });
+  });
+
+  it('typing in the name box sends name param after debounce', async () => {
+    const captured: string[] = [];
+    server.use(
+      http.get('/v1/virtual-machines', ({ request }) => {
+        captured.push(new URL(request.url).search);
+        return HttpResponse.json({ items: [fixtureVirtualMachine], next_cursor: null });
+      }),
+    );
+    renderWithRouter(<VirtualMachines />, { initialPath: '/virtual-machines' });
+    await waitFor(() =>
+      expect(screen.getByText(fixtureVirtualMachine.name)).toBeInTheDocument(),
+    );
+    const nameInput = screen.getByRole('searchbox', { name: /^Name/i });
+    fireEvent.change(nameInput, { target: { value: 'vpn' } });
+    await waitFor(
+      () => {
+        const last = captured.at(-1) ?? '';
+        expect(last).toContain('name=vpn');
+      },
+      { timeout: 1000 },
     );
   });
 });

--- a/ui/src/pages/VirtualMachines.tsx
+++ b/ui/src/pages/VirtualMachines.tsx
@@ -1,29 +1,18 @@
-import { useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
 import * as api from '../api';
-import { useResource, usePagedList } from '../hooks';
+import { useResource, usePagedList, useListControls, useDebouncedValue } from '../hooks';
 import { isAdmin, useMe } from '../me';
 import { Dash, Paginator } from '../components';
 import { useEntityTable } from '../components/column_filters';
+import { SortHeader } from '../components/SortHeader';
+import { SearchInput } from '../components/SearchInput';
 import { VirtualMachineIcon } from '../icons';
 
 // VirtualMachines is the top-level list page for ADR-0015 VMs. It mirrors
 // the shape of the EOL Inventory dashboard: filterable summary cards
 // above a sortable table. Power state is the load-bearing column —
 // running / stopped / terminated / error each get a distinct pill.
-
-type SortKey =
-  | 'name'
-  | 'role'
-  | 'cloud_account'
-  | 'region'
-  | 'zone'
-  | 'instance_type'
-  | 'image_name'
-  | 'image_id'
-  | 'private_ip'
-  | 'power_state'
-  | 'last_seen';
 
 type PowerStateGroup = 'running' | 'stopped' | 'terminated' | 'error' | 'other';
 
@@ -79,98 +68,56 @@ function formatTs(ts?: string | null): string {
   }
 }
 
-function compare(a: api.VirtualMachine, b: api.VirtualMachine, key: SortKey, asc: boolean): number {
-  const dir = asc ? 1 : -1;
-  const s = (v?: string | null) => (v ?? '').toLowerCase();
-  switch (key) {
-    case 'name':
-      return s(a.display_name || a.name).localeCompare(s(b.display_name || b.name)) * dir;
-    case 'role':
-      return s(a.role).localeCompare(s(b.role)) * dir;
-    case 'cloud_account':
-      return s(a.cloud_account_id).localeCompare(s(b.cloud_account_id)) * dir;
-    case 'region':
-      return s(a.region).localeCompare(s(b.region)) * dir;
-    case 'zone':
-      return s(a.zone).localeCompare(s(b.zone)) * dir;
-    case 'instance_type':
-      return s(a.instance_type).localeCompare(s(b.instance_type)) * dir;
-    case 'image_name':
-      return s(a.image_name).localeCompare(s(b.image_name)) * dir;
-    case 'image_id':
-      return s(a.image_id).localeCompare(s(b.image_id)) * dir;
-    case 'private_ip':
-      return s(a.private_ip).localeCompare(s(b.private_ip)) * dir;
-    case 'power_state':
-      return s(a.power_state).localeCompare(s(b.power_state)) * dir;
-    case 'last_seen':
-      return (a.last_seen_at || '').localeCompare(b.last_seen_at || '') * dir;
-  }
-}
-
 export default function VirtualMachines() {
   const me = useMe();
   const showAccountFilter = isAdmin(me);
   const tableRef = useEntityTable('vms.list');
 
-  const [cloudAccountId, setCloudAccountId] = useState<string>('');
-  const [region, setRegion] = useState<string>('');
-  const [role, setRole] = useState<string>('');
-  const [powerState, setPowerState] = useState<string>('');
-  const [includeTerminated, setIncludeTerminated] = useState<boolean>(false);
-  const [groupFilter, setGroupFilter] = useState<PowerStateGroup | null>(null);
-  // Free-text filters (ADR-0019). The *Input states track what the user
-  // has typed; the *Applied states are what the request actually carries.
-  // Submitting the form (button or Enter) copies typed → applied — that's
-  // what triggers a fresh server-side query.
-  const [nameInput, setNameInput] = useState<string>('');
-  const [imageInput, setImageInput] = useState<string>('');
-  const [appliedName, setAppliedName] = useState<string>('');
-  const [appliedImage, setAppliedImage] = useState<string>('');
-  const [application, setApplication] = useState<string>('');
-  // applicationVersion is only honoured server-side when application is
-  // also set (see api/cloud_types.go). The UI mirrors the same coupling:
-  // the dropdown is disabled until a product is selected, and changing
-  // the product resets the version to "any".
-  const [applicationVersion, setApplicationVersion] = useState<string>('');
+  const controls = useListControls();
 
-  const handleSearchSubmit = (e?: { preventDefault?: () => void }) => {
-    e?.preventDefault?.();
-    setAppliedName(nameInput.trim());
-    setAppliedImage(imageInput.trim());
+  const [searchParams, setSearchParams] = useSearchParams();
+  const setParam = (key: string, value: string) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (value) next.set(key, value);
+        else next.delete(key);
+        return next;
+      },
+      { replace: true },
+    );
   };
 
-  const handleClearSearch = () => {
-    setNameInput('');
-    setImageInput('');
-    setAppliedName('');
-    setAppliedImage('');
-  };
+  // Read all filters from the URL:
+  const cloudAccountId = searchParams.get('cloud_account_id') ?? '';
+  const region = searchParams.get('region') ?? '';
+  const powerState = searchParams.get('power_state') ?? '';
+  const includeTerminated = searchParams.get('include_terminated') === 'true';
+  const application = searchParams.get('application') ?? '';
+  const applicationVersion = searchParams.get('application_version') ?? '';
 
-  const dirty = nameInput.trim() !== appliedName || imageInput.trim() !== appliedImage;
-
-  const [sortKey, setSortKey] = useState<SortKey>('name');
-  const [sortAsc, setSortAsc] = useState<boolean>(true);
-
-  const handleSort = (k: SortKey) => {
-    if (k === sortKey) setSortAsc(!sortAsc);
-    else {
-      setSortKey(k);
-      setSortAsc(true);
-    }
-  };
+  // Image: debounced free-text like name, but page-local (not part of
+  // useListControls — it is a VM-specific filter).
+  const [imageInput, setImageInput] = useState(searchParams.get('image') ?? '');
+  const debouncedImage = useDebouncedValue(imageInput.trim(), 300);
+  useEffect(() => {
+    if (debouncedImage !== (searchParams.get('image') ?? '')) setParam('image', debouncedImage);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedImage]);
 
   // Role filter is applied client-side (after splitting comma-joined
   // role strings) so that a filter on `dns` matches a VM tagged
   // `ansible_group=dns,primary_dns`. Region / cloud_account / power_state
   // remain server-side filters.
+  const [role, setRole] = useState<string>('');
+  const [groupFilter, setGroupFilter] = useState<PowerStateGroup | null>(null);
+
   const filter: api.VirtualMachineListFilter = {
     cloud_account_id: cloudAccountId || undefined,
     region: region || undefined,
     power_state: powerState || undefined,
     include_terminated: includeTerminated,
-    name: appliedName || undefined,
-    image: appliedImage || undefined,
+    image: debouncedImage || undefined,
     application: application || undefined,
     application_version: application && applicationVersion ? applicationVersion : undefined,
   };
@@ -188,16 +135,11 @@ export default function VirtualMachines() {
   const appsState = useResource(() => api.listDistinctVMApplications(), []);
 
   const vmsList = usePagedList<api.VirtualMachine>(
-    (cursor, limit) => api.listVirtualMachines({ ...filter, cursor, limit }),
+    (cursor, limit) => api.listVirtualMachines({ ...filter, ...controls.params, cursor, limit }),
     [
-      cloudAccountId,
-      region,
-      powerState,
-      includeTerminated,
-      appliedName,
-      appliedImage,
-      application,
-      applicationVersion,
+      cloudAccountId, region, powerState, includeTerminated,
+      debouncedImage, application, applicationVersion,
+      ...controls.deps,
     ],
   );
 
@@ -246,7 +188,7 @@ export default function VirtualMachines() {
           if (groupFilter && classify(vm.power_state) !== groupFilter) return false;
           return true;
         });
-        const sorted = [...visible].sort((a, b) => compare(a, b, sortKey, sortAsc));
+        const sorted = visible;
 
         // Region dropdown options: union of regions from cloud_accounts
         // (admins only) and the currently-loaded VMs, plus the
@@ -319,7 +261,7 @@ export default function VirtualMachines() {
                     <span>Cloud account</span>
                     <select
                       value={cloudAccountId}
-                      onChange={(e) => setCloudAccountId(e.target.value)}
+                      onChange={(e) => setParam('cloud_account_id', e.target.value)}
                     >
                       <option value="">All accounts</option>
                       {accountList.map((a) => (
@@ -334,7 +276,7 @@ export default function VirtualMachines() {
                   <span>Region</span>
                   <select
                     value={region}
-                    onChange={(e) => setRegion(e.target.value)}
+                    onChange={(e) => setParam('region', e.target.value)}
                     disabled={regions.length === 0}
                   >
                     <option value="">All regions</option>
@@ -362,7 +304,7 @@ export default function VirtualMachines() {
                 </label>
                 <label>
                   <span>Power state</span>
-                  <select value={powerState} onChange={(e) => setPowerState(e.target.value)}>
+                  <select value={powerState} onChange={(e) => setParam('power_state', e.target.value)}>
                     <option value="">Any</option>
                     <option value="running">running</option>
                     <option value="stopped">stopped</option>
@@ -378,10 +320,10 @@ export default function VirtualMachines() {
                   <select
                     value={application}
                     onChange={(e) => {
-                      setApplication(e.target.value);
+                      setParam('application', e.target.value);
                       // Reset version when the product changes — the
                       // option list belongs to the previous product.
-                      setApplicationVersion('');
+                      setParam('application_version', '');
                     }}
                     disabled={
                       appsState.status !== 'ready' ||
@@ -401,7 +343,7 @@ export default function VirtualMachines() {
                   <span>App version</span>
                   <select
                     value={applicationVersion}
-                    onChange={(e) => setApplicationVersion(e.target.value)}
+                    onChange={(e) => setParam('application_version', e.target.value)}
                     disabled={!application || appsState.status !== 'ready'}
                   >
                     <option value="">Any</option>
@@ -420,25 +362,17 @@ export default function VirtualMachines() {
                   <input
                     type="checkbox"
                     checked={includeTerminated}
-                    onChange={(e) => setIncludeTerminated(e.target.checked)}
+                    onChange={(e) => setParam('include_terminated', e.target.checked ? 'true' : '')}
                   />
                   <span>Include terminated</span>
                 </label>
               </div>
 
               <div className="vm-search">
-                <label>
-                  <span>Name</span>
-                  <input
-                    type="search"
-                    value={nameInput}
-                    placeholder="prefix or substring"
-                    onChange={(e) => setNameInput(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') handleSearchSubmit(e);
-                    }}
-                  />
-                </label>
+                <SearchInput
+                  value={controls.nameInput}
+                  onChange={controls.setNameInput}
+                />
                 <label>
                   <span>Image</span>
                   <input
@@ -446,26 +380,8 @@ export default function VirtualMachines() {
                     value={imageInput}
                     placeholder="ami-… or name fragment"
                     onChange={(e) => setImageInput(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') handleSearchSubmit(e);
-                    }}
                   />
                 </label>
-                <div className="vm-filter-actions">
-                  <button
-                    type="button"
-                    className="primary"
-                    onClick={handleSearchSubmit}
-                    disabled={!dirty && !appliedName && !appliedImage}
-                  >
-                    Search
-                  </button>
-                  {(appliedName || appliedImage || nameInput || imageInput) && (
-                    <button type="button" onClick={handleClearSearch}>
-                      Clear
-                    </button>
-                  )}
-                </div>
               </div>
 
               <Paginator
@@ -490,79 +406,61 @@ export default function VirtualMachines() {
                       <SortHeader
                         label="Name"
                         sortKey="name"
-                        currentKey={sortKey}
-                        asc={sortAsc}
-                        onClick={handleSort}
+                        activeKey={controls.sort}
+                        asc={controls.order === 'asc'}
+                        onToggle={controls.toggleSort}
                       />
                       <SortHeader
                         label="Role"
                         sortKey="role"
-                        currentKey={sortKey}
-                        asc={sortAsc}
-                        onClick={handleSort}
+                        activeKey={controls.sort}
+                        asc={controls.order === 'asc'}
+                        onToggle={controls.toggleSort}
                       />
-                      <SortHeader
-                        label="Cloud account"
-                        sortKey="cloud_account"
-                        currentKey={sortKey}
-                        asc={sortAsc}
-                        onClick={handleSort}
-                      />
+                      <th>Cloud account</th>
                       <SortHeader
                         label="Region"
                         sortKey="region"
-                        currentKey={sortKey}
-                        asc={sortAsc}
-                        onClick={handleSort}
+                        activeKey={controls.sort}
+                        asc={controls.order === 'asc'}
+                        onToggle={controls.toggleSort}
                       />
                       <SortHeader
                         label="Zone"
                         sortKey="zone"
-                        currentKey={sortKey}
-                        asc={sortAsc}
-                        onClick={handleSort}
+                        activeKey={controls.sort}
+                        asc={controls.order === 'asc'}
+                        onToggle={controls.toggleSort}
                       />
                       <SortHeader
                         label="Instance type"
                         sortKey="instance_type"
-                        currentKey={sortKey}
-                        asc={sortAsc}
-                        onClick={handleSort}
+                        activeKey={controls.sort}
+                        asc={controls.order === 'asc'}
+                        onToggle={controls.toggleSort}
                       />
                       <SortHeader
                         label="Image"
                         sortKey="image_name"
-                        currentKey={sortKey}
-                        asc={sortAsc}
-                        onClick={handleSort}
+                        activeKey={controls.sort}
+                        asc={controls.order === 'asc'}
+                        onToggle={controls.toggleSort}
                       />
-                      <SortHeader
-                        label="Image ID"
-                        sortKey="image_id"
-                        currentKey={sortKey}
-                        asc={sortAsc}
-                        onClick={handleSort}
-                      />
-                      <SortHeader
-                        label="Private IP"
-                        sortKey="private_ip"
-                        currentKey={sortKey}
-                        asc={sortAsc}
-                        onClick={handleSort}
-                      />
+                      <th>Image ID</th>
+                      <th>Private IP</th>
                       <SortHeader
                         label="Power state"
                         sortKey="power_state"
-                        currentKey={sortKey}
-                        asc={sortAsc}
-                        onClick={handleSort}
+                        activeKey={controls.sort}
+                        asc={controls.order === 'asc'}
+                        onToggle={controls.toggleSort}
                       />
                       <SortHeader
                         label="Last seen"
-                        sortKey="last_seen"
-                        currentKey={sortKey}
-                        asc={sortAsc}
-                        onClick={handleSort}
+                        sortKey="last_seen_at"
+                        activeKey={controls.sort}
+                        asc={controls.order === 'asc'}
+                        onToggle={controls.toggleSort}
                       />
                     </tr>
                   </thead>
@@ -670,27 +568,5 @@ function SummaryCard({
       <span className="eol-summary-count">{count}</span>
       <span className="eol-summary-label">{label}</span>
     </div>
-  );
-}
-
-function SortHeader({
-  label,
-  sortKey,
-  currentKey,
-  asc,
-  onClick,
-}: {
-  label: string;
-  sortKey: SortKey;
-  currentKey: SortKey;
-  asc: boolean;
-  onClick: (key: SortKey) => void;
-}) {
-  const arrow = currentKey === sortKey ? (asc ? ' \u25b2' : ' \u25bc') : '';
-  return (
-    <th className="sortable" onClick={() => onClick(sortKey)}>
-      {label}
-      {arrow}
-    </th>
   );
 }


### PR DESCRIPTION
## Summary

Phase 2 (UI) of the uniform list search & sort contract (ADR-0042; server side merged in #246). Every main list page — the 9 inventory pages, Virtual Machines, and Applications — now has:

- **A uniform search box** (`SearchInput`): 300 ms debounce, `*`-glob hint tooltip, wired to the server-side `name=` filter (substring / anchored glob over the whole dataset, not just the loaded page).
- **Server-side per-column sorting** (`SortHeader`, merging the two previously duplicated private copies): clicking a header sorts the entire collection via `sort=`/`order=`; columns outside the server allowlist (lookups, composites, computed) render with no click affordance.
- **Shareable URLs**: search, sort, order and page-specific filters live in the query string (`useListControls` + a common `setParam` pattern). Cursors never enter the URL — a shared link opens page 1 of the same view. Filter typing and sort clicks use `history.replace` (no history spam).

### Structural changes

- New generic `EntityListPage` component absorbs the 9× duplicated scaffolding in `Lists.tsx` (~676 → ~300 lines of thin per-entity configs; cell rendering preserved verbatim).
- `VirtualMachines`: client-side page-local sort **removed** in favor of server sort (the old sort only reordered the visible page — misleading past page 1). Summary cards and the client-side role/power-state group filters are unchanged by design.
- `Applications`: load-more append pagination replaced by the standard prev/next `Paginator`; the client-side alphabetical re-sort is gone (server order is authoritative). **Fixes a real gap**: block-pill links emitted `?application_block_name=…` that the page never read — the URL is now ingested, so those links work.
- `EolDashboard`: migrated onto the shared `SortHeader` (still client-mode — its server-side pagination is a separate deferred project per the spec).
- `api.ts`: all list helpers forward `name`/`sort`/`order`.

## Test plan

- [x] `npm test` — 366/366 vitest (20 new: SortHeader, useListControls URL sync/debounce/toggle, SearchInput, EntityListPage behaviors, wire-capture tests asserting the exact query strings sent on header clicks and debounced typing, Applications URL-ingestion regression)
- [x] `npm run typecheck` + production `vite build` clean
- [x] Zero Go/OpenAPI/migrations changes (`git diff origin/main -- '*.go' api/openapi migrations` empty)