### PR TITLE
chore(lint): align on golangci-lint 2.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.11
+          version: v2.13
           args: --timeout=5m
 
   helm:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,6 +58,17 @@ linters:
         - performance
         - opinionated
         - experimental
+    goconst:
+      # goconst 1.10 (golangci-lint 2.12) extended detection to composite
+      # literals and map keys, which flags idiomatic JSON/map key strings
+      # repo-wide ("items", "action", ...). Scope it back to the contexts
+      # where a named constant actually helps (assignments, comparisons,
+      # case clauses, returns) using the knobs added by goconst 1.11.
+      exclude-types:
+        - Call # goconst default
+        - CompositeLit
+      ignore-map-keys: true
+      ignore-tests: true
     gocyclo:
       min-complexity: 10
     nolintlint:
@@ -103,7 +114,7 @@ linters:
         path: (.+)_test.go
       - linters:
           - staticcheck
-        text: "SA1019: n.Status.NodeInfo.KubeProxyVersion is deprecated"
+        text: "SA1019: .+KubeProxyVersion is deprecated"
         path: internal/collector/kube.go
     paths:
       - third_party$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,4 @@
 version: "2"
-
 linters:
   default: none
   enable:
@@ -39,7 +38,6 @@ linters:
     - unused
     - wrapcheck
     - funcorder
-
   settings:
     errchkjson:
       check-error-free-encoding: true
@@ -51,6 +49,17 @@ linters:
         - (*database/sql.DB).Close
         - (io.Closer).Close
         - (net.Conn).Close
+    goconst:
+      ignore-tests: true
+      # goconst 1.10+ (golangci-lint 2.12+) extended detection to composite
+      # literals and map keys, which flags idiomatic JSON/map key strings
+      # repo-wide ("items", "action", ...). Scope it back to the contexts
+      # where a named constant actually helps (assignments, comparisons,
+      # case clauses, returns).
+      exclude-types:
+        - Call # goconst default
+        - CompositeLit
+      ignore-map-keys: true
     gocritic:
       enabled-tags:
         - diagnostic
@@ -58,17 +67,6 @@ linters:
         - performance
         - opinionated
         - experimental
-    goconst:
-      # goconst 1.10 (golangci-lint 2.12) extended detection to composite
-      # literals and map keys, which flags idiomatic JSON/map key strings
-      # repo-wide ("items", "action", ...). Scope it back to the contexts
-      # where a named constant actually helps (assignments, comparisons,
-      # case clauses, returns) using the knobs added by goconst 1.11.
-      exclude-types:
-        - Call # goconst default
-        - CompositeLit
-      ignore-map-keys: true
-      ignore-tests: true
     gocyclo:
       min-complexity: 10
     nolintlint:
@@ -104,7 +102,6 @@ linters:
     funcorder:
       constructor: true
       struct-method: true
-
   exclusions:
     generated: lax
     rules:
@@ -112,6 +109,8 @@ linters:
           - err113
           - maintidx
         path: (.+)_test.go
+      # The collector intentionally still reads the deprecated
+      # KubeProxyVersion node field (its value is what the CMDB records).
       - linters:
           - staticcheck
         text: "SA1019: .+KubeProxyVersion is deprecated"
@@ -120,11 +119,9 @@ linters:
       - third_party$
       - builtin$
       - examples$
-
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-
 formatters:
   enable:
     - gci

--- a/internal/mcp/application_tools_test.go
+++ b/internal/mcp/application_tools_test.go
@@ -1,4 +1,3 @@
-//nolint:goconst // duplicated literals in assertions are clearer than named constants.
 package mcp
 
 import (

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1181,8 +1181,6 @@ func jsonResult(v any) (*mcp.CallToolResult, error) {
 // storeError maps store errors to user-facing MCP tool errors.
 // ErrNotFound becomes "X not found"; all other errors are logged
 // server-side and masked with a generic message.
-//
-//nolint:unparam // error is always nil by design — errors become tool results.
 func storeError(entity string, err error) (*mcp.CallToolResult, error) {
 	if errors.Is(err, api.ErrNotFound) {
 		return mcp.NewToolResultError(fmt.Sprintf("%s not found", entity)), nil

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -1,4 +1,3 @@
-//nolint:goconst // duplicated literals in assertions are clearer than named constants.
 package mcp
 
 import (

--- a/internal/mcp/vm_tools_test.go
+++ b/internal/mcp/vm_tools_test.go
@@ -1,4 +1,3 @@
-//nolint:goconst // duplicated literals in assertions are clearer than named constants.
 package mcp
 
 import (

--- a/internal/store/pg_namespaces_sort_test.go
+++ b/internal/store/pg_namespaces_sort_test.go
@@ -63,7 +63,7 @@ func TestListNamespacesSortByName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("desc: %v", err)
 	}
-	if items[0].Name != "gamma" { //nolint:goconst // test fixture; constant would reduce readability
+	if items[0].Name != "gamma" {
 		t.Errorf("desc first = %s, want gamma", items[0].Name)
 	}
 }

--- a/internal/store/pg_nodes.go
+++ b/internal/store/pg_nodes.go
@@ -283,7 +283,7 @@ func buildNodeUpdateSets(in *api.NodeUpdate) (sets []string, args []any, err err
 	}
 	addPtr := func(column string, ptr any) {
 		v := reflect.ValueOf(ptr)
-		if v.Kind() == reflect.Ptr && !v.IsNil() {
+		if v.Kind() == reflect.Pointer && !v.IsNil() {
 			add(column, v.Elem().Interface())
 		}
 	}
@@ -317,7 +317,7 @@ func buildNodeUpdateSets(in *api.NodeUpdate) (sets []string, args []any, err err
 			return
 		}
 		v := reflect.ValueOf(ptr)
-		if v.Kind() != reflect.Ptr || v.IsNil() {
+		if v.Kind() != reflect.Pointer || v.IsNil() {
 			return
 		}
 		b, err := marshal()


### PR DESCRIPTION
## Why

The local golangci-lint reports **~880 issues** that the v2.11 pinned in CI never sees — engine drift, not regressions. Nearly all come from goconst 1.10+ extending detection to composite literals and map/JSON keys, which flags idiomatic strings repo-wide (`"items"`, `"action"`, `"admin"`, …) and matches unrelated constants by value alone (`"error"` → `CloudAccountStatusError`). This aligns CI and local on **2.13 (latest)** and gets `golangci-lint run` back to **0 issues**.

## What

- **ci.yml**: `golangci-lint-action` version pin `v2.11` → `v2.13`.
- **goconst re-scoped** (not disabled — goconst 1.11, bundled in 2.13, added the knobs 2.12 lacked): `exclude-types: [Call, CompositeLit]`, `ignore-map-keys: true`, `ignore-tests: true`. Assignments, comparisons, case clauses and returns stay checked.
- **`internal/store/pg_nodes.go`**: `reflect.Ptr` → `reflect.Pointer` (2 sites). Same constant — the deprecated alias is now flagged by govet's new `inline` analyzer.
- **KubeProxyVersion SA1019 exclusion**: regex updated — staticcheck in 2.13 reports the fully-qualified type (`(k8s.io/api/core/v1.NodeSystemInfo).KubeProxyVersion`), so the old selector-expression text no longer matched.
- **Four `//nolint` directives dropped** (reported unused by 2.13's nolintlint): three file-level `goconst` ones in `internal/mcp`/`internal/store` tests (covered by `ignore-tests`) and one `unparam` on `storeError` in `internal/mcp/tools.go`.

## Verification

- `golangci-lint config verify` OK (2.13.1)
- `golangci-lint run` (2.13.1): **0 issues**
- `go build ./...` + `go vet ./...` clean
- `go test -race ./...`: full suite passes

No shipped-artifact change (`reflect.Pointer` is the identical constant), hence `chore` — release-please will not cut a release.