### PR TITLE
ci(security): bump Go toolchain to 1.26.6 for stdlib vuln fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/sthalbert/longue-vue
 
 go 1.25.10
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
 


### PR DESCRIPTION
## Why

The `govulncheck` job on `main` is red: 6 Go standard-library vulnerabilities (GO-2026-6218, GO-2026-6090, GO-2026-6089, GO-2026-6088, GO-2026-5972, GO-2026-5026) are present in go1.26.5 and all fixed in go1.26.6. This was not introduced by #258 — the Go 1.26.6 patch release simply made every new scan fail.

## What

Bump the `toolchain` directive in `go.mod` from `go1.26.5` to `go1.26.6`. The security workflow resolves the Go version via `go-version-file: go.mod`, so this is the single change needed.

## Verification

- `govulncheck ./...` with go1.26.6 locally: **0 vulnerabilities** (was 6)
- `go build -tags noui ./...` passes