### PR TITLE
fix(ui): upgrade to react 19 and react-router 8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
           cache-dependency-path: ui/package-lock.json
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,17 +8,17 @@
       "name": "longue-vue-ui",
       "version": "0.1.0",
       "dependencies": {
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "react-router-dom": "^6.30.4"
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "react-router": "^8.3.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "@types/react": "^18.3.5",
-        "@types/react-dom": "^18.3.0",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^4.1.8",
         "jsdom": "^29.1.1",
@@ -587,15 +587,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
@@ -689,9 +680,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -709,9 +697,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -729,9 +714,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -749,9 +731,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -769,9 +748,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -789,9 +765,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1029,32 +1002,24 @@
         "undici-types": "~7.19.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/set-cookie-parser": {
@@ -1393,6 +1358,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
+    },
     "node_modules/css-tree": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
@@ -1725,7 +1696,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jsdom": {
       "version": "29.1.1",
@@ -2039,18 +2012,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -2186,9 +2147,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2320,9 +2281,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -2340,7 +2301,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2375,28 +2336,24 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-is": {
@@ -2408,35 +2365,24 @@
       "peer": true
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/redent": {
@@ -2535,13 +2481,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/set-cookie-parser": {
       "version": "3.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,17 +14,17 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-router-dom": "^6.30.4"
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "react-router": "^8.3.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@types/react": "^18.3.5",
-    "@types/react-dom": "^18.3.0",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.8",
     "jsdom": "^29.1.1",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { NavLink, Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import { NavLink, Navigate, Route, Routes, useLocation, useNavigate } from 'react-router';
 import * as api from './api';
 import { Logo } from './Logo';
 import Login from './pages/Login';

--- a/ui/src/components.test.tsx
+++ b/ui/src/components.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import {
   AsyncView, Code, Dash, Empty, IdLink, KV, Labels, LayerPill,
   LoadBalancerAddresses, Paginator, SectionTitle, ShortId,

--- a/ui/src/components.tsx
+++ b/ui/src/components.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { AsyncState } from './hooks';
 import { PAGE_SIZE_OPTIONS, type PageSize } from './hooks';
 

--- a/ui/src/components/ListSection.test.tsx
+++ b/ui/src/components/ListSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useLocalListControls, usePagedList } from '../hooks';

--- a/ui/src/components/ListSection.tsx
+++ b/ui/src/components/ListSection.tsx
@@ -5,7 +5,7 @@
 // usePagedList hook so it can also derive extra content from the current
 // page (e.g. the nodes running a workload). Sections with bespoke layouts
 // (group-by, impact analysis) keep their hand-rolled markup.
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Empty, Paginator, SectionTitle } from '../components';
 import type { ListControls, PagedListState } from '../hooks';
 import { SearchInput } from './SearchInput';

--- a/ui/src/components/inventory/ApplicationCard.tsx
+++ b/ui/src/components/inventory/ApplicationCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import * as api from '../../api';
 
 // ApplicationCard is the single-select picker used on Workload, VM,

--- a/ui/src/components/inventory/ApplicationsCard.test.tsx
+++ b/ui/src/components/inventory/ApplicationsCard.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { ApplicationsCard } from './ApplicationsCard';
 import { MeProvider } from '../../me';
 import type { VMApplication } from '../../api';

--- a/ui/src/components/inventory/ApplicationsCard.tsx
+++ b/ui/src/components/inventory/ApplicationsCard.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import * as api from '../../api';
 import { canEdit, useMe } from '../../me';
 import { Dash, Empty, SectionTitle } from '../../components';

--- a/ui/src/components/inventory/EffectiveDICTCard.tsx
+++ b/ui/src/components/inventory/EffectiveDICTCard.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { EffectiveDICT } from '../../api';
 
 // EffectiveDICTCard renders the read-only inherited DICT classification

--- a/ui/src/hooks.test.tsx
+++ b/ui/src/hooks.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 import { type ReactNode, useState } from 'react';
 import { ApiError } from './api';
 import { useDebouncedValue, useResource, useResources, usePageSize, PAGE_SIZE_OPTIONS, usePagedList, useListControls, useLocalListControls, useClientSort } from './hooks';

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { ApiError } from './api';
 import type { ListControlParams, PagedResponse } from './api';
 

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import App from './App';
 import './styles.css';
 

--- a/ui/src/pages/ApplicationDetail.test.tsx
+++ b/ui/src/pages/ApplicationDetail.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import userEvent from '@testing-library/user-event';
 import type { ReactElement } from 'react';
 import ApplicationDetail from './ApplicationDetail';
@@ -190,10 +190,8 @@ describe('ApplicationDetail', () => {
       ),
     );
     renderDetail();
-    await waitFor(() =>
-      expect(screen.getByRole('heading', { name: /End-of-life summary/i })).toBeInTheDocument(),
-    );
-    expect(screen.getByText('vault')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('vault')).toBeInTheDocument());
+    expect(screen.getByRole('heading', { name: /End-of-life summary/i })).toBeInTheDocument();
     expect(screen.getByText('1.18.2')).toBeInTheDocument();
     expect(screen.getByText('End of Life')).toBeInTheDocument();
     expect(screen.getByText('bastion-eu')).toBeInTheDocument();
@@ -256,10 +254,8 @@ describe('ApplicationDetail', () => {
       ),
     );
     renderDetail();
-    await waitFor(() =>
-      expect(screen.getByRole('heading', { name: /End-of-life summary/i })).toBeInTheDocument(),
-    );
-    expect(screen.getByText('Far behind')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Far behind')).toBeInTheDocument());
+    expect(screen.getByRole('heading', { name: /End-of-life summary/i })).toBeInTheDocument();
     expect(screen.queryByText('Unknown')).toBeNull();
     expect(screen.getByText('Freshness')).toBeInTheDocument();
   });

--- a/ui/src/pages/ApplicationDetail.tsx
+++ b/ui/src/pages/ApplicationDetail.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import * as api from '../api';
 import { useResource } from '../hooks';
 import { canEdit, useMe } from '../me';

--- a/ui/src/pages/Applications.tsx
+++ b/ui/src/pages/Applications.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router';
 import * as api from '../api';
 import { usePagedList, useListControls, useDebouncedValue } from '../hooks';
 import { Dash, Paginator } from '../components';

--- a/ui/src/pages/ChangePassword.tsx
+++ b/ui/src/pages/ChangePassword.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { ApiError, changePassword } from '../api';
 
 // Forced-rotation page per ADR-0007. Reached automatically on first

--- a/ui/src/pages/Details.test.tsx
+++ b/ui/src/pages/Details.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {

--- a/ui/src/pages/EolDashboard.tsx
+++ b/ui/src/pages/EolDashboard.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import * as api from '../api';
 import { useResources } from '../hooks';
 import { AsyncView, Dash } from '../components';

--- a/ui/src/pages/ImageDetail.tsx
+++ b/ui/src/pages/ImageDetail.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import * as api from '../api';
 import { useResource } from '../hooks';
 import { AsyncView, Dash } from '../components';

--- a/ui/src/pages/Images.tsx
+++ b/ui/src/pages/Images.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import * as api from '../api';
 import { useResource } from '../hooks';
 import { isAdmin, useMe } from '../me';

--- a/ui/src/pages/ImpactGraph.tsx
+++ b/ui/src/pages/ImpactGraph.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import * as api from '../api';
 import { useResource } from '../hooks';
 import { AsyncView } from '../components';

--- a/ui/src/pages/Lists.tsx
+++ b/ui/src/pages/Lists.tsx
@@ -3,7 +3,7 @@
 // pagination come for free. Adding a new kind means adding one config here.
 
 import { useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import * as api from '../api';
 import { useResource } from '../hooks';
 import { Dash, IdLink, LayerPill, LoadBalancerAddresses, NamespaceLink } from '../components';

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { ApiError, getAuthConfig, login } from '../api';
 import { LogoIcon } from '../Logo';
 

--- a/ui/src/pages/Search.tsx
+++ b/ui/src/pages/Search.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router';
 import * as api from '../api';
 import { useResource } from '../hooks';
 import { AsyncView, Dash, NamespaceLink, WorkloadLink, SectionTitle, Empty } from '../components';

--- a/ui/src/pages/VirtualMachineDetail.test.tsx
+++ b/ui/src/pages/VirtualMachineDetail.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import VirtualMachineDetail from './VirtualMachineDetail';

--- a/ui/src/pages/VirtualMachineDetail.tsx
+++ b/ui/src/pages/VirtualMachineDetail.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import * as api from '../api';
 import { useResource } from '../hooks';
 import { canEdit, isAdmin, useMe } from '../me';

--- a/ui/src/pages/VirtualMachines.tsx
+++ b/ui/src/pages/VirtualMachines.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router';
 import * as api from '../api';
 import { useResource, usePagedList, useListControls, useDebouncedValue } from '../hooks';
 import { isAdmin, useMe } from '../me';

--- a/ui/src/pages/admin/AdminLayout.test.tsx
+++ b/ui/src/pages/admin/AdminLayout.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import AdminLayout from './AdminLayout';
 import { MeProvider } from '../../me';
 import { fixtureMe } from '../../test/fixtures';

--- a/ui/src/pages/admin/AdminLayout.tsx
+++ b/ui/src/pages/admin/AdminLayout.tsx
@@ -1,4 +1,4 @@
-import { NavLink, Outlet, useLocation } from 'react-router-dom';
+import { NavLink, Outlet, useLocation } from 'react-router';
 import type { Role } from '../../api';
 
 // AdminLayout wraps the admin sub-pages with a shared tab-style sub-nav.

--- a/ui/src/pages/admin/ClassificationHeatmap.tsx
+++ b/ui/src/pages/admin/ClassificationHeatmap.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import * as api from '../../api';
 import { useResource } from '../../hooks';
 import { AsyncView, SectionTitle } from '../../components';

--- a/ui/src/pages/admin/CloudAccountDetail.test.tsx
+++ b/ui/src/pages/admin/CloudAccountDetail.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import type { ReactElement } from 'react';
 import CloudAccountDetailPage from './CloudAccountDetail';
 import { renderWithRouter } from '../../test/render';

--- a/ui/src/pages/admin/CloudAccountDetail.tsx
+++ b/ui/src/pages/admin/CloudAccountDetail.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router';
 import * as api from '../../api';
 import { useResource, usePagedList, useLocalListControls } from '../../hooks';
 import { AsyncView, Dash, KV, SectionTitle } from '../../components';

--- a/ui/src/pages/admin/CloudAccounts.tsx
+++ b/ui/src/pages/admin/CloudAccounts.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router';
 import * as api from '../../api';
 import { useListControls, usePagedList, type ListControls } from '../../hooks';
 import { Dash, Paginator, SectionTitle } from '../../components';

--- a/ui/src/pages/admin/Tokens.tsx
+++ b/ui/src/pages/admin/Tokens.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import * as api from '../../api';
 import { useResource, useListControls, usePagedList, type ListControls } from '../../hooks';
 import { Dash, Paginator, SectionTitle } from '../../components';

--- a/ui/src/pages/cluster_curated.test.tsx
+++ b/ui/src/pages/cluster_curated.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { ClusterCuratedCard } from './cluster_curated';
 import { fixtureCluster, fixtureMe } from '../test/fixtures';
 import { MeProvider } from '../me';

--- a/ui/src/pages/details/ClusterDetail.tsx
+++ b/ui/src/pages/details/ClusterDetail.tsx
@@ -2,7 +2,7 @@
 // impact and history tabs.
 
 import { useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router';
 import * as api from '../../api';
 import { useResource, usePagedList, useLocalListControls } from '../../hooks';
 import { useMe, isAdmin } from '../../me';

--- a/ui/src/pages/details/IngressDetail.tsx
+++ b/ui/src/pages/details/IngressDetail.tsx
@@ -4,7 +4,7 @@
 // LB) writes its address into status.loadBalancer.ingress[]. Auditors can
 // read it directly without bouncing into kubectl.
 
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import * as api from '../../api';
 import { useResource } from '../../hooks';
 import { ImpactSection } from '../ImpactGraph';

--- a/ui/src/pages/details/NamespaceDetail.test.tsx
+++ b/ui/src/pages/details/NamespaceDetail.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { NamespaceDetail } from './NamespaceDetail';
 import { server } from '../../test/server';
 import { fixtureNamespace, paged, fixtureWorkload } from '../../test/fixtures';

--- a/ui/src/pages/details/NamespaceDetail.tsx
+++ b/ui/src/pages/details/NamespaceDetail.tsx
@@ -2,7 +2,7 @@
 // NS (serves the "application = namespace" view).
 
 import { useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import * as api from '../../api';
 import { useResource, usePagedList, useLocalListControls } from '../../hooks';
 import { NamespaceCuratedCard } from '../namespace_curated';

--- a/ui/src/pages/details/NodeDetail.tsx
+++ b/ui/src/pages/details/NodeDetail.tsx
@@ -1,7 +1,7 @@
 // Node detail — pods on this node grouped by workload (impact analysis).
 
 import { useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import * as api from '../../api';
 import { useClientSort, useResource, usePagedList } from '../../hooks';
 import { SortHeader } from '../../components/SortHeader';

--- a/ui/src/pages/details/PersistentVolumes.tsx
+++ b/ui/src/pages/details/PersistentVolumes.tsx
@@ -1,6 +1,6 @@
 // PersistentVolume + PersistentVolumeClaim detail pages.
 
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import * as api from '../../api';
 import { useResource } from '../../hooks';
 import { ImpactSection } from '../ImpactGraph';

--- a/ui/src/pages/details/PodDetail.tsx
+++ b/ui/src/pages/details/PodDetail.tsx
@@ -1,6 +1,6 @@
 // Pod detail — containers + backlinks to parent workload / namespace.
 
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import * as api from '../../api';
 import { useResource } from '../../hooks';
 import { ImpactSection } from '../ImpactGraph';

--- a/ui/src/pages/details/ServiceDetail.tsx
+++ b/ui/src/pages/details/ServiceDetail.tsx
@@ -1,6 +1,6 @@
 // Service detail.
 
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import * as api from '../../api';
 import { useResource } from '../../hooks';
 import { ImpactSection } from '../ImpactGraph';

--- a/ui/src/pages/details/WorkloadDetail.tsx
+++ b/ui/src/pages/details/WorkloadDetail.tsx
@@ -2,7 +2,7 @@
 // containers (serves the "application = workload" view).
 
 import { useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import * as api from '../../api';
 import { useResource, usePagedList, useLocalListControls } from '../../hooks';
 import { useMe, canEdit } from '../../me';

--- a/ui/src/pages/namespace_curated.test.tsx
+++ b/ui/src/pages/namespace_curated.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { NamespaceCuratedCard } from './namespace_curated';
 import { fixtureNamespace, fixtureMe } from '../test/fixtures';
 import { MeProvider } from '../me';

--- a/ui/src/pages/node_curated.test.tsx
+++ b/ui/src/pages/node_curated.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { NodeCuratedCard } from './node_curated';
 import { fixtureNode, fixtureMe } from '../test/fixtures';
 import { MeProvider } from '../me';

--- a/ui/src/test/render.tsx
+++ b/ui/src/test/render.tsx
@@ -1,5 +1,5 @@
 import { render, type RenderOptions, type RenderResult } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { type ReactElement } from 'react';
 
 interface RenderWithRouterOptions extends RenderOptions {


### PR DESCRIPTION
Supersedes #254.

## Problem

Dependabot opened #254 to fix GHSA-jjmj-jmhj-qwj2 (open redirect → XSS in `react-router-dom` 6.30.2–6.30.4, **no patched 6.x release**). Because Dependabot security updates pin the *minimum* patched version, it bumped to `react-router-dom` **7.0.0** — which reintroduced **9 HIGH advisories** (fixed between 7.5.2 and 7.18.0) plus a vulnerable `turbo-stream` 2.4.0. That is what turned the GitHub Advanced Security "Trivy" check red on the PR.

Landing on latest 7.x (7.18.2) is not enough either: **GHSA-qwww-vcr4-c8h2** (CSRF bypass in RSC mode, HIGH) affects `>= 7.12.0, < 8.3.0` and is patched **only in react-router 8.3.0**. The intersection of all open advisories leaves exactly one clean version: **8.3.0**.

## Change

- `react-router-dom` ^6.30.4 → `react-router` **^8.3.0** (the `-dom` shim no longer exists in v8; all imports move to `react-router`, one-line change in 47 files — the UI only uses the declarative API, which is unchanged).
- `react` / `react-dom` 18.3.1 → **19.2.8** (react-router 8 requires react ≥ 19.2.7).
- Transitive `postcss` 8.5.14 → **8.5.25** (GHSA-r28c-9q8g-f849, HIGH, path traversal).
- Two `ApplicationDetail` tests waited on the card heading instead of row data and were flaky under React 19's scheduling; they now wait on the data itself (same pattern as the neighbouring test).
- `release.yml` now installs Node 22 (react-router 8 declares `engines: node >= 22.22`; ci.yml and the Dockerfiles already use 22).

## Verification

- `trivy fs ui/package-lock.json` (all severities, ignore-unfixed): **0 vulnerabilities** — clears all 4 open Dependabot alerts, the 9 alerts introduced by #254, and GHSA-qwww-vcr4-c8h2.
- UI: `tsc --noEmit` clean, **398/398 vitest tests pass**, `vite build` OK.
- Go (untouched): gofmt/vet clean, `golangci-lint` 0 issues, `govulncheck` 0 affecting vulns, `go test -race ./...` green.
