### PR TITLE
ci(dependabot): prefix security updates as fix(deps) to cut releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# Dependabot security updates only — scheduled version updates are disabled
+# via open-pull-requests-limit: 0 on every entry.
+#
+# The commit-message prefixes are load-bearing for release engineering:
+# release-please only cuts a release (and therefore a v* tag, images,
+# binaries and charts) for fix/feat commits. Security bumps of runtime
+# dependencies must ship, so they are prefixed fix(deps); npm
+# devDependencies never reach the embedded UI bundle, so they stay
+# chore(deps) and do not trigger a release.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /ui
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 0
+    commit-message:
+      prefix: "fix(deps)"
+      prefix-development: "chore(deps)"
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 0
+    commit-message:
+      prefix: "fix(deps)"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 0
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## Problem

Dependabot security PRs land as `chore(deps):` commits. release-please only cuts a release (and thus a `v*` tag → images, binaries, charts via `release.yml`) for `fix`/`feat`/breaking commits — so a merged security bump never shipped until an unrelated releasable commit came along.

## Change

Adds `.github/dependabot.yml` that **only** shapes security-update PRs (`open-pull-requests-limit: 0` keeps scheduled version updates disabled, preserving current behavior):

| Ecosystem | Prefix | Rationale |
|---|---|---|
| npm (`/ui`) runtime deps | `fix(deps)` | ship in the embedded UI bundle → patch release |
| npm devDependencies | `chore(deps)` | build tooling, never reaches the artifact |
| gomod | `fix(deps)` | ships in the binaries |
| github-actions | `chore(deps)` | CI-only, nothing to release |

Note: this changes the commit message Dependabot writes on **future** branches; existing open PRs (#254, superseded by #255) are unaffected.